### PR TITLE
Factor out decoder manager

### DIFF
--- a/yew-ui/src/components/attendants.rs
+++ b/yew-ui/src/components/attendants.rs
@@ -24,9 +24,6 @@ use yew_webtransport::webtransport::{WebTransportService, WebTransportStatus, We
 
 use super::device_permissions::request_permissions;
 
-// This is important https://plnkr.co/edit/1yQd8ozGXlV9bwK6?preview
-// https://github.com/WebAudio/web-audio-api-v2/issues/133
-
 #[derive(Debug)]
 pub enum WsAction {
     Connect(bool),

--- a/yew-ui/src/components/attendants.rs
+++ b/yew-ui/src/components/attendants.rs
@@ -161,19 +161,16 @@ impl Component for AttendantsComponent {
         let webtransport_enabled = ctx.props().webtransport_enabled;
         let mut peer_decode_manager = PeerDecodeManager::new();
         let link = ctx.link().clone();
-        peer_decode_manager.on_peer_added.set(move |email| {
+        peer_decode_manager.on_peer_added = Callback::from(move |email| {
             link.send_message(Msg::OnPeerAdded(email));
         });
         let link = ctx.link().clone();
-        peer_decode_manager
-            .on_first_frame
-            .set(move |(email, media_type)| {
-                link.send_message(Msg::OnFirstFrame((email, media_type)));
-            });
-        peer_decode_manager.get_video_canvas_id.set(|email| email);
-        peer_decode_manager
-            .get_screen_canvas_id
-            .set(|email| format!("screen-share-{}", &email));
+        peer_decode_manager.on_first_frame = Callback::from(move |(email, media_type)| {
+            link.send_message(Msg::OnFirstFrame((email, media_type)));
+        });
+        peer_decode_manager.get_video_canvas_id = Callback::from(|email| email);
+        peer_decode_manager.get_screen_canvas_id =
+            Callback::from(|email| format!("screen-share-{}", &email));
         Self {
             connection: None,
             connected: false,

--- a/yew-ui/src/model/decode/mod.rs
+++ b/yew-ui/src/model/decode/mod.rs
@@ -1,6 +1,8 @@
 mod config;
+mod peer_decode_manager;
 mod peer_decoder;
 mod video_decoder_with_buffer;
 mod video_encoder_wrapper;
 
+pub use peer_decode_manager::{MultiDecoder, PeerDecodeManager};
 pub use peer_decoder::{AudioPeerDecoder, VideoPeerDecoder};

--- a/yew-ui/src/model/decode/mod.rs
+++ b/yew-ui/src/model/decode/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod peer_decode_manager;
 mod peer_decoder;
 mod video_decoder_with_buffer;
-mod video_encoder_wrapper;
+mod video_decoder_wrapper;
 
 pub use peer_decode_manager::{MultiDecoder, PeerDecodeManager};
 pub use peer_decoder::{AudioPeerDecoder, VideoPeerDecoder};

--- a/yew-ui/src/model/decode/mod.rs
+++ b/yew-ui/src/model/decode/mod.rs
@@ -5,4 +5,3 @@ mod video_decoder_with_buffer;
 mod video_decoder_wrapper;
 
 pub use peer_decode_manager::{MultiDecoder, PeerDecodeManager};
-pub use peer_decoder::{AudioPeerDecoder, VideoPeerDecoder};

--- a/yew-ui/src/model/decode/peer_decode_manager.rs
+++ b/yew-ui/src/model/decode/peer_decode_manager.rs
@@ -1,0 +1,126 @@
+use crate::model::MediaPacketWrapper;
+use std::collections::HashMap;
+use std::sync::Arc;
+use types::protos::media_packet::media_packet::MediaType;
+use types::protos::media_packet::MediaPacket;
+
+use super::{AudioPeerDecoder, VideoPeerDecoder};
+
+pub struct Callback<IN, OUT = ()> {
+    func: Option<Box<dyn FnMut(IN) -> OUT + 'static>>,
+}
+
+impl<IN, OUT: std::default::Default> Callback<IN, OUT> {
+    fn new() -> Self {
+        Self { func: None }
+    }
+
+    pub fn set(&mut self, func: impl FnMut(IN) -> OUT + 'static) {
+        self.func = Some(Box::new(func));
+    }
+
+    fn call(&mut self, arg: IN) -> OUT {
+        match &mut self.func {
+            Some(func) => func(arg),
+            None => Default::default(),
+        }
+    }
+}
+
+pub struct MultiDecoder {
+    pub audio: AudioPeerDecoder,
+    pub video: VideoPeerDecoder,
+    pub screen: VideoPeerDecoder,
+}
+
+impl MultiDecoder {
+    fn new(video_canvas_id: String, screen_canvas_id: String) -> Self {
+        Self {
+            audio: AudioPeerDecoder::new(),
+            video: VideoPeerDecoder::new(&video_canvas_id),
+            screen: VideoPeerDecoder::new(&screen_canvas_id),
+        }
+    }
+
+    fn decode(&mut self, packet: &Arc<MediaPacket>) -> Result<Option<()>, i32> {
+        match packet.media_type.enum_value()? {
+            MediaType::VIDEO => Ok(self.video.decode(packet).ok()),
+            MediaType::AUDIO => Ok(self.audio.decode(packet).ok()),
+            MediaType::SCREEN => Ok(self.screen.decode(packet).ok()),
+            MediaType::HEARTBEAT => Ok(Some(())),
+        }
+    }
+}
+
+pub struct PeerDecodeManager {
+    connected_peers: HashMap<String, MultiDecoder>,
+    sorted_connected_peers_keys: Vec<String>,
+    pub on_peer_added: Callback<String>,
+    pub on_first_frame: Callback<(String, MediaType)>,
+    pub get_video_canvas_id: Callback<String, String>,
+    pub get_screen_canvas_id: Callback<String, String>,
+}
+
+impl PeerDecodeManager {
+    pub fn new() -> Self {
+        Self {
+            connected_peers: HashMap::new(),
+            sorted_connected_peers_keys: vec![],
+            on_peer_added: Callback::new(),
+            on_first_frame: Callback::new(),
+            get_video_canvas_id: Callback::new(),
+            get_screen_canvas_id: Callback::new(),
+        }
+    }
+
+    pub fn sorted_keys(&self) -> &Vec<String> {
+        &self.sorted_connected_peers_keys
+    }
+
+    pub fn get(&self, key: &String) -> Option<&MultiDecoder> {
+        self.connected_peers.get(key)
+    }
+
+    pub fn decode(&mut self, response: MediaPacketWrapper) -> Result<(), i32> {
+        let packet = Arc::new(response.0);
+        let email = packet.email.clone();
+        if !self.connected_peers.contains_key(&email) {
+            self.add_peer(&email);
+        }
+        let peer = self.connected_peers.get_mut(&email).unwrap();
+        if let None = peer.decode(&packet)? {
+            self.reset_peer(&email);
+        }
+        Ok(())
+    }
+
+    fn add_peer(&mut self, email: &String) {
+        self.insert_peer(&email);
+        self.on_peer_added.call(email.clone())
+    }
+
+    fn insert_peer(&mut self, email: &String) {
+        self.connected_peers.insert(
+            email.clone(),
+            MultiDecoder::new(
+                self.get_video_canvas_id.call(email.clone()),
+                self.get_screen_canvas_id.call(email.clone()),
+            ),
+        );
+        self.sorted_connected_peers_keys.push(email.clone());
+        self.sorted_connected_peers_keys.sort();
+    }
+
+    fn delete_peer(&mut self, email: &String) {
+        self.connected_peers.remove(email);
+        if let Ok(index) = self.sorted_connected_peers_keys.binary_search(&email) {
+            self.sorted_connected_peers_keys.remove(index);
+        }
+        self.insert_peer(&email);
+    }
+
+    fn reset_peer(&mut self, email: &String) {
+        self.delete_peer(&email);
+        self.insert_peer(&email);
+    }
+}

--- a/yew-ui/src/model/decode/peer_decoder.rs
+++ b/yew-ui/src/model/decode/peer_decoder.rs
@@ -167,6 +167,9 @@ impl PeerDecoder<VideoDecoderWithBuffer<VideoDecoderWrapper>, JsValue> {
 ///
 /// Plays audio to the standard audio stream.
 ///
+/// This is important https://plnkr.co/edit/1yQd8ozGXlV9bwK6?preview
+/// https://github.com/WebAudio/web-audio-api-v2/issues/133
+
 pub type AudioPeerDecoder = PeerDecoder<AudioDecoder, AudioData>;
 
 impl PeerDecoder<AudioDecoder, AudioData> {

--- a/yew-ui/src/model/decode/peer_decoder.rs
+++ b/yew-ui/src/model/decode/peer_decoder.rs
@@ -12,7 +12,7 @@
 
 use super::config::configure_audio_context;
 use super::video_decoder_with_buffer::VideoDecoderWithBuffer;
-use super::video_encoder_wrapper::VideoDecoderWrapper;
+use super::video_decoder_wrapper::VideoDecoderWrapper;
 use crate::constants::AUDIO_CHANNELS;
 use crate::constants::AUDIO_CODEC;
 use crate::constants::AUDIO_SAMPLE_RATE;

--- a/yew-ui/src/model/decode/video_decoder_with_buffer.rs
+++ b/yew-ui/src/model/decode/video_decoder_with_buffer.rs
@@ -2,9 +2,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use types::protos::media_packet::MediaPacket;
 use wasm_bindgen::JsValue;
-use web_sys::{
-    CodecState, EncodedVideoChunkType, VideoDecoderConfig, VideoDecoderInit,
-};
+use web_sys::{CodecState, EncodedVideoChunkType, VideoDecoderConfig, VideoDecoderInit};
 
 use crate::model::EncodedVideoChunkTypeWrapper;
 

--- a/yew-ui/src/model/decode/video_decoder_with_buffer.rs
+++ b/yew-ui/src/model/decode/video_decoder_with_buffer.rs
@@ -1,16 +1,14 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use gloo_console::log;
-use js_sys::Uint8Array;
 use types::protos::media_packet::MediaPacket;
 use wasm_bindgen::JsValue;
 use web_sys::{
-    CodecState, EncodedVideoChunk, EncodedVideoChunkType, VideoDecoderConfig, VideoDecoderInit,
+    CodecState, EncodedVideoChunkType, VideoDecoderConfig, VideoDecoderInit,
 };
 
 use crate::model::EncodedVideoChunkTypeWrapper;
 
-use super::video_encoder_wrapper::VideoDecoderTrait;
+use super::video_decoder_wrapper::VideoDecoderTrait;
 
 const MAX_BUFFER_SIZE: usize = 10;
 

--- a/yew-ui/src/model/decode/video_decoder_wrapper.rs
+++ b/yew-ui/src/model/decode/video_decoder_wrapper.rs
@@ -1,5 +1,4 @@
 use crate::model::EncodedVideoChunkTypeWrapper;
-use gloo_console::log;
 use js_sys::Uint8Array;
 use std::sync::Arc;
 use types::protos::media_packet::MediaPacket;


### PR DESCRIPTION
[Another step towards #74]

Created a PeerDecoderManager (I'm open to a better name!) that handles keeping track of the currently connected peers, dispatching each packet to the appropriate decoder, etc. factored all that out of Attendants.

It provides some callbacks that are set by Attendants: 
*   `on_peer_added(key)` -- forces an update
*   `on_first_frame((key, media_type))` -- forces an update if the media type is screen, this fixes the hack of d760779b
*   `get_video_canvas_id(key)` called to get DOM ID of the canvas element into which video should be rendered
*   `get_share_canvas_id(key)` called to get DOM ID of the canvas element into which screen share should be rendered

In the future, could add `on_last_frame((key, media_type))` and `on_peer_removed(key))` to handle a peer stopping audio, video or screen share or a peer disconnecting entirely, if/when there's protocol to detect those.

