### PR TITLE
Factor out web media connection into model::connection::Connection

### DIFF
--- a/yew-ui/src/components/attendants.rs
+++ b/yew-ui/src/components/attendants.rs
@@ -141,7 +141,7 @@ impl Component for AttendantsComponent {
                         }
                         Err(e) => {
                             ctx.link().send_message(WsAction::Log(format!(
-                                "WebSocket connect failed: {}",
+                                "Connection failed: {}",
                                 e
                             )));
                         }

--- a/yew-ui/src/components/attendants.rs
+++ b/yew-ui/src/components/attendants.rs
@@ -1,26 +1,18 @@
 use crate::constants::WEBTRANSPORT_HOST;
+use crate::model::connection::{ConnectOptions, Connection};
 use crate::model::decode::PeerDecodeManager;
 use crate::model::MediaPacketWrapper;
 use crate::{components::host::Host, constants::ACTIX_WEBSOCKET};
-use gloo::timers::callback::Interval;
 use gloo_console::log;
-use js_sys::Boolean;
-use js_sys::JsString;
-use js_sys::Reflect;
-use js_sys::Uint8Array;
-use protobuf::Message;
 use types::protos::media_packet::media_packet::MediaType;
 use types::protos::media_packet::MediaPacket;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
-use wasm_bindgen_futures::JsFuture;
 
 use web_sys::*;
 use yew::prelude::*;
 use yew::virtual_dom::VNode;
 use yew::{html, Component, Context, Html};
-use yew_websocket::websocket::{WebSocketService, WebSocketStatus, WebSocketTask};
-use yew_webtransport::webtransport::{WebTransportService, WebTransportStatus, WebTransportTask};
 
 use super::device_permissions::request_permissions;
 
@@ -36,12 +28,6 @@ pub enum WsAction {
 }
 
 #[derive(Debug)]
-pub enum Connection {
-    WebSocket(WebSocketTask),
-    WebTransport(WebTransportTask),
-}
-
-#[derive(Debug)]
 pub enum MeetingAction {
     ToggleScreenShare,
     ToggleMicMute,
@@ -53,10 +39,6 @@ pub enum Msg {
     MeetingAction(MeetingAction),
     OnInboundMedia(MediaPacketWrapper),
     OnOutboundPacket(MediaPacket),
-    OnDatagram(Vec<u8>),
-    OnUniStream(WebTransportReceiveStream),
-    OnBidiStream(WebTransportBidirectionalStream),
-    OnMessage(Vec<u8>, WebTransportMessageType),
     OnPeerAdded(String),
     OnFirstFrame((String, MediaType)),
 }
@@ -84,70 +66,16 @@ pub struct AttendantsComponentProps {
     pub webtransport_enabled: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum WebTransportMessageType {
-    Datagram,
-    UnidirectionalStream,
-    BidirectionalStream,
-    Unknown,
-}
-
 pub struct AttendantsComponent {
     pub connection: Option<Connection>,
-    pub media_packet: MediaPacket,
-    pub connected: bool,
-    pub connecting: bool,
     pub peer_decode_manager: PeerDecodeManager,
     pub outbound_audio_buffer: [u8; 2000],
     pub share_screen: bool,
     pub webtransport_enabled: bool,
     pub mic_enabled: bool,
     pub video_enabled: bool,
-    pub heartbeat: Option<Interval>,
     pub error: Option<String>,
     pub media_access_granted: bool,
-}
-
-pub fn connect_websocket(
-    ctx: &Context<AttendantsComponent>,
-    email: &str,
-    id: &str,
-) -> anyhow::Result<WebSocketTask> {
-    let callback = ctx.link().callback(Msg::OnInboundMedia);
-    let notification = ctx.link().batch_callback(|status| match status {
-        WebSocketStatus::Opened => Some(WsAction::Connected.into()),
-        WebSocketStatus::Closed | WebSocketStatus::Error => Some(WsAction::Lost(None).into()),
-    });
-    let url = format!("{}/{}/{}", ACTIX_WEBSOCKET, email, id);
-    log!("Connecting to ", &url);
-    let task = WebSocketService::connect(&url, callback, notification)?;
-    Ok(task)
-}
-
-pub fn connect_webtransport(
-    ctx: &Context<AttendantsComponent>,
-    email: &str,
-    id: &str,
-) -> anyhow::Result<WebTransportTask> {
-    let on_datagram = ctx.link().callback(Msg::OnDatagram);
-    let on_unidirectional_stream = ctx.link().callback(Msg::OnUniStream);
-    let on_bidirectional_stream = ctx.link().callback(Msg::OnBidiStream);
-    let notification = ctx.link().batch_callback(|status| match status {
-        WebTransportStatus::Opened => Some(WsAction::Connected.into()),
-        WebTransportStatus::Closed(error) | WebTransportStatus::Error(error) => {
-            Some(WsAction::Lost(Some(error)).into())
-        }
-    });
-    let url = format!("{}/{}/{}", WEBTRANSPORT_HOST, email, id);
-    log!("Connecting to ", &url);
-    let task = WebTransportService::connect(
-        &url,
-        on_datagram,
-        on_unidirectional_stream,
-        on_bidirectional_stream,
-        notification,
-    )?;
-    Ok(task)
 }
 
 impl Component for AttendantsComponent {
@@ -170,16 +98,12 @@ impl Component for AttendantsComponent {
             Callback::from(|email| format!("screen-share-{}", &email));
         Self {
             connection: None,
-            connected: false,
-            connecting: false,
-            media_packet: MediaPacket::default(),
             peer_decode_manager,
             outbound_audio_buffer: [0; 2000],
             share_screen: false,
             mic_enabled: false,
             video_enabled: false,
             webtransport_enabled,
-            heartbeat: None,
             error: None,
             media_access_granted: false,
         }
@@ -195,51 +119,38 @@ impl Component for AttendantsComponent {
         match msg {
             Msg::WsAction(action) => match action {
                 WsAction::Connect(webtransport) => {
-                    if self.connecting {
+                    if self.connection.is_some() {
                         return false;
                     }
-                    self.connecting = true;
                     log!("webtransport connect = {}", webtransport);
                     let id = ctx.props().id.clone();
                     let email = ctx.props().email.clone();
-                    if !webtransport {
-                        if let Ok(task) = connect_websocket(ctx, &email, &id).map_err(|e| {
+                    let options = ConnectOptions {
+                        userid: email.clone(),
+                        websocket_url: format!("{}/{}/{}", ACTIX_WEBSOCKET, email, id),
+                        webtransport_url: format!("{}/{}/{}", WEBTRANSPORT_HOST, email, id),
+                        on_inbound_media: ctx.link().callback(Msg::OnInboundMedia),
+                        on_connected: ctx.link().callback(|_| Msg::from(WsAction::Connected)),
+                        on_connection_lost: ctx
+                            .link()
+                            .callback(|_| Msg::from(WsAction::Lost(None))),
+                    };
+                    match Connection::connect(webtransport, options) {
+                        Ok(connection) => {
+                            self.connection = Some(connection);
+                        }
+                        Err(e) => {
                             ctx.link().send_message(WsAction::Log(format!(
                                 "WebSocket connect failed: {}",
                                 e
                             )));
-                        }) {
-                            self.connection = Some(Connection::WebSocket(task));
-                        }
-                    } else {
-                        let task = connect_webtransport(ctx, &email, &id);
-                        match task {
-                            Ok(task) => {
-                                self.connection = Some(Connection::WebTransport(task));
-                            }
-                            Err(_e) => {
-                                log!("WebTransport connect failed, falling back to WebSocket");
-                                ctx.link().send_message(WsAction::Connect(false));
-                            }
                         }
                     }
 
-                    let link = ctx.link().clone();
-                    self.heartbeat = Some(Interval::new(1000, move || {
-                        let media_packet = MediaPacket {
-                            media_type: MediaType::HEARTBEAT.into(),
-                            email: email.clone(),
-                            timestamp: js_sys::Date::now(),
-                            ..Default::default()
-                        };
-                        link.send_message(Msg::OnOutboundPacket(media_packet));
-                    }));
                     true
                 }
                 WsAction::Connected => {
                     log!("Connected");
-                    self.connecting = false;
-                    self.connected = true;
                     true
                 }
                 WsAction::Log(msg) => {
@@ -248,12 +159,7 @@ impl Component for AttendantsComponent {
                 }
                 WsAction::Lost(_reason) => {
                     log!("Lost");
-                    self.connected = false;
-                    self.connecting = false;
-                    self.connection.take();
-                    if let Some(heartbeat) = self.heartbeat.take() {
-                        heartbeat.cancel();
-                    };
+                    self.connection = None;
                     ctx.link()
                         .send_message(WsAction::Connect(self.webtransport_enabled));
                     true
@@ -298,174 +204,8 @@ impl Component for AttendantsComponent {
             }
             Msg::OnOutboundPacket(media) => {
                 if let Some(connection) = &self.connection {
-                    match connection {
-                        Connection::WebSocket(ws) => {
-                            if self.connected {
-                                match media
-                                    .write_to_bytes()
-                                    .map_err(|w| JsValue::from(format!("{:?}", w)))
-                                {
-                                    Ok(bytes) => {
-                                        ws.send_binary(bytes);
-                                    }
-                                    Err(e) => {
-                                        let packet_type = media.media_type.enum_value_or_default();
-                                        log!(
-                                            "error sending {} packet: {:?}",
-                                            JsValue::from(format!("{}", packet_type)),
-                                            e
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                        Connection::WebTransport(wt) => {
-                            if self.connected {
-                                match media
-                                    .write_to_bytes()
-                                    .map_err(|w| JsValue::from(format!("{:?}", w)))
-                                {
-                                    Ok(bytes) => {
-                                        if bytes.len() > 100 {
-                                            WebTransportTask::send_unidirectional_stream(
-                                                wt.transport.clone(),
-                                                bytes,
-                                            );
-                                        } else {
-                                            WebTransportTask::send_datagram(
-                                                wt.transport.clone(),
-                                                bytes,
-                                            );
-                                        }
-                                    }
-                                    Err(e) => {
-                                        let packet_type = media.media_type.enum_value_or_default();
-                                        log!(
-                                            "error sending {} packet: {:?}",
-                                            JsValue::from(format!("{}", packet_type)),
-                                            e
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    connection.send_packet(media);
                 }
-                false
-            }
-            Msg::OnDatagram(bytes) => {
-                let media_packet = MediaPacket::parse_from_bytes(&bytes);
-                match media_packet {
-                    Ok(media_packet) => {
-                        ctx.link()
-                            .send_message(Msg::OnInboundMedia(MediaPacketWrapper(media_packet)));
-                    }
-                    Err(e) => {
-                        let e = JsValue::from(format!("{:?}", e));
-                        log!("error parsing datagram: {:?}", e);
-                    }
-                }
-                false
-            }
-            Msg::OnMessage(response, message_type) => {
-                let res = MediaPacket::parse_from_bytes(&response);
-                if let Ok(media_packet) = res {
-                    ctx.link()
-                        .send_message(Msg::OnInboundMedia(MediaPacketWrapper(media_packet)));
-                } else {
-                    let message_type = format!("{:?}", message_type);
-                    log!("failed to parse media packet ", message_type);
-                }
-                false
-            }
-            Msg::OnUniStream(stream) => {
-                if stream.is_undefined() {
-                    log!("stream is undefined");
-                    return true;
-                }
-                let incoming_unistreams: ReadableStreamDefaultReader =
-                    stream.get_reader().unchecked_into();
-                let callback = ctx
-                    .link()
-                    .callback(|d| Msg::OnMessage(d, WebTransportMessageType::UnidirectionalStream));
-                wasm_bindgen_futures::spawn_local(async move {
-                    let mut buffer: Vec<u8> = vec![];
-                    loop {
-                        let read_result = JsFuture::from(incoming_unistreams.read()).await;
-                        match read_result {
-                            Err(e) => {
-                                let mut reason = WebTransportCloseInfo::default();
-                                reason.reason(
-                                    format!("Failed to read incoming unistream {e:?}").as_str(),
-                                );
-                                break;
-                            }
-                            Ok(result) => {
-                                let done = Reflect::get(&result, &JsString::from("done"))
-                                    .unwrap()
-                                    .unchecked_into::<Boolean>();
-
-                                let value =
-                                    Reflect::get(&result, &JsString::from("value")).unwrap();
-                                if !value.is_undefined() {
-                                    let value: Uint8Array = value.unchecked_into();
-                                    append_uint8_array_to_vec(&mut buffer, &value);
-                                }
-
-                                if done.is_truthy() {
-                                    process_binary(buffer, &callback);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                });
-                false
-            }
-            Msg::OnBidiStream(stream) => {
-                log!("OnBidiStream: ", &stream);
-                if stream.is_undefined() {
-                    log!("stream is undefined");
-                    return true;
-                }
-                let readable: ReadableStreamDefaultReader =
-                    stream.readable().get_reader().unchecked_into();
-                let callback = ctx
-                    .link()
-                    .callback(|d| Msg::OnMessage(d, WebTransportMessageType::BidirectionalStream));
-                wasm_bindgen_futures::spawn_local(async move {
-                    let mut buffer: Vec<u8> = vec![];
-                    loop {
-                        log!("reading from stream");
-                        let read_result = JsFuture::from(readable.read()).await;
-
-                        match read_result {
-                            Err(e) => {
-                                let mut reason = WebTransportCloseInfo::default();
-                                reason.reason(
-                                    format!("Failed to read incoming bidistream {e:?}").as_str(),
-                                );
-                                break;
-                            }
-                            Ok(result) => {
-                                let done = Reflect::get(&result, &JsString::from("done"))
-                                    .unwrap()
-                                    .unchecked_into::<Boolean>();
-                                let value =
-                                    Reflect::get(&result, &JsString::from("value")).unwrap();
-                                if !value.is_undefined() {
-                                    let value: Uint8Array = value.unchecked_into();
-                                    append_uint8_array_to_vec(&mut buffer, &value);
-                                }
-                                if done.is_truthy() {
-                                    process_binary(buffer, &callback);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    log!("readable stream closed");
-                });
                 false
             }
             Msg::MeetingAction(action) => {
@@ -550,13 +290,23 @@ impl Component for AttendantsComponent {
                         }
                     }
                     <h4 class="floating-name">{email}</h4>
-                    {if !self.connected {
+
+                    {if !self.is_connected() {
                         html! {<h4>{"Connecting"}</h4>}
                     } else {
                         html! {<h4>{"Connected"}</h4>}
                     }}
                 </nav>
             </div>
+        }
+    }
+}
+
+impl AttendantsComponent {
+    fn is_connected(&self) -> bool {
+        match &self.connection {
+            Some(connection) => connection.is_connected(),
+            None => false,
         }
     }
 }
@@ -592,17 +342,4 @@ fn user_video(props: &UserVideoProps) -> Html {
     html! {
         <canvas ref={(*video_ref).clone()} id={props.id.clone()}></canvas>
     }
-}
-
-pub fn append_uint8_array_to_vec(rust_vec: &mut Vec<u8>, js_array: &Uint8Array) {
-    // Convert the Uint8Array into a Vec<u8>
-    let mut temp_vec = vec![0; js_array.length() as usize];
-    js_array.copy_to(&mut temp_vec);
-
-    // Append it to the existing Rust Vec<u8>
-    rust_vec.append(&mut temp_vec);
-}
-
-pub fn process_binary(bytes: Vec<u8>, callback: &Callback<Vec<u8>>) {
-    callback.emit(bytes);
 }

--- a/yew-ui/src/model/connection/connection.rs
+++ b/yew-ui/src/model/connection/connection.rs
@@ -1,0 +1,105 @@
+//
+// Connection struct wraps the lower-level "Task" (task.rs), providing a heartbeat and keeping
+// track of connection status.
+//
+use super::task::Task;
+use super::ConnectOptions;
+use gloo::timers::callback::Interval;
+use std::cell::Cell;
+use std::sync::Arc;
+use types::protos::media_packet::media_packet::MediaType;
+use types::protos::media_packet::MediaPacket;
+use yew::prelude::Callback;
+
+#[derive(Clone, Copy)]
+enum Status {
+    Connecting,
+    Connected,
+    Closed,
+}
+
+pub struct Connection {
+    task: Arc<Task>,
+    heartbeat: Option<Interval>,
+    status: Arc<Cell<Status>>,
+}
+
+impl Connection {
+    pub fn connect(webtransport: bool, options: ConnectOptions) -> anyhow::Result<Self> {
+        let mut options = options.clone();
+        let userid = options.userid.clone();
+        let status = Arc::new(Cell::new(Status::Connecting));
+        {
+            let status = Arc::clone(&status);
+            options.on_connected = tap_callback(
+                options.on_connected,
+                Callback::from(move |_| status.set(Status::Connected)),
+            );
+        }
+        {
+            let status = Arc::clone(&status);
+            options.on_connection_lost = tap_callback(
+                options.on_connection_lost,
+                Callback::from(move |_| status.set(Status::Closed)),
+            );
+        }
+        let mut connection = Self {
+            task: Arc::new(Task::connect(webtransport, options)?),
+            heartbeat: None,
+            status,
+        };
+        connection.start_heartbeat(userid);
+        Ok(connection)
+    }
+
+    pub fn is_connected(&self) -> bool {
+        match self.status.get() {
+            Status::Connected => true,
+            _ => false,
+        }
+    }
+
+    fn start_heartbeat(&mut self, userid: String) {
+        let task = Arc::clone(&self.task);
+        let status = Arc::clone(&self.status);
+        self.heartbeat = Some(Interval::new(1000, move || {
+            let packet = MediaPacket {
+                media_type: MediaType::HEARTBEAT.into(),
+                email: userid.clone(),
+                timestamp: js_sys::Date::now(),
+                ..Default::default()
+            };
+            if let Status::Connected = status.get() {
+                task.send_packet(packet);
+            }
+        }));
+    }
+
+    fn stop_heartbeat(&mut self) {
+        if let Some(heartbeat) = self.heartbeat.take() {
+            heartbeat.cancel();
+        }
+    }
+
+    pub fn send_packet(&self, packet: MediaPacket) {
+        if let Status::Connected = self.status.get() {
+            self.task.send_packet(packet);
+        }
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.stop_heartbeat();
+    }
+}
+
+fn tap_callback<IN: 'static, OUT: 'static>(
+    callback: Callback<IN, OUT>,
+    tap: Callback<()>,
+) -> Callback<IN, OUT> {
+    Callback::from(move |arg| {
+        tap.emit(());
+        callback.emit(arg)
+    })
+}

--- a/yew-ui/src/model/connection/mod.rs
+++ b/yew-ui/src/model/connection/mod.rs
@@ -1,0 +1,8 @@
+mod connection;
+mod task;
+mod webmedia;
+mod websocket;
+mod webtransport;
+
+pub use connection::Connection;
+pub use webmedia::ConnectOptions;

--- a/yew-ui/src/model/connection/task.rs
+++ b/yew-ui/src/model/connection/task.rs
@@ -18,11 +18,13 @@ pub(super) enum Task {
 impl Task {
     pub fn connect(webtransport: bool, options: ConnectOptions) -> anyhow::Result<Self> {
         if webtransport {
+            log!("Task::connect trying WebTransport");
             match WebTransportTask::connect(options.clone()) {
                 Ok(task) => return Ok(Task::WebTransport(task)),
                 Err(_e) => log!("WebTransport connect failed, falling back to WebSocket"),
             }
         }
+        log!("Task::connect trying WebSocket");
         WebSocketTask::connect(options.clone()).map(|task| Task::WebSocket(task))
     }
 

--- a/yew-ui/src/model/connection/task.rs
+++ b/yew-ui/src/model/connection/task.rs
@@ -1,0 +1,35 @@
+//
+// Generic Task that can be a WebSocketTask or WebTransportTask.
+//
+// Handles rollover of connection from WebTransport to WebSocket
+//
+use gloo_console::log;
+use types::protos::media_packet::MediaPacket;
+use yew_websocket::websocket::WebSocketTask;
+use yew_webtransport::webtransport::WebTransportTask;
+
+use super::webmedia::{ConnectOptions, WebMedia};
+
+pub(super) enum Task {
+    WebSocket(WebSocketTask),
+    WebTransport(WebTransportTask),
+}
+
+impl Task {
+    pub fn connect(webtransport: bool, options: ConnectOptions) -> anyhow::Result<Self> {
+        if webtransport {
+            match WebTransportTask::connect(options.clone()) {
+                Ok(task) => return Ok(Task::WebTransport(task)),
+                Err(_e) => log!("WebTransport connect failed, falling back to WebSocket"),
+            }
+        }
+        WebSocketTask::connect(options.clone()).map(|task| Task::WebSocket(task))
+    }
+
+    pub fn send_packet(&self, packet: MediaPacket) {
+        match self {
+            Task::WebSocket(ws) => ws.send_packet(packet),
+            Task::WebTransport(wt) => wt.send_packet(packet),
+        }
+    }
+}

--- a/yew-ui/src/model/connection/webmedia.rs
+++ b/yew-ui/src/model/connection/webmedia.rs
@@ -1,0 +1,43 @@
+// Defines trait giving a consistent interface for making and using connections, at the level of
+// MediaPackets
+//
+// Implemented both for WebSockets (websocket.rs) and WebTransport (webtransport.rs)
+//
+use super::super::MediaPacketWrapper;
+use gloo_console::log;
+use protobuf::Message;
+use types::protos::media_packet::MediaPacket;
+use wasm_bindgen::JsValue;
+use yew::prelude::Callback;
+
+#[derive(Clone)]
+pub struct ConnectOptions {
+    pub userid: String,
+    pub websocket_url: String,
+    pub webtransport_url: String,
+    pub on_inbound_media: Callback<MediaPacketWrapper>,
+    pub on_connected: Callback<()>,
+    pub on_connection_lost: Callback<()>,
+}
+
+pub(super) trait WebMedia<TASK> {
+    fn connect(options: ConnectOptions) -> anyhow::Result<TASK>;
+    fn send_bytes(&self, bytes: Vec<u8>);
+
+    fn send_packet(&self, packet: MediaPacket) {
+        match packet
+            .write_to_bytes()
+            .map_err(|w| JsValue::from(format!("{:?}", w)))
+        {
+            Ok(bytes) => self.send_bytes(bytes),
+            Err(e) => {
+                let packet_type = packet.media_type.enum_value_or_default();
+                log!(
+                    "error sending {} packet: {:?}",
+                    JsValue::from(format!("{}", packet_type)),
+                    e
+                );
+            }
+        }
+    }
+}

--- a/yew-ui/src/model/connection/websocket.rs
+++ b/yew-ui/src/model/connection/websocket.rs
@@ -1,0 +1,27 @@
+//
+// This submodule implements our WebMedia trait for WebSocketTask.
+//
+use super::webmedia::{ConnectOptions, WebMedia};
+use gloo_console::log;
+use yew::prelude::Callback;
+use yew_websocket::websocket::{WebSocketService, WebSocketStatus, WebSocketTask};
+
+impl WebMedia<WebSocketTask> for WebSocketTask {
+    fn connect(options: ConnectOptions) -> anyhow::Result<WebSocketTask> {
+        let notification = Callback::from(move |status| match status {
+            WebSocketStatus::Opened => options.on_connected.emit(()),
+            WebSocketStatus::Closed | WebSocketStatus::Error => options.on_connection_lost.emit(()),
+        });
+        log!("Connecting to ", &options.websocket_url);
+        let task = WebSocketService::connect(
+            &options.websocket_url,
+            options.on_inbound_media,
+            notification,
+        )?;
+        Ok(task)
+    }
+
+    fn send_bytes(&self, bytes: Vec<u8>) {
+        self.send_binary(bytes);
+    }
+}

--- a/yew-ui/src/model/connection/websocket.rs
+++ b/yew-ui/src/model/connection/websocket.rs
@@ -12,12 +12,13 @@ impl WebMedia<WebSocketTask> for WebSocketTask {
             WebSocketStatus::Opened => options.on_connected.emit(()),
             WebSocketStatus::Closed | WebSocketStatus::Error => options.on_connection_lost.emit(()),
         });
-        log!("Connecting to ", &options.websocket_url);
+        log!("WebSocket connecting to ", &options.websocket_url);
         let task = WebSocketService::connect(
             &options.websocket_url,
             options.on_inbound_media,
             notification,
         )?;
+        log!("WebSocket connection success");
         Ok(task)
     }
 

--- a/yew-ui/src/model/connection/webtransport.rs
+++ b/yew-ui/src/model/connection/webtransport.rs
@@ -1,0 +1,190 @@
+// This submodule implements our WebMedia trait for WebTransportTask
+//
+// Sets up all the stream handling to support the callbacks on_connected, on_connection_lost, and
+// on_inbound_media
+//
+use super::webmedia::{ConnectOptions, WebMedia};
+use crate::model::MediaPacketWrapper;
+use gloo_console::log;
+use js_sys::Boolean;
+use js_sys::JsString;
+use js_sys::Reflect;
+use js_sys::Uint8Array;
+use protobuf::Message;
+use types::protos::media_packet::MediaPacket;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::ReadableStreamDefaultReader;
+use web_sys::WebTransportBidirectionalStream;
+use web_sys::WebTransportCloseInfo;
+use web_sys::WebTransportReceiveStream;
+use yew::prelude::Callback;
+use yew_webtransport::webtransport::{WebTransportService, WebTransportStatus, WebTransportTask};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum MessageType {
+    Datagram,
+    UnidirectionalStream,
+    BidirectionalStream,
+    // Unknown,
+}
+
+impl WebMedia<WebTransportTask> for WebTransportTask {
+    fn connect(options: ConnectOptions) -> anyhow::Result<WebTransportTask> {
+        let on_datagram = {
+            let on_inbound_media = options.on_inbound_media.clone();
+            Callback::from(move |bytes: Vec<u8>| {
+                emit_packet(bytes, MessageType::Datagram, on_inbound_media.clone())
+            })
+        };
+
+        let on_unidirectional_stream = {
+            let on_inbound_media = options.on_inbound_media.clone();
+            Callback::from(move |stream: WebTransportReceiveStream| {
+                handle_unidirectional_stream(stream, on_inbound_media.clone())
+            })
+        };
+
+        let on_bidirectional_stream = {
+            let on_inbound_media = options.on_inbound_media.clone();
+            Callback::from(move |stream: WebTransportBidirectionalStream| {
+                handle_bidirectional_stream(stream, on_inbound_media.clone())
+            })
+        };
+
+        let notification = Callback::from(move |status| match status {
+            WebTransportStatus::Opened => options.on_connected.emit(()),
+            WebTransportStatus::Closed(_error) | WebTransportStatus::Error(_error) => {
+                options.on_connection_lost.emit(())
+            }
+        });
+        log!("Connecting to ", &options.webtransport_url);
+        let task = WebTransportService::connect(
+            &options.webtransport_url,
+            on_datagram,
+            on_unidirectional_stream,
+            on_bidirectional_stream,
+            notification,
+        )?;
+        Ok(task)
+    }
+
+    fn send_bytes(&self, bytes: Vec<u8>) {
+        WebTransportTask::send_unidirectional_stream(self.transport.clone(), bytes);
+    }
+}
+
+fn handle_unidirectional_stream(
+    stream: WebTransportReceiveStream,
+    on_inbound_media: Callback<MediaPacketWrapper>,
+) {
+    if stream.is_undefined() {
+        log!("stream is undefined");
+        return;
+    }
+    let incoming_unistreams: ReadableStreamDefaultReader = stream.get_reader().unchecked_into();
+    let callback = Callback::from(move |d| {
+        emit_packet(
+            d,
+            MessageType::UnidirectionalStream,
+            on_inbound_media.clone(),
+        )
+    });
+    wasm_bindgen_futures::spawn_local(async move {
+        let mut buffer: Vec<u8> = vec![];
+        loop {
+            let read_result = JsFuture::from(incoming_unistreams.read()).await;
+            match read_result {
+                Err(e) => {
+                    let mut reason = WebTransportCloseInfo::default();
+                    reason.reason(format!("Failed to read incoming unistream {e:?}").as_str());
+                    break;
+                }
+                Ok(result) => {
+                    let done = Reflect::get(&result, &JsString::from("done"))
+                        .unwrap()
+                        .unchecked_into::<Boolean>();
+
+                    let value = Reflect::get(&result, &JsString::from("value")).unwrap();
+                    if !value.is_undefined() {
+                        let value: Uint8Array = value.unchecked_into();
+                        append_uint8_array_to_vec(&mut buffer, &value);
+                    }
+
+                    if done.is_truthy() {
+                        callback.emit(buffer);
+                        break;
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn handle_bidirectional_stream(
+    stream: WebTransportBidirectionalStream,
+    on_inbound_media: Callback<MediaPacketWrapper>,
+) {
+    log!("OnBidiStream: ", &stream);
+    if stream.is_undefined() {
+        log!("stream is undefined");
+        return;
+    }
+    let readable: ReadableStreamDefaultReader = stream.readable().get_reader().unchecked_into();
+    let callback = Callback::from(move |d| {
+        emit_packet(
+            d,
+            MessageType::BidirectionalStream,
+            on_inbound_media.clone(),
+        )
+    });
+    wasm_bindgen_futures::spawn_local(async move {
+        let mut buffer: Vec<u8> = vec![];
+        loop {
+            log!("reading from stream");
+            let read_result = JsFuture::from(readable.read()).await;
+
+            match read_result {
+                Err(e) => {
+                    let mut reason = WebTransportCloseInfo::default();
+                    reason.reason(format!("Failed to read incoming bidistream {e:?}").as_str());
+                    break;
+                }
+                Ok(result) => {
+                    let done = Reflect::get(&result, &JsString::from("done"))
+                        .unwrap()
+                        .unchecked_into::<Boolean>();
+                    let value = Reflect::get(&result, &JsString::from("value")).unwrap();
+                    if !value.is_undefined() {
+                        let value: Uint8Array = value.unchecked_into();
+                        append_uint8_array_to_vec(&mut buffer, &value);
+                    }
+                    if done.is_truthy() {
+                        callback.emit(buffer);
+                        break;
+                    }
+                }
+            }
+        }
+        log!("readable stream closed");
+    });
+}
+
+fn emit_packet(bytes: Vec<u8>, message_type: MessageType, callback: Callback<MediaPacketWrapper>) {
+    match MediaPacket::parse_from_bytes(&bytes) {
+        Ok(media_packet) => callback.emit(MediaPacketWrapper(media_packet)),
+        Err(_) => {
+            let message_type = format!("{:?}", message_type);
+            log!("failed to parse media packet ", message_type);
+        }
+    }
+}
+
+fn append_uint8_array_to_vec(rust_vec: &mut Vec<u8>, js_array: &Uint8Array) {
+    // Convert the Uint8Array into a Vec<u8>
+    let mut temp_vec = vec![0; js_array.length() as usize];
+    js_array.copy_to(&mut temp_vec);
+
+    // Append it to the existing Rust Vec<u8>
+    rust_vec.append(&mut temp_vec);
+}

--- a/yew-ui/src/model/connection/webtransport.rs
+++ b/yew-ui/src/model/connection/webtransport.rs
@@ -58,7 +58,7 @@ impl WebMedia<WebTransportTask> for WebTransportTask {
                 options.on_connection_lost.emit(())
             }
         });
-        log!("Connecting to ", &options.webtransport_url);
+        log!("WebTransport connecting to ", &options.webtransport_url);
         let task = WebTransportService::connect(
             &options.webtransport_url,
             on_datagram,
@@ -66,6 +66,7 @@ impl WebMedia<WebTransportTask> for WebTransportTask {
             on_bidirectional_stream,
             notification,
         )?;
+        log!("WebTransport connection success");
         Ok(task)
     }
 

--- a/yew-ui/src/model/mod.rs
+++ b/yew-ui/src/model/mod.rs
@@ -1,3 +1,4 @@
+pub mod connection;
 pub mod decode;
 pub mod encode;
 pub mod wrappers;


### PR DESCRIPTION
[Another step towards #74]

 @darioalessandro:   **I haven't tested this with WebTransport -- I don't know how.**

Even in `main` I can't/don't know how to get webtransport working?!   

So the WebTransport parts of this PR are all of the hopeful vein "if it compiles it probably works" --  I didn't write any real new logic it's all just rearranging the existing code, so that's got a reasonable chance of being true :)    But of course you should test it.      And/or can you explain how to run with webtransport locally on my mac?

Here's what's in the PR:
-----

Pulled all the relevant code out of `attendants.rs` into `model/connection/*` including eliminating a bunch of yew Messages that had been used to set up the WebTransport connection.

In doing the refactoring, organized the code into a few levels of abstraction.  From the bottom up, they are:

* `webmedia.rs` defines a `WebMedia` trait for MediaPacket-based connections, to provide a `connect()` method that sets up the desired callbacks (in particular `on_incoming_packet`), and a `send_packet()` method to transmit packets.

* `websocket.rs` and `webtransport.rs` implement the `WebMedia` trait for their respective mechanisms.  websocket.rs is pretty trivial; webtransport contains the logic to handle the different types of streams and to buffer the data to construct and dispatch packets.

* `task.rs` defines a generic `Task` interface over websocket and webtransport, and in particular handles the fallback rollover from webtransport to websocket

* `connection.rs` defines the top-level public interface, which wraps the `Task` interface in a `Connection` struct that also handles heartbeats and keeps track of the connection status, so that it can suppress attempts to send packets when the connection has been closed and can provide an `is_connected()` method.