### PR TITLE
Clean up some unused variable and unused result warnings

### DIFF
--- a/yew-ui/src/components/attendants.rs
+++ b/yew-ui/src/components/attendants.rs
@@ -127,10 +127,14 @@ impl AttendantsComponent {
                                 ..Default::default()
                             }));
                     }
-                    Err(e) => { error!("Failed to serialize rsa packet: {}", e.to_string()) }
+                    Err(e) => {
+                        error!("Failed to serialize rsa packet: {}", e.to_string())
+                    }
                 };
             }
-            Err(e) =>  { error!("Failed to export rsa public key to der: {}", e.to_string()) }
+            Err(e) => {
+                error!("Failed to export rsa public key to der: {}", e.to_string())
+            }
         }
     }
 

--- a/yew-ui/src/components/attendants.rs
+++ b/yew-ui/src/components/attendants.rs
@@ -110,29 +110,28 @@ impl AttendantsComponent {
         }
         let email = ctx.props().email.clone();
         let rsa = &*self.rsa;
-        rsa.pub_key
-            .to_public_key_der()
-            .map_err(|e| error!("Failed to export rsa public key to der: {}", e.to_string()))
-            .and_then(|public_key_der| {
-                let data = RsaPacket {
+        match rsa.pub_key.to_public_key_der() {
+            Ok(public_key_der) => {
+                let packet = RsaPacket {
                     username: email.clone(),
                     public_key_der: public_key_der.to_vec(),
                     ..Default::default()
-                }
-                .write_to_bytes()
-                .map_err(|e| error!("Failed to serialize rsa packet: {}", e.to_string()))
-                .and_then(|data| {
-                    ctx.link()
-                        .send_message(Msg::OnOutboundPacket(PacketWrapper {
-                            packet_type: PacketType::RSA_PUB_KEY.into(),
-                            email,
-                            data,
-                            ..Default::default()
-                        }));
-                    Ok(())
-                });
-                Ok(())
-            });
+                };
+                match packet.write_to_bytes() {
+                    Ok(data) => {
+                        ctx.link()
+                            .send_message(Msg::OnOutboundPacket(PacketWrapper {
+                                packet_type: PacketType::RSA_PUB_KEY.into(),
+                                email,
+                                data,
+                                ..Default::default()
+                            }));
+                    }
+                    Err(e) => { error!("Failed to serialize rsa packet: {}", e.to_string()) }
+                };
+            }
+            Err(e) =>  { error!("Failed to export rsa public key to der: {}", e.to_string()) }
+        }
     }
 
     fn create_peer_decoder_manager(ctx: &Context<Self>) -> PeerDecodeManager {
@@ -298,11 +297,8 @@ impl Component for AttendantsComponent {
                         }
                         debug!("Received AES_KEY {}", &response.email);
                         if let Ok(bytes) = self.rsa.decrypt(&response.data) {
-                            let aes_packet = AesPacket::parse_from_bytes(&bytes)
-                                .map_err(|e| {
-                                    error!("Failed to parse aes packet: {}", e.to_string())
-                                })
-                                .and_then(|aes_packet| {
+                            match AesPacket::parse_from_bytes(&bytes) {
+                                Ok(aes_packet) => {
                                     self.peer_keys.insert(
                                         response.email,
                                         Aes128State::from_vecs(
@@ -311,8 +307,11 @@ impl Component for AttendantsComponent {
                                             self.e2ee_enabled,
                                         ),
                                     );
-                                    Ok(())
-                                });
+                                }
+                                Err(e) => {
+                                    error!("Failed to parse aes packet: {}", e.to_string())
+                                }
+                            }
                         }
                         return false;
                     }
@@ -325,7 +324,7 @@ impl Component for AttendantsComponent {
                             .and_then(parse_public_key)
                             .and_then(|pub_key| {
                                 self.serialize_aes_packet()
-                                    .and_then(|aes_packet| Ok((aes_packet, pub_key)))
+                                    .map(|aes_packet| (aes_packet, pub_key))
                             })
                             .and_then(|(aes_packet, pub_key)| {
                                 self.encrypt_aes_packet(&aes_packet, &pub_key)


### PR DESCRIPTION
Kinda following up from #130...

Switch from .map_err().and_then() to match { }

This eliminates warnings about unused variables/result.  Also I think makes it easier to read.

Also switch from .and_then(... Ok()) to .map() to be a little cleaner.