### PR TITLE
Clean up scripts for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,43 +41,6 @@ Technically you could run this with a single computer, but it is more fun if you
 
 ![Oct-24-2022 08-37-09](https://user-images.githubusercontent.com/1176339/197853024-171e0dcc-2098-4780-b3be-bfc3cb5adb43.gif)
 
-# Developing/testing on a local computer
-
-(Without docker)
-
-## Prerequisites
-
-1. Create a postgresql database that you can accessed without a password.  The default database name is `actix-api-db`, i.e. the default connection string is `postgresql://$USER@localhost/actix-api-db`
-
-2. Install [trurl](see https://github.com/curl/trurl) and [nats-server]((see https://docs.nats.io/running-a-nats-service/introduction/installation)
-
-## Starting up the servers
-
-1. Run the script `./start_dev.sh`.
-
-   It examines various environment variables to control the behavior; see the script itself for details.
-   By default it runs using websockets rather than webtransport (`WEBTRANSPORT_ENABLED=0`) and without encryption (`E2EE_ENABLED=0`).
-
-2. Connect your browser to `http://localhost:8081/meeting/<username>/<meeting-id>`
-
-   You can make multiple connections (with varying usernames) from multiple browser windows or tabs.
-
-   If you are using encryption (`E2EE_ENABLED=1`), you should lanuch Chrome with
-   the necessary options for it to accept the local certificate by running `./launch_chrome.sh`
-
-
-# Compiling Cargo Workspace
-
-## Ubuntu
-
-Some system dependencies are required for the workspace to compile
- 
-```sh
-sudo apt-get update
-sudo apt-get install libglib2.0-dev libgtk-3-dev libsoup2.4 libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
-```
-
-
 ## ▶️ YouTube Channel
 https://www.youtube.com/@securityunion
 
@@ -96,7 +59,31 @@ Contains 3 sub-projects
 2. yew-ui: Yew frontend
 3. types: json serializable structures used to communicate the frontend and backend.
 
-# Dockerized workflow
+# Local Development
+
+## Without docker
+
+### Prerequisites
+
+1. Create a postgresql database that you can accessed without a password.  The default database name is `actix-api-db`, i.e. the default connection string is `postgresql://$USER@localhost/actix-api-db`
+
+2. Install [trurl](see https://github.com/curl/trurl) and [nats-server]((see https://docs.nats.io/running-a-nats-service/introduction/installation)
+
+### Starting up the servers
+
+1. Run the script `./start_dev.sh`.
+
+   It examines various environment variables to control the behavior; see the script itself for details.
+   By default it runs using websockets rather than webtransport (`WEBTRANSPORT_ENABLED=0`) and without encryption (`E2EE_ENABLED=0`).
+
+2. Connect your browser to `http://localhost:8081/meeting/<username>/<meeting-id>`
+
+   You can make multiple connections (with varying usernames) from multiple browser windows or tabs.
+
+   If you are using encryption (`E2EE_ENABLED=1`), you should lanuch Chrome with
+   the necessary options for it to accept the local certificate by running `./launch_chrome.sh`
+
+## Dockerized workflow
 
 1. Install docker
 2. Run one of the supported make commands

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ https://www.youtube.com/watch?v=kZ9isFw1TQ8
 
 MVP of a teleconferencing system written in rust, both the backend and the UI.
 
-# How to test?
+# How to try it out?
 
 ## Setup 
-Technically you could test this with a single computer, but it is more fun if you use 2+.
+Technically you could run this with a single computer, but it is more fun if you use 2+.
 
 ## Steps
 
@@ -41,12 +41,37 @@ Technically you could test this with a single computer, but it is more fun if yo
 
 ![Oct-24-2022 08-37-09](https://user-images.githubusercontent.com/1176339/197853024-171e0dcc-2098-4780-b3be-bfc3cb5adb43.gif)
 
+# Developing/testing on a local computer
+
+(Without docker)
+
+## Prerequisites
+
+1. Create a postgresql database that you can accessed without a password.  The default database name is `actix-api-db`, i.e. the default connection string is `postgresql://$USER@localhost/actix-api-db`
+
+2. Install [trurl](see https://github.com/curl/trurl) and [nats-server]((see https://docs.nats.io/running-a-nats-service/introduction/installation)
+
+## Starting up the servers
+
+1. Run the script `./start_dev.sh`.
+
+   It examines various environment variables to control the behavior; see the script itself for details.
+   By default it runs using websockets rather than webtransport (`WEBTRANSPORT_ENABLED=0`) and without encryption (`E2EE_ENABLED=0`).
+
+2. Connect your browser to `http://localhost:8081/meeting/<username>/<meeting-id>`
+
+   You can make multiple connections (with varying usernames) from multiple browser windows or tabs.
+
+   If you are using encryption (`E2EE_ENABLED=1`), you should lanuch Chrome with
+   the necessary options for it to accept the local certificate by running `./launch_chrome.sh`
+
+
 # Compiling Cargo Workspace
 
 ## Ubuntu
 
 Some system dependencies are required for the workspace to compile
-
+ 
 ```sh
 sudo apt-get update
 sudo apt-get install libglib2.0-dev libgtk-3-dev libsoup2.4 libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev

--- a/launch_chrome.sh
+++ b/launch_chrome.sh
@@ -3,24 +3,22 @@
 set -e
 
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+CERTSPATH="$SCRIPTPATH/actix-api/certs"
 
-# generate certificate
+if ! [ -f "$CERTSPATH/localhost.der" ] ; then
+    echo "Generating certificate in $CERTSPATH"
+    openssl req -x509 -newkey rsa:2048 -keyout "$CERTSPATH/localhost.key" -out "$CERTSPATH/localhost.pem" -days 365 -nodes -subj "/CN=127.0.0.1"
+    openssl x509 -in "$CERTSPATH/localhost.pem" -outform der -out "$CERTSPATH/localhost.der"
+    openssl rsa -in "$CERTSPATH/localhost.key" -outform DER -out "$CERTSPATH/localhost_key.der"
+fi
 
-openssl req -x509 -newkey rsa:2048 -keyout $SCRIPTPATH/actix-api/certs/localhost.key -out $SCRIPTPATH/actix-api/certs/localhost.pem -days 365 -nodes -subj "/CN=127.0.0.1"
-
-openssl x509 -in $SCRIPTPATH/actix-api/certs/localhost.pem -outform der -out $SCRIPTPATH/actix-api/certs/localhost.der
-
-openssl rsa -in $SCRIPTPATH/actix-api/certs/localhost.key -outform DER -out $SCRIPTPATH/actix-api/certs/localhost_key.der
-
-SPKI=`openssl x509 -inform der -in $SCRIPTPATH/actix-api/certs/localhost.der -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64`
-
-echo "Got cert key $SPKI"
+SPKI=$(openssl x509 -inform der -in "$CERTSPATH/localhost.der" -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64)
 
 echo "Opening google chrome"
 
-case `uname` in
-    (*Linux*)  google-chrome --origin-to-force-quic-on=127.0.0.1:4433 --ignore-certificate-errors-spki-list=$SPKI --enable-logging --v=1 ;;
-    (*Darwin*)  open -a "Google Chrome" --args --origin-to-force-quic-on=127.0.0.1:4433 --ignore-certificate-errors-spki-list=$SPKI --enable-logging --v=1 ;;
+case $(uname) in
+    (*Linux*)  google-chrome --origin-to-force-quic-on=127.0.0.1:4433 --ignore-certificate-errors-spki-list="$SPKI" --enable-logging --v=1 ;;
+    (*Darwin*)  open -a "Google Chrome" --args --origin-to-force-quic-on=127.0.0.1:4433 --ignore-certificate-errors-spki-list="$SPKI" --enable-logging --v=1 ;;
 esac
 
 ## Logs are stored to ~/Library/Application Support/Google/Chrome/chrome_debug.log

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -2,40 +2,54 @@
 
 # WARNING!! use this script while running without docker.
 
-
 export TRUNK_SERVE_PORT=8081
 export ACTIX_PORT=8086
+export LOGIN_URL=${LOGIN_URL:-http://localhost:${ACTIX_PORT:-8080}/login}
+export ACTIX_UI_BACKEND_URL=${ACTIX_UI_BACKEND_URL:-ws://localhost:${ACTIX_PORT:-8080}}
+export WEBTRANSPORT_HOST=${WEBTRANSPORT_HOST:-https://127.0.0.1:4433}
+export ENABLE_OAUTH=${ENABLE_OAUTH:-0}
+export WEBTRANSPORT_ENABLED=${WEBTRANSPORT_ENABLED:-0}
+export E2EE_ENABLED=${E2EE_ENABLED:-0}
+export NATS_URL=${NATS_URL:-0.0.0.0:4222}
+export HEALTH_LISTEN_URL=${HEALTH_LISTEN_URL:-0.0.0.0:5321}
+export LISTEN_URL=${LISTEN_URL:-0.0.0.0:4433}
+export DATABASE_URL=${DATABASE_URL:-postgresql://$USER@localhost/actix-api-db}
 
-children=()
+server_command="$( ((WEBTRANSPORT_ENABLED)) && echo webtransport_server || echo websocket_server )"
 
-_term() {
-    echo "Caught SIGTERM"
-    for child in "${children[@]}"; do
-        kill -TERM "$child" 2>/dev/null
-    done 
+_kill() {
+    kill -- -$$
+    # the command spawned by cargo watch doesn't get killed with the process group, so kill it explicitly
+    pkill -f "$server_command"
 }
 
-_int() {
-    echo "Caught SIGINT"
-    for child in "${children[@]}"; do
-        kill -TERM "$child" 2>/dev/null
-    done 
-}
+trap _kill SIGINT SIGTERM SIGQUIT
 
-trap _term SIGTERM
-trap _int SIGINT
+if ! [ -x "$(command -v trurl)" ] ; then
+    echo "please install trurl (see https://github.com/curl/trurl)"
+    exit
+fi
 
-pushd actix-api;
-cargo watch -x "run" &
+if ! [ -x "$(command -v nats-server)" ] ; then
+    echo "please install nats-server (see https://docs.nats.io/running-a-nats-service/introduction/installation)"
+    exit
+fi
+
+if ! psql "$DATABASE_URL" -c 'SELECT 1' >/dev/null; then
+    echo "please make sure postgresql is running with database defined for: $DATABASE_URL"
+    exit
+fi
+
+nats-server --addr "$(trurl -g '{host}' "$NATS_URL")" --port "$(trurl -g '{port}' "$NATS_URL")" &
+
+pushd actix-api > /dev/null || exit
+cargo watch -x "run --bin $server_command" &
 ACTIX_PROC=$!
-children+=($ACTIX_PROC)
-popd;
+popd > /dev/null || exit
 
-pushd yew-ui;
+pushd yew-ui > /dev/null || exit
 trunk serve &
-YEW_PROCESS=$!
-children+=($YEW_PROCESS)
-popd;
+popd > /dev/null || exit
 
 wait $ACTIX_PROC
 echo "Done running actix and yew, bye"


### PR DESCRIPTION
I've cleaned up `./start_dev.sh` so it works out of the box (for me anyway :) -- default values for environment variables, etc. -- to make it easy to develop locally without going through docker.    And I added some checks for a few prerequisites, though there are probably more I didn't think of.

I also changed `./launch-chrome.sh` so that it doesn't generate a new certificate each time, since that was forcing recompilation.

I've updated the README to include instructions for them.
