### PR TITLE
Add peer heartbeat monitor #36

### DIFF
--- a/videocall-client/src/connection/webmedia.rs
+++ b/videocall-client/src/connection/webmedia.rs
@@ -17,6 +17,7 @@ pub struct ConnectOptions {
     pub on_inbound_media: Callback<PacketWrapper>,
     pub on_connected: Callback<()>,
     pub on_connection_lost: Callback<()>,
+    pub peer_monitor: Callback<()>,
 }
 
 pub(super) trait WebMedia<TASK> {

--- a/videocall-client/src/decode/hash_map_with_ordered_keys.rs
+++ b/videocall-client/src/decode/hash_map_with_ordered_keys.rs
@@ -74,4 +74,24 @@ impl<K: Ord + Hash + Clone, V> HashMapWithOrderedKeys<K, V> {
     pub fn ordered_keys(&self) -> &Vec<K> {
         &self.keys
     }
+
+    pub fn remove_if<F>(&mut self, predicate: F)
+    where
+        F: Fn(&mut V) -> bool
+    {
+        let mut keys_to_remove = Vec::new();
+
+        for key in &self.keys{
+            if let Some(value) = self.map.get_mut(key) {
+                if !predicate(value){
+                    keys_to_remove.push(key.clone());
+               }
+            }
+        }
+
+         for key in &keys_to_remove {
+            self.map.remove(&key);
+            self.keys.retain(|k| k != key);
+        }
+    }
 }


### PR DESCRIPTION
The commit adds peer heartbeat monitoring functionality that registers each heartbeat received and removes peers that stopped missed all heartbeat opportunities in current monitoring period.

The heartbeat-based peer removal will take up to 2x of monitoring period duration to detect a lost peer.