### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "protobuf",
  "serde",

--- a/actix-api/CHANGELOG.md
+++ b/actix-api/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/sec-api-v0.1.0) - 2025-03-24
+
+### Other
+
+- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
+- Fix ci ([#191](https://github.com/security-union/videocall-rs/pull/191))
+- Upload images with the latest TAG ([#190](https://github.com/security-union/videocall-rs/pull/190))
+- Release video call daemon ([#176](https://github.com/security-union/videocall-rs/pull/176))
+- Fix webtransport ([#165](https://github.com/security-union/videocall-rs/pull/165))
+- make db optional and update instructions to digital ocean ([#163](https://github.com/security-union/videocall-rs/pull/163))
+- Video daemon ([#144](https://github.com/security-union/videocall-rs/pull/144))
+- Form validation ([#141](https://github.com/security-union/videocall-rs/pull/141))
+- Async nats ([#135](https://github.com/security-union/videocall-rs/pull/135))
+- End to end encryption ([#107](https://github.com/security-union/videocall-rs/pull/107))
+- Fix fmt & clippy on ci ([#124](https://github.com/security-union/videocall-rs/pull/124))
+- Use cargo workspace ([#113](https://github.com/security-union/videocall-rs/pull/113))
+- Remove spots that websocket API looks at packets to prep for e2ee ([#109](https://github.com/security-union/videocall-rs/pull/109))
+- Moving to digital ocean ([#97](https://github.com/security-union/videocall-rs/pull/97))
+- Fix UI stuttering by playing key frames asap ([#91](https://github.com/security-union/videocall-rs/pull/91))
+- Deploy webtransport to k8s ([#88](https://github.com/security-union/videocall-rs/pull/88))
+- Add Webtransport part 2 ([#86](https://github.com/security-union/videocall-rs/pull/86))
+- Basic Webtransport ([#79](https://github.com/security-union/videocall-rs/pull/79))
+- Bump openssl from 0.10.41 to 0.10.55 in /actix-api ([#78](https://github.com/security-union/videocall-rs/pull/78))
+- refactor chat server join room method ([#77](https://github.com/security-union/videocall-rs/pull/77))
+- Helm chart ([#71](https://github.com/security-union/videocall-rs/pull/71))
+- Horizontal scaling with NATS ([#62](https://github.com/security-union/videocall-rs/pull/62))
+- Fix audio && screenshare ([#65](https://github.com/security-union/videocall-rs/pull/65))
+- cargo clippy ([#45](https://github.com/security-union/videocall-rs/pull/45))
+- Add videoframe reordering on the UI ([#44](https://github.com/security-union/videocall-rs/pull/44))
+- Video 2 version ([#42](https://github.com/security-union/videocall-rs/pull/42))
+- Add bots ([#21](https://github.com/security-union/videocall-rs/pull/21))
+- Refactor for video shooting ([#11](https://github.com/security-union/videocall-rs/pull/11))
+- removes command module ([#8](https://github.com/security-union/videocall-rs/pull/8))
+- Add audio ([#2](https://github.com/security-union/videocall-rs/pull/2))
+- Initial MVP ([#1](https://github.com/security-union/videocall-rs/pull/1))
+- Initial commit

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
 tracing-tree = "0.2.3"
-videocall-types = { path= "../videocall-types", version = "0.1.0"}
+videocall-types = { path= "../videocall-types", version = "0.2.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/bot-v0.1.0) - 2025-03-24
+
+### Added
+
+- bot dotenv ([#54](https://github.com/security-union/videocall-rs/pull/54))
+
+### Other
+
+- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
+- Release video call daemon ([#176](https://github.com/security-union/videocall-rs/pull/176))
+- updating base images ([#160](https://github.com/security-union/videocall-rs/pull/160))
+- Video daemon ([#144](https://github.com/security-union/videocall-rs/pull/144))
+- Implement allow list ([#143](https://github.com/security-union/videocall-rs/pull/143))
+- End to end encryption ([#107](https://github.com/security-union/videocall-rs/pull/107))
+- Use cargo workspace ([#113](https://github.com/security-union/videocall-rs/pull/113))
+- Video 2 version ([#42](https://github.com/security-union/videocall-rs/pull/42))
+- Add bots ([#21](https://github.com/security-union/videocall-rs/pull/21))

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -13,7 +13,7 @@ serde = "1.0.130"
 serde_json = "1.0.72"
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "0.1.0"}
+videocall-types = { path= "../videocall-types", version = "0.2.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-client-v0.1.0) - 2025-03-24
+
+### Fixed
+
+- fix instructions ([#161](https://github.com/security-union/videocall-rs/pull/161))
+
+### Other
+
+- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
+- Diagnostics P1 (UI tweaks) ([#207](https://github.com/security-union/videocall-rs/pull/207))
+- Diagnostics Part 1 ([#206](https://github.com/security-union/videocall-rs/pull/206))
+- yew-ui enhance error handling for unable to access camera ([#200](https://github.com/security-union/videocall-rs/pull/200))
+- Fix ci ([#191](https://github.com/security-union/videocall-rs/pull/191))
+- Release video call daemon ([#176](https://github.com/security-union/videocall-rs/pull/176))
+- Fix webtransport ([#165](https://github.com/security-union/videocall-rs/pull/165))
+- updating base images ([#160](https://github.com/security-union/videocall-rs/pull/160))
+- Add peer heartbeat monitor ([#157](https://github.com/security-union/videocall-rs/pull/157))
+- Video daemon ([#144](https://github.com/security-union/videocall-rs/pull/144))
+- Revert "Revert "Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))" ([#147](https://github.com/security-union/videocall-rs/pull/147))" ([#150](https://github.com/security-union/videocall-rs/pull/150))
+- Revert "Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))" ([#147](https://github.com/security-union/videocall-rs/pull/147))
+- Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "0.1.0"}
+videocall-types = { path= "../videocall-types", version = "0.2.0" }
 wasm-bindgen = "0.2.78"
 wasm-bindgen-futures = "0.4.30"
 yew = { version = "0.21" }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v0.1.0...videocall-types-v0.2.0) - 2025-03-24
+
+### Other
+
+- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
+- Diagnostics Part 1 ([#206](https://github.com/security-union/videocall-rs/pull/206))

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `sec-api`: 0.1.0
* `bot`: 0.1.0
* `videocall-client`: 0.1.0

### ⚠ `videocall-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AudioMetadata.sequence in /tmp/.tmpz3bgiL/videocall-rs/videocall-types/src/protos/media_packet.rs:365

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant PacketType:DIAGNOSTICS in /tmp/.tmpz3bgiL/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:199
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v0.1.0...videocall-types-v0.2.0) - 2025-03-24

### Other

- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
- Diagnostics Part 1 ([#206](https://github.com/security-union/videocall-rs/pull/206))
</blockquote>

## `sec-api`

<blockquote>

## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/sec-api-v0.1.0) - 2025-03-24

### Other

- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
- Fix ci ([#191](https://github.com/security-union/videocall-rs/pull/191))
- Upload images with the latest TAG ([#190](https://github.com/security-union/videocall-rs/pull/190))
- Release video call daemon ([#176](https://github.com/security-union/videocall-rs/pull/176))
- Fix webtransport ([#165](https://github.com/security-union/videocall-rs/pull/165))
- make db optional and update instructions to digital ocean ([#163](https://github.com/security-union/videocall-rs/pull/163))
- Video daemon ([#144](https://github.com/security-union/videocall-rs/pull/144))
- Form validation ([#141](https://github.com/security-union/videocall-rs/pull/141))
- Async nats ([#135](https://github.com/security-union/videocall-rs/pull/135))
- End to end encryption ([#107](https://github.com/security-union/videocall-rs/pull/107))
- Fix fmt & clippy on ci ([#124](https://github.com/security-union/videocall-rs/pull/124))
- Use cargo workspace ([#113](https://github.com/security-union/videocall-rs/pull/113))
- Remove spots that websocket API looks at packets to prep for e2ee ([#109](https://github.com/security-union/videocall-rs/pull/109))
- Moving to digital ocean ([#97](https://github.com/security-union/videocall-rs/pull/97))
- Fix UI stuttering by playing key frames asap ([#91](https://github.com/security-union/videocall-rs/pull/91))
- Deploy webtransport to k8s ([#88](https://github.com/security-union/videocall-rs/pull/88))
- Add Webtransport part 2 ([#86](https://github.com/security-union/videocall-rs/pull/86))
- Basic Webtransport ([#79](https://github.com/security-union/videocall-rs/pull/79))
- Bump openssl from 0.10.41 to 0.10.55 in /actix-api ([#78](https://github.com/security-union/videocall-rs/pull/78))
- refactor chat server join room method ([#77](https://github.com/security-union/videocall-rs/pull/77))
- Helm chart ([#71](https://github.com/security-union/videocall-rs/pull/71))
- Horizontal scaling with NATS ([#62](https://github.com/security-union/videocall-rs/pull/62))
- Fix audio && screenshare ([#65](https://github.com/security-union/videocall-rs/pull/65))
- cargo clippy ([#45](https://github.com/security-union/videocall-rs/pull/45))
- Add videoframe reordering on the UI ([#44](https://github.com/security-union/videocall-rs/pull/44))
- Video 2 version ([#42](https://github.com/security-union/videocall-rs/pull/42))
- Add bots ([#21](https://github.com/security-union/videocall-rs/pull/21))
- Refactor for video shooting ([#11](https://github.com/security-union/videocall-rs/pull/11))
- removes command module ([#8](https://github.com/security-union/videocall-rs/pull/8))
- Add audio ([#2](https://github.com/security-union/videocall-rs/pull/2))
- Initial MVP ([#1](https://github.com/security-union/videocall-rs/pull/1))
- Initial commit
</blockquote>

## `bot`

<blockquote>

## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/bot-v0.1.0) - 2025-03-24

### Added

- bot dotenv ([#54](https://github.com/security-union/videocall-rs/pull/54))

### Other

- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
- Release video call daemon ([#176](https://github.com/security-union/videocall-rs/pull/176))
- updating base images ([#160](https://github.com/security-union/videocall-rs/pull/160))
- Video daemon ([#144](https://github.com/security-union/videocall-rs/pull/144))
- Implement allow list ([#143](https://github.com/security-union/videocall-rs/pull/143))
- End to end encryption ([#107](https://github.com/security-union/videocall-rs/pull/107))
- Use cargo workspace ([#113](https://github.com/security-union/videocall-rs/pull/113))
- Video 2 version ([#42](https://github.com/security-union/videocall-rs/pull/42))
- Add bots ([#21](https://github.com/security-union/videocall-rs/pull/21))
</blockquote>

## `videocall-client`

<blockquote>

## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-client-v0.1.0) - 2025-03-24

### Fixed

- fix instructions ([#161](https://github.com/security-union/videocall-rs/pull/161))

### Other

- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
- Diagnostics P1 (UI tweaks) ([#207](https://github.com/security-union/videocall-rs/pull/207))
- Diagnostics Part 1 ([#206](https://github.com/security-union/videocall-rs/pull/206))
- yew-ui enhance error handling for unable to access camera ([#200](https://github.com/security-union/videocall-rs/pull/200))
- Fix ci ([#191](https://github.com/security-union/videocall-rs/pull/191))
- Release video call daemon ([#176](https://github.com/security-union/videocall-rs/pull/176))
- Fix webtransport ([#165](https://github.com/security-union/videocall-rs/pull/165))
- updating base images ([#160](https://github.com/security-union/videocall-rs/pull/160))
- Add peer heartbeat monitor ([#157](https://github.com/security-union/videocall-rs/pull/157))
- Video daemon ([#144](https://github.com/security-union/videocall-rs/pull/144))
- Revert "Revert "Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))" ([#147](https://github.com/security-union/videocall-rs/pull/147))" ([#150](https://github.com/security-union/videocall-rs/pull/150))
- Revert "Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))" ([#147](https://github.com/security-union/videocall-rs/pull/147))
- Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).