### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "dotenv",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "sec-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "actix-cors",

--- a/actix-api/CHANGELOG.md
+++ b/actix-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/security-union/videocall-rs/compare/sec-api-v0.1.0...sec-api-v0.1.1) - 2025-03-24
+
+### Other
+
+- release ([#210](https://github.com/security-union/videocall-rs/pull/210))
+
 ## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/sec-api-v0.1.0) - 2025-03-24
 
 ### Other

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sec-api"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 release = false
 license = "MIT OR Apache-2.0"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/security-union/videocall-rs/compare/bot-v0.1.0...bot-v0.1.1) - 2025-03-24
+
+### Other
+
+- release ([#210](https://github.com/security-union/videocall-rs/pull/210))
+
 ## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/bot-v0.1.0) - 2025-03-24
 
 ### Added

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 release = false
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `sec-api`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `bot`: 0.1.0 -> 0.1.1
* `videocall-client`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `sec-api`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/sec-api-v0.1.0...sec-api-v0.1.1) - 2025-03-24

### Other

- release ([#210](https://github.com/security-union/videocall-rs/pull/210))
</blockquote>

## `bot`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/bot-v0.1.0...bot-v0.1.1) - 2025-03-24

### Other

- release ([#210](https://github.com/security-union/videocall-rs/pull/210))
</blockquote>

## `videocall-client`

<blockquote>

## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-client-v0.1.0) - 2025-03-24

### Fixed

- fix instructions ([#161](https://github.com/security-union/videocall-rs/pull/161))

### Other

- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
- Diagnostics P1 (UI tweaks) ([#207](https://github.com/security-union/videocall-rs/pull/207))
- Diagnostics Part 1 ([#206](https://github.com/security-union/videocall-rs/pull/206))
- yew-ui enhance error handling for unable to access camera ([#200](https://github.com/security-union/videocall-rs/pull/200))
- Fix ci ([#191](https://github.com/security-union/videocall-rs/pull/191))
- Release video call daemon ([#176](https://github.com/security-union/videocall-rs/pull/176))
- Fix webtransport ([#165](https://github.com/security-union/videocall-rs/pull/165))
- updating base images ([#160](https://github.com/security-union/videocall-rs/pull/160))
- Add peer heartbeat monitor ([#157](https://github.com/security-union/videocall-rs/pull/157))
- Video daemon ([#144](https://github.com/security-union/videocall-rs/pull/144))
- Revert "Revert "Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))" ([#147](https://github.com/security-union/videocall-rs/pull/147))" ([#150](https://github.com/security-union/videocall-rs/pull/150))
- Revert "Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))" ([#147](https://github.com/security-union/videocall-rs/pull/147))
- Move `VideoCallClient` into its own crate ([#142](https://github.com/security-union/videocall-rs/pull/142))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).