### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "protobuf",
  "serde",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -46,7 +46,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "0.2.0" }
+videocall-types = { path= "../videocall-types", version = "0.2.1" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "0.2.0" }
+videocall-types = { path= "../videocall-types", version = "0.2.1" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v0.1.0...videocall-client-v0.1.1) - 2025-03-25
+
+### Other
+
+- Try to get release plz to work ([#216](https://github.com/security-union/videocall-rs/pull/216))
+- add release-plz.toml ([#212](https://github.com/security-union/videocall-rs/pull/212))
+
 ## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-client-v0.1.0) - 2025-03-24
 
 ### Fixed

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "0.2.0" }
+videocall-types = { path= "../videocall-types", version = "0.2.1" }
 wasm-bindgen = "0.2.78"
 wasm-bindgen-futures = "0.4.30"
 yew = { version = "0.21" }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v0.2.0...videocall-types-v0.2.1) - 2025-03-25
+
+### Other
+
+- Try to get release plz to work ([#216](https://github.com/security-union/videocall-rs/pull/216))
+
 ## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v0.1.0...videocall-types-v0.2.0) - 2025-03-24
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `videocall-client`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [0.2.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v0.2.0...videocall-types-v0.2.1) - 2025-03-25

### Other

- Try to get release plz to work ([#216](https://github.com/security-union/videocall-rs/pull/216))
</blockquote>

## `videocall-client`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v0.1.0...videocall-client-v0.1.1) - 2025-03-25

### Other

- Try to get release plz to work ([#216](https://github.com/security-union/videocall-rs/pull/216))
- add release-plz.toml ([#212](https://github.com/security-union/videocall-rs/pull/212))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).