### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.1...videocall-cli-v1.0.2) - 2025-03-26
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.0...videocall-cli-v1.0.1) - 2025-03-26
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.0.0...videocall-client-v1.0.1) - 2025-03-26
+
+### Fixed
+
+- bring back audio playback ([#226](https://github.com/security-union/videocall-rs/pull/226))
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v0.1.0...videocall-client-v0.1.1) - 2025-03-25
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"


### PR DESCRIPTION



## 🤖 New release

* `videocall-client`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `videocall-cli`: 1.0.1 -> 1.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-client`

<blockquote>

## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.0.0...videocall-client-v1.0.1) - 2025-03-26

### Fixed

- bring back audio playback ([#226](https://github.com/security-union/videocall-rs/pull/226))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.2](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.1...videocall-cli-v1.0.2) - 2025-03-26

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).