### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "dotenv",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/security-union/videocall-rs/compare/bot-v1.0.0...bot-v1.0.1) - 2025-03-26
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/bot-v0.1.0) - 2025-03-24
 
 ### Added

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.2...videocall-cli-v1.0.3) - 2025-03-26
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.2](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.1...videocall-cli-v1.0.2) - 2025-03-26
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.0.1...videocall-client-v1.1.0) - 2025-03-26
+
+### Added
+
+- Publish UI as a standalone crate and incorporate into single videocall workspace ([#228](https://github.com/security-union/videocall-rs/pull/228))
+
 ## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.0.0...videocall-client-v1.0.1) - 2025-03-26
 
 ### Fixed

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.0...videocall-ui-v1.0.1) - 2025-03-26
+
+### Other
+
+- updated the following local packages: videocall-client

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2.95"
 videocall-types = { path= "../videocall-types", version = "1.0.0"}
-videocall-client = { path= "../videocall-client", version = "1.0.0"}
+videocall-client = { path= "../videocall-client", version = "1.1.0" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION



## 🤖 New release

* `bot`: 1.0.0 -> 1.0.1
* `videocall-client`: 1.0.1 -> 1.1.0 (✓ API compatible changes)
* `videocall-cli`: 1.0.2 -> 1.0.3 (✓ API compatible changes)
* `videocall-ui`: 1.0.0 -> 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `bot`

<blockquote>

## [1.0.1](https://github.com/security-union/videocall-rs/compare/bot-v1.0.0...bot-v1.0.1) - 2025-03-26

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.0.1...videocall-client-v1.1.0) - 2025-03-26

### Added

- Publish UI as a standalone crate and incorporate into single videocall workspace ([#228](https://github.com/security-union/videocall-rs/pull/228))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.2...videocall-cli-v1.0.3) - 2025-03-26

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.0...videocall-ui-v1.0.1) - 2025-03-26

### Other

- updated the following local packages: videocall-client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).