### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "2.0.0"
+version = "1.0.1"
 dependencies = [
  "protobuf",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "dotenv",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aes",
  "anyhow",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "protobuf",
  "serde",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "1.0.0" }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-types = { path= "../videocall-types", version = "1.0.1" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/security-union/videocall-rs/compare/bot-v1.0.1...bot-v1.0.2) - 2025-03-28
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.0.1](https://github.com/security-union/videocall-rs/compare/bot-v1.0.0...bot-v1.0.1) - 2025-03-26
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "1.0.0" }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-types = { path= "../videocall-types", version = "1.0.1" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.4...videocall-cli-v1.0.5) - 2025-03-28
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.4](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.3...videocall-cli-v1.0.4) - 2025-03-27
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.8", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "2.0.0"
+version = "1.0.1"
 

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.8", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "1.0.0"
+version = "2.0.0"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.1...videocall-client-v1.1.2) - 2025-03-28
+
+### Added
+
+- Add video, screen and mic state to heartbeat and to peer state ([#234](https://github.com/security-union/videocall-rs/pull/234))
+
 ## [1.1.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.0...videocall-client-v1.1.1) - 2025-03-27
 
 ### Fixed

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -27,7 +27,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "1.0.0" }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.30"
 web-time = "1.1.0"

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-types = { path= "../videocall-types", version = "1.0.1" }
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.30"
 web-time = "1.1.0"

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.0...videocall-types-v2.0.0) - 2025-03-28
+
+### Added
+
+- Add video, screen and mic state to heartbeat and to peer state ([#234](https://github.com/security-union/videocall-rs/pull/234))
+
 ## [0.2.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v0.2.0...videocall-types-v0.2.1) - 2025-03-25
 
 ### Other

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.0...videocall-types-v2.0.0) - 2025-03-28
+## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.0...videocall-types-v1.0.1) - 2025-03-28
 
 ### Added
 

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "2.0.0"
+version = "1.0.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.2...videocall-ui-v1.0.3) - 2025-03-28
+
+### Added
+
+- Add video, screen and mic state to heartbeat and to peer state ([#234](https://github.com/security-union/videocall-rs/pull/234))
+
 ## [1.0.2](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.1...videocall-ui-v1.0.2) - 2025-03-27
 
 ### Fixed

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2.95"
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-types = { path= "../videocall-types", version = "1.0.1" }
 videocall-client = { path= "../videocall-client", version = "1.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -15,8 +15,8 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2.95"
-videocall-types = { path= "../videocall-types", version = "1.0.0"}
-videocall-client = { path= "../videocall-client", version = "1.1.1" }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-client = { path= "../videocall-client", version = "1.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION


## 🤖 New release

* `videocall-types`: 1.0.0 -> 1.0.1 ✓ API compatible changes)
* `videocall-client`: 1.1.1 -> 1.1.2 (✓ API compatible changes)
* `videocall-cli`: 1.0.4 -> 1.0.5 (✓ API compatible changes)
* `videocall-ui`: 1.0.2 -> 1.0.3
* `bot`: 1.0.1 -> 1.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.0...videocall-types-v1.0.1) - 2025-03-28

### Added

- Add video, screen and mic state to heartbeat and to peer state ([#234](https://github.com/security-union/videocall-rs/pull/234))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.2](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.1...videocall-client-v1.1.2) - 2025-03-28

### Added

- Add video, screen and mic state to heartbeat and to peer state ([#234](https://github.com/security-union/videocall-rs/pull/234))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.5](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.4...videocall-cli-v1.0.5) - 2025-03-28

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.2...videocall-ui-v1.0.3) - 2025-03-28

### Added

- Add video, screen and mic state to heartbeat and to peer state ([#234](https://github.com/security-union/videocall-rs/pull/234))
</blockquote>

## `bot`

<blockquote>

## [1.0.2](https://github.com/security-union/videocall-rs/compare/bot-v1.0.1...bot-v1.0.2) - 2025-03-28

### Other

- updated the following local packages: videocall-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).