### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.0"
+version = "1.0.4"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.5...videocall-cli-v1.0.6) - 2025-03-28
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.5](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.4...videocall-cli-v1.0.5) - 2025-03-28
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.3...videocall-ui-v1.1.0) - 2025-03-28
+
+### Added
+
+- Add a nice error handler for browser compatibility.([#236](https://github.com/security-union/videocall-rs/pull/236))
+
 ## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.2...videocall-ui-v1.0.3) - 2025-03-28
 
 ### Added

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.3...videocall-ui-v1.1.0) - 2025-03-28
+## [1.0.4](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.3...videocall-ui-v1.0.4) - 2025-03-28
 
 ### Added
 

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.0"
+version = "1.0.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"


### PR DESCRIPTION


## 🤖 New release

* `videocall-cli`: 1.0.5 -> 1.0.6 (✓ API compatible changes)
* `videocall-ui`: 1.0.3 -> 1.0.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-cli`

<blockquote>

## [1.0.6](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.5...videocall-cli-v1.0.6) - 2025-03-28

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.4](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.3...videocall-ui-v1.0.4) - 2025-03-28

### Added

- Add a nice error handler for browser compatibility.([#236](https://github.com/security-union/videocall-rs/pull/236))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).