### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "aes",
  "anyhow",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.7...videocall-cli-v1.0.8) - 2025-03-29
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.7](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.6...videocall-cli-v1.0.7) - 2025-03-29
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.3...videocall-client-v1.1.4) - 2025-03-29
+
+### Fixed
+
+- UI Prevent constant updates due to minor bitrate changes. ([#240](https://github.com/security-union/videocall-rs/pull/240))
+
 ## [1.1.3](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.2...videocall-client-v1.1.3) - 2025-03-29
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.5...videocall-ui-v1.0.6) - 2025-03-29
+
+### Fixed
+
+- UI Prevent constant updates due to minor bitrate changes. ([#240](https://github.com/security-union/videocall-rs/pull/240))
+
 ## [1.0.5](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.4...videocall-ui-v1.0.5) - 2025-03-29
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2.95"
 videocall-types = { path= "../videocall-types", version = "1.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.3" }
+videocall-client = { path= "../videocall-client", version = "1.1.4" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-client`: 1.1.3 -> 1.1.4 (✓ API compatible changes)
* `videocall-cli`: 1.0.7 -> 1.0.8 (✓ API compatible changes)
* `videocall-ui`: 1.0.5 -> 1.0.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-client`

<blockquote>

## [1.1.4](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.3...videocall-client-v1.1.4) - 2025-03-29

### Fixed

- UI Prevent constant updates due to minor bitrate changes. ([#240](https://github.com/security-union/videocall-rs/pull/240))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.8](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.7...videocall-cli-v1.0.8) - 2025-03-29

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.6](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.5...videocall-ui-v1.0.6) - 2025-03-29

### Fixed

- UI Prevent constant updates due to minor bitrate changes. ([#240](https://github.com/security-union/videocall-rs/pull/240))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).