### PR TITLE
fix leptos website

### DIFF
--- a/leptos-website/Cargo.lock
+++ b/leptos-website/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_website"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3082,24 +3082,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -3120,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3130,9 +3130,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3143,9 +3143,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"

--- a/leptos-website/Cargo.toml
+++ b/leptos-website/Cargo.toml
@@ -45,7 +45,7 @@ sqlx = { version = "0.6.2", features = [
 	"sqlite",
 ], optional = true }
 thiserror = "1.0.38"
-wasm-bindgen = "0.2.85"
+wasm-bindgen = "0.2.100"
 femark = { version = "=0.1.3", optional = true }
 axum-extra = { version = "0.7.4", optional = true, features = ["cookie"] }
 web-sys = { version = "0.3", optional = true, features = [

--- a/leptos-website/README.md
+++ b/leptos-website/README.md
@@ -12,6 +12,11 @@ cargo-leptos is now the easiest and most featureful way to build server side ren
 ```bash
 cargo install --locked cargo-leptos
 ``` 
+2. Install wasm-bindegen
+```bash
+cargo install wasm-bindgen-cli@0.2.100 --locked
+```
+
 2. Build the site in watch mode, recompiling on file changes
 ```bash
 cargo leptos watch

--- a/leptos-website/README.md
+++ b/leptos-website/README.md
@@ -12,7 +12,7 @@ cargo-leptos is now the easiest and most featureful way to build server side ren
 ```bash
 cargo install --locked cargo-leptos
 ``` 
-2. Install wasm-bindegen
+2. Install wasm-bindgen
 ```bash
 cargo install wasm-bindgen-cli@0.2.100 --locked
 ```


### PR DESCRIPTION
1. Update README with instructions regarding which version of wasm-bindgen-cli to install. 
2. Updated wasm-bindgen to 0.2.100

CC @majorrawdawg