### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6063,7 +6063,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -6185,7 +6185,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.12](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.11...videocall-cli-v1.0.12) - 2025-04-20
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.11](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.10...videocall-cli-v1.0.11) - 2025-04-07
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.0...videocall-sdk-v0.1.1) - 2025-04-20
+
+### Other
+
+- *(videocall-cli)* release v1.0.11 ([#252](https://github.com/security-union/videocall-rs/pull/252))
+
 ## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-sdk-v0.1.0) - 2025-04-07
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.8...videocall-ui-v1.0.9) - 2025-04-20
+
+### Other
+
+- Add digital ocean both in the readme and main page ([#260](https://github.com/security-union/videocall-rs/pull/260))
+
+### Removed
+
+- removed E2E encryption from description ([#249](https://github.com/security-union/videocall-rs/pull/249))
+
 ## [1.0.8](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.7...videocall-ui-v1.0.8) - 2025-03-31
 
 ### Added

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"


### PR DESCRIPTION



## 🤖 New release

* `videocall-cli`: 1.0.11 -> 1.0.12 (✓ API compatible changes)
* `videocall-ui`: 1.0.8 -> 1.0.9
* `videocall-sdk`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-cli`

<blockquote>

## [1.0.12](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.11...videocall-cli-v1.0.12) - 2025-04-20

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.9](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.8...videocall-ui-v1.0.9) - 2025-04-20

### Other

- Add digital ocean both in the readme and main page ([#260](https://github.com/security-union/videocall-rs/pull/260))

### Removed

- removed E2E encryption from description ([#249](https://github.com/security-union/videocall-rs/pull/249))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.0...videocall-sdk-v0.1.1) - 2025-04-20

### Other

- *(videocall-cli)* release v1.0.11 ([#252](https://github.com/security-union/videocall-rs/pull/252))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).