### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.6"
+version = "1.1.7"
 dependencies = [
  "aes",
  "anyhow",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "flume",
  "image 0.25.6",
@@ -6303,7 +6303,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-bindings-linux"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "v4l",
  "videocall-nokhwa-core",
@@ -6326,7 +6326,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-bindings-windows"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "once_cell",
  "videocall-nokhwa-core",
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "protobuf",
  "serde",
@@ -6384,7 +6384,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "1.0.1" }
+videocall-types = { path= "../videocall-types", version = "1.0.2" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/security-union/videocall-rs/compare/bot-v1.0.2...bot-v1.0.3) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+- move audio, video and speaker settings under a modal #273 ([#278](https://github.com/security-union/videocall-rs/pull/278))
+
 ## [1.0.2](https://github.com/security-union/videocall-rs/compare/bot-v1.0.1...bot-v1.0.2) - 2025-03-28
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "1.0.1" }
+videocall-types = { path= "../videocall-types", version = "1.0.2" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.13](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.12...videocall-cli-v1.0.13) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
+
 ## [1.0.12](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.11...videocall-cli-v1.0.12) - 2025-04-20
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.12"
+version = "1.0.13"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -38,10 +38,10 @@ cpal = "0.15.2"
 opus = "0.3.0"
 image = "0.25.5"
 env-libvpx-sys = { version = "5.1.3", features=["generate"] }
-videocall-nokhwa = { path = "nokhwa", version = "0.10.8", features = ["input-native", "output-threaded"] }
+videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-native", "output-threaded"] }
 
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "1.0.1"
+version = "1.0.2"
 

--- a/videocall-cli/nokhwa/CHANGELOG.md
+++ b/videocall-cli/nokhwa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.9](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-v0.10.8...videocall-nokhwa-v0.10.9) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+
 ## [0.10.8](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-v0.10.7...videocall-nokhwa-v0.10.8) - 2025-03-26
 
 ### Other

--- a/videocall-cli/nokhwa/Cargo.toml
+++ b/videocall-cli/nokhwa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa"
-version = "0.10.8"
+version = "0.10.9"
 authors = ["l1npengtul <l1npengtul@protonmail.com>", "Dario Lencina <dario@securityunion.dev>"]
 edition = "2021"
 description = "A Simple-to-use, cross-platform Rust Webcam Capture Library"

--- a/videocall-cli/nokhwa/nokhwa-bindings-linux/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-bindings-linux/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-linux-v0.1.2...videocall-nokhwa-bindings-linux-v0.1.3) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-linux-v0.1.1...videocall-nokhwa-bindings-linux-v0.1.2) - 2025-03-26
 
 ### Other

--- a/videocall-cli/nokhwa/nokhwa-bindings-linux/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-bindings-linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-bindings-linux"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["l1npengtul <l1npengtul@protonmail.com>", "Dario Lencina <dario@securityunion.dev>"]

--- a/videocall-cli/nokhwa/nokhwa-bindings-windows/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-bindings-windows/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-windows-v0.4.3...videocall-nokhwa-bindings-windows-v0.4.4) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+
 ## [0.4.3](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-windows-v0.4.2...videocall-nokhwa-bindings-windows-v0.4.3) - 2025-03-26
 
 ### Other

--- a/videocall-cli/nokhwa/nokhwa-bindings-windows/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-bindings-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-bindings-windows"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["l1npengtul", "Dario Lencina <dario@securityunion.dev>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/videocall-cli/nokhwa/nokhwa-core/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.6...videocall-nokhwa-core-v0.1.7) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+
 ## [0.1.6](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.5...videocall-nokhwa-core-v0.1.6) - 2025-03-26
 
 ### Other

--- a/videocall-cli/nokhwa/nokhwa-core/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-core"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["l1npengtul <l1npengtul@protonmail.com>", "Dario Lencina <dario@securityunion.dev>"]
 edition = "2021"
 description = "Core type definitions for nokhwa"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.7](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.6...videocall-client-v1.1.7) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+- Fix rotation ios image aspect ratio ([#282](https://github.com/security-union/videocall-rs/pull/282))
+- Hide screen share safari and fix selector ([#281](https://github.com/security-union/videocall-rs/pull/281))
+- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
+
 ## [1.1.6](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.5...videocall-client-v1.1.6) - 2025-03-31
 
 ### Added

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.6"
+version = "1.1.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "1.0.1" }
+videocall-types = { path= "../videocall-types", version = "1.0.2" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.1...videocall-sdk-v0.1.2) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+- Add disclaimer regarding dev stage ([#264](https://github.com/security-union/videocall-rs/pull/264))
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.0...videocall-sdk-v0.1.1) - 2025-04-20
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "1.0.1" }
+videocall-types = { path = "../videocall-types", version = "1.0.2" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.1...videocall-types-v1.0.2) - 2025-06-23
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+
 ## [1.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.0...videocall-types-v1.0.1) - 2025-03-28
 
 ### Added

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.10](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.9...videocall-ui-v1.0.10) - 2025-06-23
+
+### Fixed
+
+- fix CSS for attendants and diagnostics ([#277](https://github.com/security-union/videocall-rs/pull/277))
+
+### Other
+
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+- disable ios controls maybe ([#284](https://github.com/security-union/videocall-rs/pull/284))
+- save ([#283](https://github.com/security-union/videocall-rs/pull/283))
+- save
+- save
+- Fix device modal selection ([#279](https://github.com/security-union/videocall-rs/pull/279))
+- move audio, video and speaker settings under a modal #273 ([#278](https://github.com/security-union/videocall-rs/pull/278))
+- Add the rawdawg to contributors ([#276](https://github.com/security-union/videocall-rs/pull/276))
+- Feature/gh 274 enhance mobile grid layout ([#275](https://github.com/security-union/videocall-rs/pull/275))
+- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
+
 ## [1.0.9](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.8...videocall-ui-v1.0.9) - 2025-04-20
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -15,8 +15,8 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2.95"
-videocall-types = { path= "../videocall-types", version = "1.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.6" }
+videocall-types = { path= "../videocall-types", version = "1.0.2" }
+videocall-client = { path= "../videocall-client", version = "1.1.7" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `bot`: 1.0.2 -> 1.0.3
* `videocall-client`: 1.1.6 -> 1.1.7 (✓ API compatible changes)
* `videocall-nokhwa-core`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `videocall-nokhwa-bindings-linux`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `videocall-nokhwa-bindings-windows`: 0.4.3 -> 0.4.4 (✓ API compatible changes)
* `videocall-nokhwa`: 0.10.8 -> 0.10.9
* `videocall-cli`: 1.0.12 -> 1.0.13 (✓ API compatible changes)
* `videocall-ui`: 1.0.9 -> 1.0.10
* `videocall-sdk`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [1.0.2](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.1...videocall-types-v1.0.2) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
</blockquote>

## `bot`

<blockquote>

## [1.0.3](https://github.com/security-union/videocall-rs/compare/bot-v1.0.2...bot-v1.0.3) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
- move audio, video and speaker settings under a modal #273 ([#278](https://github.com/security-union/videocall-rs/pull/278))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.7](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.6...videocall-client-v1.1.7) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
- Fix rotation ios image aspect ratio ([#282](https://github.com/security-union/videocall-rs/pull/282))
- Hide screen share safari and fix selector ([#281](https://github.com/security-union/videocall-rs/pull/281))
- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
</blockquote>

## `videocall-nokhwa-core`

<blockquote>

## [0.1.7](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.6...videocall-nokhwa-core-v0.1.7) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
</blockquote>

## `videocall-nokhwa-bindings-linux`

<blockquote>

## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-linux-v0.1.2...videocall-nokhwa-bindings-linux-v0.1.3) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
</blockquote>

## `videocall-nokhwa-bindings-windows`

<blockquote>

## [0.4.4](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-windows-v0.4.3...videocall-nokhwa-bindings-windows-v0.4.4) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
</blockquote>

## `videocall-nokhwa`

<blockquote>

## [0.10.9](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-v0.10.8...videocall-nokhwa-v0.10.9) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.13](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.12...videocall-cli-v1.0.13) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.10](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.9...videocall-ui-v1.0.10) - 2025-06-23

### Fixed

- fix CSS for attendants and diagnostics ([#277](https://github.com/security-union/videocall-rs/pull/277))

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
- disable ios controls maybe ([#284](https://github.com/security-union/videocall-rs/pull/284))
- save ([#283](https://github.com/security-union/videocall-rs/pull/283))
- save
- save
- Fix device modal selection ([#279](https://github.com/security-union/videocall-rs/pull/279))
- move audio, video and speaker settings under a modal #273 ([#278](https://github.com/security-union/videocall-rs/pull/278))
- Add the rawdawg to contributors ([#276](https://github.com/security-union/videocall-rs/pull/276))
- Feature/gh 274 enhance mobile grid layout ([#275](https://github.com/security-union/videocall-rs/pull/275))
- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.1...videocall-sdk-v0.1.2) - 2025-06-23

### Other

- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
- Add disclaimer regarding dev stage ([#264](https://github.com/security-union/videocall-rs/pull/264))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).