### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "protobuf",
  "serde",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "1.0.2" }
+videocall-types = { path= "../videocall-types", version = "1.0.3" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/security-union/videocall-rs/compare/bot-v1.0.3...bot-v1.0.4) - 2025-06-29
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.0.3](https://github.com/security-union/videocall-rs/compare/bot-v1.0.2...bot-v1.0.3) - 2025-06-23
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "1.0.2" }
+videocall-types = { path= "../videocall-types", version = "1.0.3" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "1.0.2"
+version = "1.0.3"
 

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "1.0.2" }
+videocall-types = { path= "../videocall-types", version = "1.0.3" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "1.0.2" }
+videocall-types = { path = "../videocall-types", version = "1.0.3" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.2...videocall-types-v1.0.3) - 2025-06-29
+
+### Other
+
+- Fix meeting creation ([#293](https://github.com/security-union/videocall-rs/pull/293))
+
 ## [1.0.2](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.1...videocall-types-v1.0.2) - 2025-06-23
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2.95"
-videocall-types = { path= "../videocall-types", version = "1.0.2" }
+videocall-types = { path= "../videocall-types", version = "1.0.3" }
 videocall-client = { path= "../videocall-client", version = "1.1.7" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 1.0.2 -> 1.0.3 (✓ API compatible changes)
* `bot`: 1.0.3 -> 1.0.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.2...videocall-types-v1.0.3) - 2025-06-29

### Other

- Fix meeting creation ([#293](https://github.com/security-union/videocall-rs/pull/293))
</blockquote>

## `bot`

<blockquote>

## [1.0.4](https://github.com/security-union/videocall-rs/compare/bot-v1.0.3...bot-v1.0.4) - 2025-06-29

### Other

- updated the following local packages: videocall-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).