### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6232,7 +6232,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -6255,7 +6255,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "aes",
  "anyhow",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -6415,7 +6415,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.14](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.13...videocall-cli-v1.0.14) - 2025-07-03
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.13](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.12...videocall-cli-v1.0.13) - 2025-06-23
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.13"
+version = "1.0.14"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.8](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.7...videocall-client-v1.1.8) - 2025-07-03
+
+### Other
+
+- Reset decoder and jitter buffer when there's a decoder error ([#298](https://github.com/security-union/videocall-rs/pull/298))
+
 ## [1.1.7](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.6...videocall-client-v1.1.7) - 2025-06-23
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.7"
+version = "1.1.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,7 +37,7 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.1" }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.2" }
 
 [dependencies.web-sys]
 version = "0.3.72"

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.1...videocall-codecs-v0.1.2) - 2025-07-03
+
+### Other
+
+- Reset decoder and jitter buffer when there's a decoder error ([#298](https://github.com/security-union/videocall-rs/pull/298))
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.0...videocall-codecs-v0.1.1) - 2025-06-25
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.11](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.10...videocall-ui-v1.0.11) - 2025-07-03
+
+### Other
+
+- Reset decoder and jitter buffer when there's a decoder error ([#298](https://github.com/security-union/videocall-rs/pull/298))
+
 ## [1.0.10](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.9...videocall-ui-v1.0.10) - 2025-06-23
 
 ### Fixed

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = "0.2.95"
 videocall-types = { path= "../videocall-types", version = "1.0.3" }
-videocall-client = { path= "../videocall-client", version = "1.1.7" }
+videocall-client = { path= "../videocall-client", version = "1.1.8" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-codecs`: 0.1.1 -> 0.1.2
* `videocall-client`: 1.1.7 -> 1.1.8 (✓ API compatible changes)
* `videocall-cli`: 1.0.13 -> 1.0.14 (✓ API compatible changes)
* `videocall-ui`: 1.0.10 -> 1.0.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-codecs`

<blockquote>

## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.1...videocall-codecs-v0.1.2) - 2025-07-03

### Other

- Reset decoder and jitter buffer when there's a decoder error ([#298](https://github.com/security-union/videocall-rs/pull/298))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.8](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.7...videocall-client-v1.1.8) - 2025-07-03

### Other

- Reset decoder and jitter buffer when there's a decoder error ([#298](https://github.com/security-union/videocall-rs/pull/298))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.14](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.13...videocall-cli-v1.0.14) - 2025-07-03

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.11](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.10...videocall-ui-v1.0.11) - 2025-07-03

### Other

- Reset decoder and jitter buffer when there's a decoder error ([#298](https://github.com/security-union/videocall-rs/pull/298))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).