### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "axum",
  "clap",
@@ -6541,7 +6541,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-diagnostics"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "flume",
  "js-sys",

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.1.2...neteq-v0.2.0) - 2025-07-10
+
+### Other
+
+- Add neteq to safari and use worklet for audio decoding across the board ([#315](https://github.com/security-union/videocall-rs/pull/315))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/neteq-v0.1.1...neteq-v0.1.2) - 2025-07-07
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -38,10 +38,10 @@ yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
 videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.2" }
-neteq = { path = "../neteq", features = ["web"], version = "0.1.1", optional = true,  default-features = false }
+neteq = { path = "../neteq", features = ["web"], version = "0.2.0", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.0" }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
 serde_json = { version = "1.0" }
 
 [features]

--- a/videocall-diagnostics/Cargo.toml
+++ b/videocall-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-diagnostics"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Lightweight diagnostics event bus for the videocall-rs project"

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -17,7 +17,7 @@ yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "1.0.3" }
 videocall-client = { path= "../videocall-client", version = "1.1.9", features = ["neteq_ff"] }
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.0" }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION


## 🤖 New release

* `neteq`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `videocall-diagnostics`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

### ⚠ `neteq` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetworkStatistics.reordered_packets in /tmp/.tmpajfDC6/videocall-rs/neteq/src/statistics.rs:45
  field NetworkStatistics.total_packets_received in /tmp/.tmpajfDC6/videocall-rs/neteq/src/statistics.rs:46
  field NetworkStatistics.reorder_rate_permyriad in /tmp/.tmpajfDC6/videocall-rs/neteq/src/statistics.rs:47
  field NetworkStatistics.max_reorder_distance in /tmp/.tmpajfDC6/videocall-rs/neteq/src/statistics.rs:48
  field NetEqConfig.bypass_mode in /tmp/.tmpajfDC6/videocall-rs/neteq/src/neteq.rs:54
  field NetEqConfig.bypass_mode in /tmp/.tmpajfDC6/videocall-rs/neteq/src/neteq.rs:54

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type UnifiedOpusDecoder no longer derives Debug, in /tmp/.tmpajfDC6/videocall-rs/neteq/src/codec.rs:55
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `neteq`

<blockquote>

## [0.2.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.1.2...neteq-v0.2.0) - 2025-07-10

### Other

- Add neteq to safari and use worklet for audio decoding across the board ([#315](https://github.com/security-union/videocall-rs/pull/315))
</blockquote>

## `videocall-diagnostics`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.0...videocall-diagnostics-v0.1.1) - 2025-07-07

### Other

- release ([#313](https://github.com/security-union/videocall-rs/pull/313))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).