### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "aes",
  "anyhow",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.17](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.16...videocall-cli-v1.0.17) - 2025-07-10
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.16](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.15...videocall-cli-v1.0.16) - 2025-07-07
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.16"
+version = "1.0.17"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.10](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.9...videocall-client-v1.1.10) - 2025-07-10
+
+### Other
+
+- release ([#316](https://github.com/security-union/videocall-rs/pull/316))
+
 ## [1.1.9](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.8...videocall-client-v1.1.9) - 2025-07-07
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.9"
+version = "1.1.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.13](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.12...videocall-ui-v1.0.13) - 2025-07-10
+
+### Other
+
+- release ([#316](https://github.com/security-union/videocall-rs/pull/316))
+
 ## [1.0.12](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.11...videocall-ui-v1.0.12) - 2025-07-07
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.12"
+version = "1.0.13"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "1.0.3" }
-videocall-client = { path= "../videocall-client", version = "1.1.9", features = ["neteq_ff"] }
+videocall-client = { path= "../videocall-client", version = "1.1.10", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-client`: 1.1.9 -> 1.1.10 (✓ API compatible changes)
* `videocall-cli`: 1.0.16 -> 1.0.17 (✓ API compatible changes)
* `videocall-ui`: 1.0.12 -> 1.0.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-client`

<blockquote>

## [1.1.10](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.9...videocall-client-v1.1.10) - 2025-07-10

### Other

- release ([#316](https://github.com/security-union/videocall-rs/pull/316))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.17](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.16...videocall-cli-v1.0.17) - 2025-07-10

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.13](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.12...videocall-ui-v1.0.13) - 2025-07-10

### Other

- release ([#316](https://github.com/security-union/videocall-rs/pull/316))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).