### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "chrono",
  "dotenv",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "clap",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "aes",
  "anyhow",
@@ -6519,7 +6519,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "1.0.3"
+version = "2.0.0"
 dependencies = [
  "protobuf",
  "serde",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "1.0.3" }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5](https://github.com/security-union/videocall-rs/compare/bot-v1.0.4...bot-v1.0.5) - 2025-07-20
+
+### Other
+
+- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
+
 ## [1.0.4](https://github.com/security-union/videocall-rs/compare/bot-v1.0.3...bot-v1.0.4) - 2025-06-29
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "1.0.3" }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.2.0...neteq-v0.2.1) - 2025-07-20
+
+### Other
+
+- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
+
 ## [0.2.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.1.2...neteq-v0.2.0) - 2025-07-10
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.19](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.18...videocall-cli-v1.0.19) - 2025-07-20
+
+### Other
+
+- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
+
 ## [1.0.18](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.17...videocall-cli-v1.0.18) - 2025-07-11
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.18"
+version = "1.0.19"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "1.0.3"
+version = "2.0.0"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.11](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.10...videocall-client-v1.1.11) - 2025-07-20
+
+### Other
+
+- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
+
 ## [1.1.10](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.9...videocall-client-v1.1.10) - 2025-07-10
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.10"
+version = "1.1.11"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "1.0.3" }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
@@ -37,8 +37,8 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.2" }
-neteq = { path = "../neteq", features = ["web"], version = "0.2.0", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.3" }
+neteq = { path = "../neteq", features = ["web"], version = "0.2.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.2...videocall-codecs-v0.1.3) - 2025-07-20
+
+### Other
+
+- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.1...videocall-codecs-v0.1.2) - 2025-07-03
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.2...videocall-sdk-v0.1.3) - 2025-07-20
+
+### Other
+
+- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.1...videocall-sdk-v0.1.2) - 2025-06-23
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "1.0.3" }
+videocall-types = { path = "../videocall-types", version = "2.0.0" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.3...videocall-types-v2.0.0) - 2025-07-20
+
+### Other
+
+- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
+
 ## [1.0.3](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.2...videocall-types-v1.0.3) - 2025-06-29
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "1.0.3"
+version = "2.0.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -15,8 +15,8 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-types = { path= "../videocall-types", version = "1.0.3" }
-videocall-client = { path= "../videocall-client", version = "1.1.10", features = ["neteq_ff"] }
+videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-client = { path= "../videocall-client", version = "1.1.11", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 1.0.3 -> 2.0.0 (⚠ API breaking changes)
* `bot`: 1.0.4 -> 1.0.5
* `neteq`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `videocall-codecs`: 0.1.2 -> 0.1.3
* `videocall-client`: 1.1.10 -> 1.1.11 (✓ API compatible changes)
* `videocall-cli`: 1.0.18 -> 1.0.19 (✓ API compatible changes)
* `videocall-sdk`: 0.1.2 -> 0.1.3

### ⚠ `videocall-types` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant MediaType:RTT in /tmp/.tmpLo9g4e/videocall-rs/videocall-types/src/protos/media_packet.rs:310
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.3...videocall-types-v2.0.0) - 2025-07-20

### Other

- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
</blockquote>

## `bot`

<blockquote>

## [1.0.5](https://github.com/security-union/videocall-rs/compare/bot-v1.0.4...bot-v1.0.5) - 2025-07-20

### Other

- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
</blockquote>

## `neteq`

<blockquote>

## [0.2.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.2.0...neteq-v0.2.1) - 2025-07-20

### Other

- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.2...videocall-codecs-v0.1.3) - 2025-07-20

### Other

- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.11](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.10...videocall-client-v1.1.11) - 2025-07-20

### Other

- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.19](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.18...videocall-cli-v1.0.19) - 2025-07-20

### Other

- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.2...videocall-sdk-v0.1.3) - 2025-07-20

### Other

- Add High availability ([#325](https://github.com/security-union/videocall-rs/pull/325))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).