### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.22"
+version = "1.0.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "aes",
  "anyhow",
@@ -6519,7 +6519,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "approx",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.23](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.22...videocall-cli-v1.0.23) - 2025-07-25
+
+### Other
+
+- Fix pin icon positioning and visibility on iOS and desktop ([#324](https://github.com/security-union/videocall-rs/pull/324)) ([#338](https://github.com/security-union/videocall-rs/pull/338))
+
 ## [1.0.22](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.21...videocall-cli-v1.0.22) - 2025-07-22
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.22"
+version = "1.0.23"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.12](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.11...videocall-client-v1.1.12) - 2025-07-25
+
+### Other
+
+- Fix net eq 2 ([#340](https://github.com/security-union/videocall-rs/pull/340))
+- Fix pin icon positioning and visibility on iOS and desktop ([#324](https://github.com/security-union/videocall-rs/pull/324)) ([#338](https://github.com/security-union/videocall-rs/pull/338))
+
 ## [1.1.11](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.10...videocall-client-v1.1.11) - 2025-07-20
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.11"
+version = "1.1.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,7 +37,7 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.3" }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.4" }
 neteq = { path = "../neteq", features = ["web"], version = "0.2.2", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.3...videocall-codecs-v0.1.4) - 2025-07-25
+
+### Other
+
+- Fix pin icon positioning and visibility on iOS and desktop ([#324](https://github.com/security-union/videocall-rs/pull/324)) ([#338](https://github.com/security-union/videocall-rs/pull/338))
+
 ## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.2...videocall-codecs-v0.1.3) - 2025-07-20
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "2.0.0" }
-videocall-client = { path= "../videocall-client", version = "1.1.11", features = ["neteq_ff"] }
+videocall-client = { path= "../videocall-client", version = "1.1.12", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-codecs`: 0.1.3 -> 0.1.4
* `videocall-client`: 1.1.11 -> 1.1.12 (✓ API compatible changes)
* `videocall-cli`: 1.0.22 -> 1.0.23 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-codecs`

<blockquote>

## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.3...videocall-codecs-v0.1.4) - 2025-07-25

### Other

- Fix pin icon positioning and visibility on iOS and desktop ([#324](https://github.com/security-union/videocall-rs/pull/324)) ([#338](https://github.com/security-union/videocall-rs/pull/338))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.12](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.11...videocall-client-v1.1.12) - 2025-07-25

### Other

- Fix net eq 2 ([#340](https://github.com/security-union/videocall-rs/pull/340))
- Fix pin icon positioning and visibility on iOS and desktop ([#324](https://github.com/security-union/videocall-rs/pull/324)) ([#338](https://github.com/security-union/videocall-rs/pull/338))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.23](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.22...videocall-cli-v1.0.23) - 2025-07-25

### Other

- Fix pin icon positioning and visibility on iOS and desktop ([#324](https://github.com/security-union/videocall-rs/pull/324)) ([#338](https://github.com/security-union/videocall-rs/pull/338))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).