### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "axum",
  "clap",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.28"
+version = "1.0.29"
 dependencies = [
  "anyhow",
  "clap",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.16"
+version = "1.1.17"
 dependencies = [
  "aes",
  "anyhow",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.3.1...neteq-v0.4.0) - 2025-08-02
+
+### Other
+
+- rewrite filter buffer, add a ton of tests  ([#356](https://github.com/security-union/videocall-rs/pull/356))
+
 ## [0.3.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.3.0...neteq-v0.3.1) - 2025-08-02
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.29](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.28...videocall-cli-v1.0.29) - 2025-08-02
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.28](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.27...videocall-cli-v1.0.28) - 2025-08-02
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.28"
+version = "1.0.29"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.17](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.16...videocall-client-v1.1.17) - 2025-08-02
+
+### Other
+
+- updated the following local packages: neteq
+
 ## [1.1.16](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.15...videocall-client-v1.1.16) - 2025-08-02
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.16"
+version = "1.1.17"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -38,7 +38,7 @@ yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
 videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.4" }
-neteq = { path = "../neteq", features = ["web"], version = "0.3.1", optional = true,  default-features = false }
+neteq = { path = "../neteq", features = ["web"], version = "0.4.0", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.19](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.18...videocall-ui-v1.0.19) - 2025-08-02
+
+### Other
+
+- rewrite filter buffer, add a ton of tests  ([#356](https://github.com/security-union/videocall-rs/pull/356))
+
 ## [1.0.18](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.17...videocall-ui-v1.0.18) - 2025-08-02
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.18"
+version = "1.0.19"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "2.0.0" }
-videocall-client = { path= "../videocall-client", version = "1.1.16", features = ["neteq_ff"] }
+videocall-client = { path= "../videocall-client", version = "1.1.17", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.3.1", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.4.0", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `neteq`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `videocall-cli`: 1.0.28 -> 1.0.29 (✓ API compatible changes)
* `videocall-ui`: 1.0.18 -> 1.0.19
* `videocall-client`: 1.1.16 -> 1.1.17

### ⚠ `neteq` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetworkStatistics.operation_counters in /tmp/.tmpdbZPva/videocall-rs/neteq/src/statistics.rs:238

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  neteq::buffer_level_filter::BufferLevelFilter::target_level_samples now takes 2 parameters instead of 1, in /tmp/.tmpdbZPva/videocall-rs/neteq/src/buffer_level_filter.rs:129

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field enable_fast_accelerate of struct NetEqConfig, previously in file /tmp/.tmpKjky41/neteq/src/neteq.rs:61
  field enable_muted_state of struct NetEqConfig, previously in file /tmp/.tmpKjky41/neteq/src/neteq.rs:63
  field enable_rtx_handling of struct NetEqConfig, previously in file /tmp/.tmpKjky41/neteq/src/neteq.rs:65
  field enable_fast_accelerate of struct NetEqConfig, previously in file /tmp/.tmpKjky41/neteq/src/neteq.rs:61
  field enable_muted_state of struct NetEqConfig, previously in file /tmp/.tmpKjky41/neteq/src/neteq.rs:63
  field enable_rtx_handling of struct NetEqConfig, previously in file /tmp/.tmpKjky41/neteq/src/neteq.rs:65
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `neteq`

<blockquote>

## [0.4.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.3.1...neteq-v0.4.0) - 2025-08-02

### Other

- rewrite filter buffer, add a ton of tests  ([#356](https://github.com/security-union/videocall-rs/pull/356))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.29](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.28...videocall-cli-v1.0.29) - 2025-08-02

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.19](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.18...videocall-ui-v1.0.19) - 2025-08-02

### Other

- rewrite filter buffer, add a ton of tests  ([#356](https://github.com/security-union/videocall-rs/pull/356))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.17](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.16...videocall-client-v1.1.17) - 2025-08-02

### Other

- updated the following local packages: neteq
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).