### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.30](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.29...videocall-cli-v1.0.30) - 2025-08-02
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.29](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.28...videocall-cli-v1.0.29) - 2025-08-02
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.29"
+version = "1.0.30"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.20](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.19...videocall-ui-v1.0.20) - 2025-08-02
+
+### Other
+
+- Fix crash on the yew-ui due to discrepancy in yew-ui stats data structure ([#358](https://github.com/security-union/videocall-rs/pull/358))
+
 ## [1.0.19](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.18...videocall-ui-v1.0.19) - 2025-08-02
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.19"
+version = "1.0.20"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"


### PR DESCRIPTION



## 🤖 New release

* `videocall-cli`: 1.0.29 -> 1.0.30 (✓ API compatible changes)
* `videocall-ui`: 1.0.19 -> 1.0.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-cli`

<blockquote>

## [1.0.30](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.29...videocall-cli-v1.0.30) - 2025-08-02

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.20](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.19...videocall-ui-v1.0.20) - 2025-08-02

### Other

- Fix crash on the yew-ui due to discrepancy in yew-ui stats data structure ([#358](https://github.com/security-union/videocall-rs/pull/358))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).