### PR TITLE
avoid trunk panic - use trunk v0.21.1

### DIFF
--- a/docker/base_images/Dockerfile.yew
+++ b/docker/base_images/Dockerfile.yew
@@ -3,5 +3,5 @@ FROM rust:1.85-slim as development
 RUN rustup default nightly-2024-08-21
 RUN apt-get --yes update && apt-get --yes install git pkg-config libssl-dev
 RUN cargo install wasm-bindgen-cli --version 0.2.95
-RUN cargo install trunk --version 0.17.5 --locked
+RUN cargo install trunk --version 0.21.1 --locked
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
We're seeing panic's from the docker-yew-ui  container on startup:

```
yew-ui-1            | thread 'notify-rs debouncer loop' panicked at core/src/slice/sort/shared/smallsort.rs:859:5:
yew-ui-1            | user-provided comparison function does not correctly implement a total order
yew-ui-1            | stack backtrace:
yew-ui-1            |    0: rust_begin_unwind
yew-ui-1            |    1: core::panicking::panic_fmt
yew-ui-1            |    2: core::slice::sort::shared::smallsort::panic_on_ord_violation
yew-ui-1            |    3: core::slice::sort::stable::quicksort::quicksort
yew-ui-1            |    4: core::slice::sort::stable::quicksort::quicksort
yew-ui-1            |    5: core::slice::sort::stable::quicksort::quicksort
yew-ui-1            |    6: core::slice::sort::stable::quicksort::quicksort
yew-ui-1            |    7: core::slice::sort::stable::quicksort::quicksort
yew-ui-1            |    8: core::slice::sort::stable::driftsort_main
yew-ui-1            | note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
yew-ui-1 exited with code 139
```

Some environments reproduce it very frequently, others not as often.  All our docker deployments see it at least occassionally.   This looks to be a core issue with the trunk dependency on notify.rs and fixed with newer versions of trunk.  https://github.com/trunk-rs/trunk/issues/870

I should note my local fix consisted of modifying `docker/Dockerfile.yew` adding 
```
RUN cargo install trunk --version 0.21.1 --locked
```
to the end of the file.  But I believe what I have here in the PR is the proper fix.