### PR TITLE
Fix release-plz CI by ignoring leptos-website build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ Carthage/Build/
 
 
 deployment-**.log
+
+# Leptos website build artifacts
+leptos-website/package-lock.json
+leptos-website/style/output.css


### PR DESCRIPTION
- Add leptos-website/package-lock.json to root .gitignore
- Add leptos-website/style/output.css to root .gitignore

These files are already ignored in leptos-website/.gitignore but release-plz runs from the workspace root and was detecting them as uncommitted changes.