### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.31"
+version = "1.0.32"
 dependencies = [
  "anyhow",
  "clap",
@@ -6483,7 +6483,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.17"
+version = "1.1.18"
 dependencies = [
  "aes",
  "anyhow",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.32](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.31...videocall-cli-v1.0.32) - 2025-08-05
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.31](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.30...videocall-cli-v1.0.31) - 2025-08-04
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.31"
+version = "1.0.32"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.18](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.17...videocall-client-v1.1.18) - 2025-08-05
+
+### Other
+
+- Fix website hash and local yew not connecting to single server ([#366](https://github.com/security-union/videocall-rs/pull/366))
+
 ## [1.1.17](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.16...videocall-client-v1.1.17) - 2025-08-02
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.17"
+version = "1.1.18"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.21](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.20...videocall-ui-v1.0.21) - 2025-08-05
+
+### Other
+
+- updated the following local packages: videocall-client
+
 ## [1.0.20](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.19...videocall-ui-v1.0.20) - 2025-08-02
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.20"
+version = "1.0.21"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "2.0.0" }
-videocall-client = { path= "../videocall-client", version = "1.1.17", features = ["neteq_ff"] }
+videocall-client = { path= "../videocall-client", version = "1.1.18", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-client`: 1.1.17 -> 1.1.18 (✓ API compatible changes)
* `videocall-cli`: 1.0.31 -> 1.0.32 (✓ API compatible changes)
* `videocall-ui`: 1.0.20 -> 1.0.21

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-client`

<blockquote>

## [1.1.18](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.17...videocall-client-v1.1.18) - 2025-08-05

### Other

- Fix website hash and local yew not connecting to single server ([#366](https://github.com/security-union/videocall-rs/pull/366))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.32](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.31...videocall-cli-v1.0.32) - 2025-08-05

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.21](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.20...videocall-ui-v1.0.21) - 2025-08-05

### Other

- updated the following local packages: videocall-client
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).