### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "chrono",
  "dotenv",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "clap",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.33"
+version = "1.0.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -6554,7 +6554,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.18"
+version = "1.1.19"
 dependencies = [
  "aes",
  "anyhow",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "approx",
@@ -6614,7 +6614,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-diagnostics"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-broadcast",
  "flume",
@@ -6699,7 +6699,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6724,7 +6724,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "protobuf 3.7.1",
  "serde",
@@ -6734,7 +6734,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.21"
+version = "1.0.22"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-types = { path= "../videocall-types", version = "2.0.1" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/security-union/videocall-rs/compare/bot-v1.0.5...bot-v1.0.6) - 2025-08-08
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.0.5](https://github.com/security-union/videocall-rs/compare/bot-v1.0.4...bot-v1.0.5) - 2025-07-20
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-types = { path= "../videocall-types", version = "2.0.1" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.4.0...neteq-v0.4.1) - 2025-08-08
+
+### Other
+
+- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
+
 ## [0.4.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.3.1...neteq-v0.4.0) - 2025-08-02
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.34](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.33...videocall-cli-v1.0.34) - 2025-08-08
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.33](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.32...videocall-cli-v1.0.33) - 2025-08-07
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.33"
+version = "1.0.34"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "2.0.0"
+version = "2.0.1"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.19](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.18...videocall-client-v1.1.19) - 2025-08-08
+
+### Other
+
+- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
+
 ## [1.1.18](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.17...videocall-client-v1.1.18) - 2025-08-05
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.18"
+version = "1.1.19"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
+videocall-types = { path= "../videocall-types", version = "2.0.1" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
@@ -37,11 +37,11 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.4" }
-neteq = { path = "../neteq", features = ["web"], version = "0.4.0", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.5" }
+neteq = { path = "../neteq", features = ["web"], version = "0.4.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 serde_json = { version = "1.0" }
 async-broadcast = "0.7.2"
 

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.4...videocall-codecs-v0.1.5) - 2025-08-08
+
+### Other
+
+- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
+
 ## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.3...videocall-codecs-v0.1.4) - 2025-07-25
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-diagnostics/CHANGELOG.md
+++ b/videocall-diagnostics/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.1...videocall-diagnostics-v0.1.2) - 2025-08-08
+
+### Other
+
+- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.0...videocall-diagnostics-v0.1.1) - 2025-07-07
 
 ### Other

--- a/videocall-diagnostics/Cargo.toml
+++ b/videocall-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-diagnostics"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Lightweight diagnostics event bus for the videocall-rs project"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.3...videocall-sdk-v0.1.4) - 2025-08-08
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.2...videocall-sdk-v0.1.3) - 2025-07-20
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "2.0.0" }
+videocall-types = { path = "../videocall-types", version = "2.0.1" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.0...videocall-types-v2.0.1) - 2025-08-08
+
+### Other
+
+- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
+
 ## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v1.0.3...videocall-types-v2.0.0) - 2025-07-20
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.22](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.21...videocall-ui-v1.0.22) - 2025-08-08
+
+### Other
+
+- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
+
 ## [1.0.21](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.20...videocall-ui-v1.0.21) - 2025-08-05
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.21"
+version = "1.0.22"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -15,9 +15,9 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-types = { path= "../videocall-types", version = "2.0.0" }
-videocall-client = { path= "../videocall-client", version = "1.1.18", features = ["neteq_ff"] }
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.1" }
+videocall-types = { path= "../videocall-types", version = "2.0.1" }
+videocall-client = { path= "../videocall-client", version = "1.1.19", features = ["neteq_ff"] }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 lazy_static = "1.4.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.4.0", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.4.1", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 2.0.0 -> 2.0.1 (✓ API compatible changes)
* `neteq`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `videocall-diagnostics`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `videocall-codecs`: 0.1.4 -> 0.1.5
* `videocall-client`: 1.1.18 -> 1.1.19 (✓ API compatible changes)
* `videocall-cli`: 1.0.33 -> 1.0.34 (✓ API compatible changes)
* `videocall-ui`: 1.0.21 -> 1.0.22
* `bot`: 1.0.5 -> 1.0.6
* `videocall-sdk`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [2.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.0...videocall-types-v2.0.1) - 2025-08-08

### Other

- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
</blockquote>

## `neteq`

<blockquote>

## [0.4.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.4.0...neteq-v0.4.1) - 2025-08-08

### Other

- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
</blockquote>

## `videocall-diagnostics`

<blockquote>

## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.1...videocall-diagnostics-v0.1.2) - 2025-08-08

### Other

- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.5](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.4...videocall-codecs-v0.1.5) - 2025-08-08

### Other

- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.19](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.18...videocall-client-v1.1.19) - 2025-08-08

### Other

- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.34](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.33...videocall-cli-v1.0.34) - 2025-08-08

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.22](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.21...videocall-ui-v1.0.22) - 2025-08-08

### Other

- (feature) Add diagnostics with Prometheus and Grafana ([#365](https://github.com/security-union/videocall-rs/pull/365))
</blockquote>

## `bot`

<blockquote>

## [1.0.6](https://github.com/security-union/videocall-rs/compare/bot-v1.0.5...bot-v1.0.6) - 2025-08-08

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.3...videocall-sdk-v0.1.4) - 2025-08-08

### Other

- updated the following local packages: videocall-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).