### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.34"
+version = "1.0.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -6554,7 +6554,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.19"
+version = "1.1.20"
 dependencies = [
  "aes",
  "anyhow",
@@ -6699,7 +6699,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6724,7 +6724,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "protobuf 3.7.1",
  "serde",
@@ -6734,7 +6734,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.0.22"
+version = "1.0.23"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "2.0.1" }
+videocall-types = { path= "../videocall-types", version = "2.0.2" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7](https://github.com/security-union/videocall-rs/compare/bot-v1.0.6...bot-v1.0.7) - 2025-08-10
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.0.6](https://github.com/security-union/videocall-rs/compare/bot-v1.0.5...bot-v1.0.6) - 2025-08-08
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "2.0.1" }
+videocall-types = { path= "../videocall-types", version = "2.0.2" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.35](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.34...videocall-cli-v1.0.35) - 2025-08-10
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.34](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.33...videocall-cli-v1.0.34) - 2025-08-08
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.34"
+version = "1.0.35"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "2.0.1"
+version = "2.0.2"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.20](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.19...videocall-client-v1.1.20) - 2025-08-10
+
+### Other
+
+- Reduce RTT freq, add RTT to stats,  ([#376](https://github.com/security-union/videocall-rs/pull/376))
+
 ## [1.1.19](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.18...videocall-client-v1.1.19) - 2025-08-08
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.19"
+version = "1.1.20"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "2.0.1" }
+videocall-types = { path= "../videocall-types", version = "2.0.2" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.4...videocall-sdk-v0.1.5) - 2025-08-10
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.3...videocall-sdk-v0.1.4) - 2025-08-08
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "2.0.1" }
+videocall-types = { path = "../videocall-types", version = "2.0.2" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.1...videocall-types-v2.0.2) - 2025-08-10
+
+### Other
+
+- Reduce RTT freq, add RTT to stats,  ([#376](https://github.com/security-union/videocall-rs/pull/376))
+
 ## [2.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.0...videocall-types-v2.0.1) - 2025-08-08
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.23](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.22...videocall-ui-v1.0.23) - 2025-08-10
+
+### Other
+
+- updated the following local packages: videocall-types, videocall-client
+
 ## [1.0.22](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.21...videocall-ui-v1.0.22) - 2025-08-08
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.0.22"
+version = "1.0.23"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -15,8 +15,8 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-types = { path= "../videocall-types", version = "2.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.19", features = ["neteq_ff"] }
+videocall-types = { path= "../videocall-types", version = "2.0.2" }
+videocall-client = { path= "../videocall-client", version = "1.1.20", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 2.0.1 -> 2.0.2 (✓ API compatible changes)
* `videocall-client`: 1.1.19 -> 1.1.20 (✓ API compatible changes)
* `videocall-cli`: 1.0.34 -> 1.0.35 (✓ API compatible changes)
* `bot`: 1.0.6 -> 1.0.7
* `videocall-ui`: 1.0.22 -> 1.0.23
* `videocall-sdk`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [2.0.2](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.1...videocall-types-v2.0.2) - 2025-08-10

### Other

- Reduce RTT freq, add RTT to stats,  ([#376](https://github.com/security-union/videocall-rs/pull/376))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.20](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.19...videocall-client-v1.1.20) - 2025-08-10

### Other

- Reduce RTT freq, add RTT to stats,  ([#376](https://github.com/security-union/videocall-rs/pull/376))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.35](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.34...videocall-cli-v1.0.35) - 2025-08-10

### Other

- update Cargo.lock dependencies
</blockquote>

## `bot`

<blockquote>

## [1.0.7](https://github.com/security-union/videocall-rs/compare/bot-v1.0.6...bot-v1.0.7) - 2025-08-10

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-ui`

<blockquote>

## [1.0.23](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.22...videocall-ui-v1.0.23) - 2025-08-10

### Other

- updated the following local packages: videocall-types, videocall-client
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.5](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.4...videocall-sdk-v0.1.5) - 2025-08-10

### Other

- updated the following local packages: videocall-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).