### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.36"
+version = "1.0.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -6734,7 +6734,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.23"
+version = "1.1.24"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.37](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.36...videocall-cli-v1.0.37) - 2025-08-10
+
+### Other
+
+- Add config.js to version control along with instructions ([#381](https://github.com/security-union/videocall-rs/pull/381))
+
 ## [1.0.36](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.35...videocall-cli-v1.0.36) - 2025-08-10
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.36"
+version = "1.0.37"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.24](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.23...videocall-ui-v1.1.24) - 2025-08-10
+
+### Other
+
+- Add config.js to version control along with instructions ([#381](https://github.com/security-union/videocall-rs/pull/381))
+
 ## [1.0.23](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.0.22...videocall-ui-v1.0.23) - 2025-08-10
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.23"
+version = "1.1.24"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"


### PR DESCRIPTION



## 🤖 New release

* `videocall-cli`: 1.0.36 -> 1.0.37 (✓ API compatible changes)
* `videocall-ui`: 1.1.23 -> 1.1.24

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-cli`

<blockquote>

## [1.0.37](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.36...videocall-cli-v1.0.37) - 2025-08-10

### Other

- Add config.js to version control along with instructions ([#381](https://github.com/security-union/videocall-rs/pull/381))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.24](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.23...videocall-ui-v1.1.24) - 2025-08-10

### Other

- Add config.js to version control along with instructions ([#381](https://github.com/security-union/videocall-rs/pull/381))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).