### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "chrono",
  "dotenv",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "axum",
  "clap",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.37"
+version = "1.0.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.20"
+version = "1.1.21"
 dependencies = [
  "aes",
  "anyhow",
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6738,7 +6738,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "2.0.2"
+version = "3.0.0"
 dependencies = [
  "protobuf 3.7.1",
  "serde",
@@ -6748,7 +6748,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.24"
+version = "1.1.25"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "2.0.2" }
+videocall-types = { path= "../videocall-types", version = "3.0.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8](https://github.com/security-union/videocall-rs/compare/bot-v1.0.7...bot-v1.0.8) - 2025-08-15
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.0.7](https://github.com/security-union/videocall-rs/compare/bot-v1.0.6...bot-v1.0.7) - 2025-08-10
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "2.0.2" }
+videocall-types = { path= "../videocall-types", version = "3.0.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.4.1...neteq-v0.5.0) - 2025-08-15
+
+### Other
+
+- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
+
 ## [0.4.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.4.0...neteq-v0.4.1) - 2025-08-08
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.38](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.37...videocall-cli-v1.0.38) - 2025-08-15
+
+### Other
+
+- Add videocall-cli to the copy ([#386](https://github.com/security-union/videocall-rs/pull/386))
+
 ## [1.0.37](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.36...videocall-cli-v1.0.37) - 2025-08-10
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.37"
+version = "1.0.38"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "2.0.2"
+version = "3.0.0"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.21](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.20...videocall-client-v1.1.21) - 2025-08-15
+
+### Other
+
+- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
+
 ## [1.1.20](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.19...videocall-client-v1.1.20) - 2025-08-10
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.20"
+version = "1.1.21"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "2.0.2" }
+videocall-types = { path= "../videocall-types", version = "3.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
@@ -38,7 +38,7 @@ yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
 videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.5" }
-neteq = { path = "../neteq", features = ["web"], version = "0.4.1", optional = true,  default-features = false }
+neteq = { path = "../neteq", features = ["web"], version = "0.5.0", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.5...videocall-sdk-v0.1.6) - 2025-08-15
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [0.1.5](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.4...videocall-sdk-v0.1.5) - 2025-08-10
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "2.0.2" }
+videocall-types = { path = "../videocall-types", version = "3.0.0" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.2...videocall-types-v3.0.0) - 2025-08-15
+
+### Other
+
+- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
+
 ## [2.0.2](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.1...videocall-types-v2.0.2) - 2025-08-10
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "2.0.2"
+version = "3.0.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.25](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.24...videocall-ui-v1.1.25) - 2025-08-15
+
+### Added
+
+- feature/self as attendant ([#392](https://github.com/security-union/videocall-rs/pull/392))
+
+### Other
+
+- Add low end android device profiles ([#394](https://github.com/security-union/videocall-rs/pull/394))
+- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
+
 ## [1.1.24](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.23...videocall-ui-v1.1.24) - 2025-08-10
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.24"
+version = "1.1.25"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -15,8 +15,8 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-types = { path= "../videocall-types", version = "2.0.2" }
-videocall-client = { path= "../videocall-client", version = "1.1.20", features = ["neteq_ff"] }
+videocall-types = { path= "../videocall-types", version = "3.0.0" }
+videocall-client = { path= "../videocall-client", version = "1.1.21", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.4.1", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.5.0", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 2.0.2 -> 3.0.0 (⚠ API breaking changes)
* `neteq`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `videocall-client`: 1.1.20 -> 1.1.21 (✓ API compatible changes)
* `videocall-cli`: 1.0.37 -> 1.0.38 (✓ API compatible changes)
* `videocall-ui`: 1.1.24 -> 1.1.25
* `bot`: 1.0.7 -> 1.0.8
* `videocall-sdk`: 0.1.5 -> 0.1.6

### ⚠ `videocall-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetEqStats.packets_per_sec in /tmp/.tmp8TMvyf/videocall-rs/videocall-types/src/protos/health_packet.rs:428
```

### ⚠ `neteq` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetEqStats.packets_per_sec in /tmp/.tmp8TMvyf/videocall-rs/neteq/src/neteq.rs:120
  field NetEqStats.packets_per_sec in /tmp/.tmp8TMvyf/videocall-rs/neteq/src/neteq.rs:120
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.2...videocall-types-v3.0.0) - 2025-08-15

### Other

- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
</blockquote>

## `neteq`

<blockquote>

## [0.5.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.4.1...neteq-v0.5.0) - 2025-08-15

### Other

- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.21](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.20...videocall-client-v1.1.21) - 2025-08-15

### Other

- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.38](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.37...videocall-cli-v1.0.38) - 2025-08-15

### Other

- Add videocall-cli to the copy ([#386](https://github.com/security-union/videocall-rs/pull/386))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.25](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.24...videocall-ui-v1.1.25) - 2025-08-15

### Added

- feature/self as attendant ([#392](https://github.com/security-union/videocall-rs/pull/392))

### Other

- Add low end android device profiles ([#394](https://github.com/security-union/videocall-rs/pull/394))
- Add packets per sec, and matomo logs to debug system, handle mic errors more gracefully ([#385](https://github.com/security-union/videocall-rs/pull/385))
</blockquote>

## `bot`

<blockquote>

## [1.0.8](https://github.com/security-union/videocall-rs/compare/bot-v1.0.7...bot-v1.0.8) - 2025-08-15

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.6](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.5...videocall-sdk-v0.1.6) - 2025-08-15

### Other

- updated the following local packages: videocall-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).