### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.38"
+version = "1.0.39"
 dependencies = [
  "anyhow",
  "clap",
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.21"
+version = "1.1.22"
 dependencies = [
  "aes",
  "anyhow",
@@ -6748,7 +6748,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.25"
+version = "1.1.26"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.39](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.38...videocall-cli-v1.0.39) - 2025-08-15
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.38](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.37...videocall-cli-v1.0.38) - 2025-08-15
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.38"
+version = "1.0.39"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.22](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.21...videocall-client-v1.1.22) - 2025-08-15
+
+### Other
+
+- Disable caching and create blog post, also downgrade many messages to debug  ([#395](https://github.com/security-union/videocall-rs/pull/395))
+
 ## [1.1.21](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.20...videocall-client-v1.1.21) - 2025-08-15
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.21"
+version = "1.1.22"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.26](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.25...videocall-ui-v1.1.26) - 2025-08-15
+
+### Other
+
+- Disable caching and create blog post, also downgrade many messages to debug  ([#395](https://github.com/security-union/videocall-rs/pull/395))
+
 ## [1.1.25](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.24...videocall-ui-v1.1.25) - 2025-08-15
 
 ### Added

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.25"
+version = "1.1.26"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "3.0.0" }
-videocall-client = { path= "../videocall-client", version = "1.1.21", features = ["neteq_ff"] }
+videocall-client = { path= "../videocall-client", version = "1.1.22", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-client`: 1.1.21 -> 1.1.22 (✓ API compatible changes)
* `videocall-cli`: 1.0.38 -> 1.0.39 (✓ API compatible changes)
* `videocall-ui`: 1.1.25 -> 1.1.26

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-client`

<blockquote>

## [1.1.22](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.21...videocall-client-v1.1.22) - 2025-08-15

### Other

- Disable caching and create blog post, also downgrade many messages to debug  ([#395](https://github.com/security-union/videocall-rs/pull/395))
</blockquote>

## `videocall-cli`

<blockquote>

## [1.0.39](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.38...videocall-cli-v1.0.39) - 2025-08-15

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.26](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.25...videocall-ui-v1.1.26) - 2025-08-15

### Other

- Disable caching and create blog post, also downgrade many messages to debug  ([#395](https://github.com/security-union/videocall-rs/pull/395))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).