### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "chrono",
  "dotenv",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "1.0.39"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6568,7 +6568,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.22"
+version = "1.1.23"
 dependencies = [
  "aes",
  "anyhow",
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6738,7 +6738,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "protobuf 3.7.1",
  "serde",
@@ -6748,7 +6748,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.26"
+version = "1.1.27"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "3.0.0" }
+videocall-types = { path= "../videocall-types", version = "3.0.1" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = "0.3.1"

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9](https://github.com/security-union/videocall-rs/compare/bot-v1.0.8...bot-v1.0.9) - 2025-08-18
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.0.8](https://github.com/security-union/videocall-rs/compare/bot-v1.0.7...bot-v1.0.8) - 2025-08-15
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
 rand = "0.8.5"
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "3.0.0" }
+videocall-types = { path= "../videocall-types", version = "3.0.1" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.39...videocall-cli-v2.0.0) - 2025-08-18
+
+### Other
+
+- Add server stats ([#399](https://github.com/security-union/videocall-rs/pull/399))
+
 ## [1.0.39](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.38...videocall-cli-v1.0.39) - 2025-08-15
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "1.0.39"
+version = "2.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -43,5 +43,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "3.0.0"
+version = "3.0.1"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.23](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.22...videocall-client-v1.1.23) - 2025-08-18
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.1.22](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.21...videocall-client-v1.1.22) - 2025-08-15
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.22"
+version = "1.1.23"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "3.0.0" }
+videocall-types = { path= "../videocall-types", version = "3.0.1" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.6...videocall-sdk-v0.1.7) - 2025-08-18
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [0.1.6](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.5...videocall-sdk-v0.1.6) - 2025-08-15
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "3.0.0" }
+videocall-types = { path = "../videocall-types", version = "3.0.1" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v3.0.0...videocall-types-v3.0.1) - 2025-08-18
+
+### Other
+
+- Add server stats ([#399](https://github.com/security-union/videocall-rs/pull/399))
+
 ## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v2.0.2...videocall-types-v3.0.0) - 2025-08-15
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.27](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.26...videocall-ui-v1.1.27) - 2025-08-18
+
+### Other
+
+- Add server stats ([#399](https://github.com/security-union/videocall-rs/pull/399))
+
 ## [1.1.26](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.25...videocall-ui-v1.1.26) - 2025-08-15
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.26"
+version = "1.1.27"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -15,8 +15,8 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-types = { path= "../videocall-types", version = "3.0.0" }
-videocall-client = { path= "../videocall-client", version = "1.1.22", features = ["neteq_ff"] }
+videocall-types = { path= "../videocall-types", version = "3.0.1" }
+videocall-client = { path= "../videocall-client", version = "1.1.23", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `videocall-cli`: 1.0.39 -> 2.0.0 (⚠ API breaking changes)
* `videocall-ui`: 1.1.26 -> 1.1.27
* `bot`: 1.0.8 -> 1.0.9
* `videocall-client`: 1.1.22 -> 1.1.23
* `videocall-sdk`: 0.1.6 -> 0.1.7

### ⚠ `videocall-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Stream.insecure_skip_verify in /tmp/.tmpAcqolu/videocall-rs/videocall-cli/src/cli_args.rs:155
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [3.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v3.0.0...videocall-types-v3.0.1) - 2025-08-18

### Other

- Add server stats ([#399](https://github.com/security-union/videocall-rs/pull/399))
</blockquote>

## `videocall-cli`

<blockquote>

## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.39...videocall-cli-v2.0.0) - 2025-08-18

### Other

- Add server stats ([#399](https://github.com/security-union/videocall-rs/pull/399))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.27](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.26...videocall-ui-v1.1.27) - 2025-08-18

### Other

- Add server stats ([#399](https://github.com/security-union/videocall-rs/pull/399))
</blockquote>

## `bot`

<blockquote>

## [1.0.9](https://github.com/security-union/videocall-rs/compare/bot-v1.0.8...bot-v1.0.9) - 2025-08-18

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.23](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.22...videocall-client-v1.1.23) - 2025-08-18

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.7](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.6...videocall-sdk-v0.1.7) - 2025-08-18

### Other

- updated the following local packages: videocall-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).