### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "clap",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6559,7 +6559,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.23"
+version = "1.1.24"
 dependencies = [
  "aes",
  "anyhow",
@@ -6596,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "approx",
@@ -6739,7 +6739,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.27"
+version = "1.1.28"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.10](https://github.com/security-union/videocall-rs/compare/bot-v1.0.9...bot-v1.0.10) - 2025-08-20
+
+### Other
+
+- Superbot and get rid of the should_run cancellation token ([#407](https://github.com/security-union/videocall-rs/pull/407))
+
 ## [1.0.9](https://github.com/security-union/videocall-rs/compare/bot-v1.0.8...bot-v1.0.9) - 2025-08-18
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.5.0...neteq-v0.5.1) - 2025-08-20
+
+### Fixed
+
+- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))
+
 ## [0.5.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.4.1...neteq-v0.5.0) - 2025-08-15
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/security-union/videocall-rs/compare/videocall-cli-v2.0.0...videocall-cli-v2.0.1) - 2025-08-20
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v1.0.39...videocall-cli-v2.0.0) - 2025-08-18
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.24](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.23...videocall-client-v1.1.24) - 2025-08-20
+
+### Fixed
+
+- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))
+
 ## [1.1.23](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.22...videocall-client-v1.1.23) - 2025-08-18
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.23"
+version = "1.1.24"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,8 +37,8 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.5" }
-neteq = { path = "../neteq", features = ["web"], version = "0.5.0", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.6" }
+neteq = { path = "../neteq", features = ["web"], version = "0.5.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.5...videocall-codecs-v0.1.6) - 2025-08-20
+
+### Fixed
+
+- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))
+
 ## [0.1.5](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.4...videocall-codecs-v0.1.5) - 2025-08-08
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.28](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.27...videocall-ui-v1.1.28) - 2025-08-20
+
+### Fixed
+
+- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))
+
+### Other
+
+- (bug) screenshare now works only if there are at least 3 peers connected: host+ two listener #398 ([#402](https://github.com/security-union/videocall-rs/pull/402))
+
 ## [1.1.27](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.26...videocall-ui-v1.1.27) - 2025-08-18
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.27"
+version = "1.1.28"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "3.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.23", features = ["neteq_ff"] }
+videocall-client = { path= "../videocall-client", version = "1.1.24", features = ["neteq_ff"] }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.5.0", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.5.1", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `bot`: 1.0.9 -> 1.0.10
* `neteq`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `videocall-codecs`: 0.1.5 -> 0.1.6
* `videocall-client`: 1.1.23 -> 1.1.24 (✓ API compatible changes)
* `videocall-cli`: 2.0.0 -> 2.0.1 (✓ API compatible changes)
* `videocall-ui`: 1.1.27 -> 1.1.28

<details><summary><i><b>Changelog</b></i></summary><p>

## `bot`

<blockquote>

## [1.0.10](https://github.com/security-union/videocall-rs/compare/bot-v1.0.9...bot-v1.0.10) - 2025-08-20

### Other

- Superbot and get rid of the should_run cancellation token ([#407](https://github.com/security-union/videocall-rs/pull/407))
</blockquote>

## `neteq`

<blockquote>

## [0.5.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.5.0...neteq-v0.5.1) - 2025-08-20

### Fixed

- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.6](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.5...videocall-codecs-v0.1.6) - 2025-08-20

### Fixed

- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.24](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.23...videocall-client-v1.1.24) - 2025-08-20

### Fixed

- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))
</blockquote>

## `videocall-cli`

<blockquote>

## [2.0.1](https://github.com/security-union/videocall-rs/compare/videocall-cli-v2.0.0...videocall-cli-v2.0.1) - 2025-08-20

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.28](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.27...videocall-ui-v1.1.28) - 2025-08-20

### Fixed

- *(codecs)* route worker diag messages to health bus; refs #397 ([#400](https://github.com/security-union/videocall-rs/pull/400))

### Other

- (bug) screenshare now works only if there are at least 3 peers connected: host+ two listener #398 ([#402](https://github.com/security-union/videocall-rs/pull/402))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).