### PR TITLE
Fix: Elide lifetime in return type `Result<Frames>` in `Vp9Encoder::encode` signature

### DIFF
--- a/videocall-codecs/src/encoder.rs
+++ b/videocall-codecs/src/encoder.rs
@@ -83,7 +83,7 @@ impl Vp9Encoder {
         }
     }
 
-    pub fn encode(&mut self, frame_count: i64, yuv_data: Option<&[u8]>) -> Result<Frames> {
+    pub fn encode(&mut self, frame_count: i64, yuv_data: Option<&[u8]>) -> Result<Frames<'_>> {
         unsafe {
             let image_ptr = if let Some(data) = yuv_data {
                 let mut image: vpx_image_t = MaybeUninit::zeroed().assume_init();


### PR DESCRIPTION
This PR eliminates the `mismatched_lifetime_syntaxes` compiler warning by eliding the return type of `Result<Frames>` -> `Result<Frames<'_>>` in the `Vp9Encoder::encode` function.
