### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "axum",
  "clap",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.24"
+version = "1.1.25"
 dependencies = [
  "aes",
  "anyhow",
@@ -6511,7 +6511,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "approx",
@@ -6654,7 +6654,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.28"
+version = "1.1.29"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.5.1...neteq-v0.6.0) - 2025-09-24
+
+### Other
+
+- refactor to use a single context ([#428](https://github.com/security-union/videocall-rs/pull/428))
+- Fix #415: Failed to enqueue PCM Data ([#417](https://github.com/security-union/videocall-rs/pull/417))
+
 ## [0.5.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.5.0...neteq-v0.5.1) - 2025-08-20
 
 ### Fixed

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.0...videocall-cli-v3.0.1) - 2025-09-24
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v2.0.1...videocall-cli-v3.0.0) - 2025-08-22
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.25](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.24...videocall-client-v1.1.25) - 2025-09-24
+
+### Other
+
+- refactor to use a single context ([#428](https://github.com/security-union/videocall-rs/pull/428))
+- Fix #415: Failed to enqueue PCM Data ([#417](https://github.com/security-union/videocall-rs/pull/417))
+
 ## [1.1.24](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.23...videocall-client-v1.1.24) - 2025-08-20
 
 ### Fixed

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.24"
+version = "1.1.25"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,8 +37,8 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.6" }
-neteq = { path = "../neteq", features = ["web"], version = "0.5.1", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.7" }
+neteq = { path = "../neteq", features = ["web"], version = "0.6.0", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.6...videocall-codecs-v0.1.7) - 2025-09-24
+
+### Other
+
+- Eliminate mismatched_lifetime_syntaxes compiler warning by eliding return type lifetime to Result<Frames<'_>> ([#413](https://github.com/security-union/videocall-rs/pull/413))
+
 ## [0.1.6](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.5...videocall-codecs-v0.1.6) - 2025-08-20
 
 ### Fixed

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.29](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.28...videocall-ui-v1.1.29) - 2025-09-24
+
+### Other
+
+- refactor to use a single context ([#428](https://github.com/security-union/videocall-rs/pull/428))
+- Fix #415: Failed to enqueue PCM Data ([#417](https://github.com/security-union/videocall-rs/pull/417))
+
 ## [1.1.28](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.27...videocall-ui-v1.1.28) - 2025-08-20
 
 ### Fixed

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.28"
+version = "1.1.29"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "3.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.24" }
+videocall-client = { path= "../videocall-client", version = "1.1.25" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.5.1", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.6.0", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `neteq`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `videocall-codecs`: 0.1.6 -> 0.1.7
* `videocall-client`: 1.1.24 -> 1.1.25 (✓ API compatible changes)
* `videocall-cli`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `videocall-ui`: 1.1.28 -> 1.1.29

### ⚠ `neteq` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  UnifiedOpusDecoder::new_with_playback, previously in file /tmp/.tmpUYLhMK/neteq/src/codec.rs:119
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `neteq`

<blockquote>

## [0.6.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.5.1...neteq-v0.6.0) - 2025-09-24

### Other

- refactor to use a single context ([#428](https://github.com/security-union/videocall-rs/pull/428))
- Fix #415: Failed to enqueue PCM Data ([#417](https://github.com/security-union/videocall-rs/pull/417))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.7](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.6...videocall-codecs-v0.1.7) - 2025-09-24

### Other

- Eliminate mismatched_lifetime_syntaxes compiler warning by eliding return type lifetime to Result<Frames<'_>> ([#413](https://github.com/security-union/videocall-rs/pull/413))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.25](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.24...videocall-client-v1.1.25) - 2025-09-24

### Other

- refactor to use a single context ([#428](https://github.com/security-union/videocall-rs/pull/428))
- Fix #415: Failed to enqueue PCM Data ([#417](https://github.com/security-union/videocall-rs/pull/417))
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.1](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.0...videocall-cli-v3.0.1) - 2025-09-24

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.29](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.28...videocall-ui-v1.1.29) - 2025-09-24

### Other

- refactor to use a single context ([#428](https://github.com/security-union/videocall-rs/pull/428))
- Fix #415: Failed to enqueue PCM Data ([#417](https://github.com/security-union/videocall-rs/pull/417))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).