### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "axum",
  "clap",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.26"
+version = "1.1.27"
 dependencies = [
  "aes",
  "anyhow",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "approx",
@@ -6682,7 +6682,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-bindings-macos"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "block",
  "cocoa-foundation",
@@ -6720,7 +6720,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.30"
+version = "1.1.31"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.13](https://github.com/security-union/videocall-rs/compare/bot-v1.0.12...bot-v1.0.13) - 2025-10-30
+
+### Other
+
+- Fix matomo ([#454](https://github.com/security-union/videocall-rs/pull/454))
+
 ## [1.0.12](https://github.com/security-union/videocall-rs/compare/bot-v1.0.11...bot-v1.0.12) - 2025-10-13
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.12"
+version = "1.0.13"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.6.2...neteq-v0.7.0) - 2025-10-30
+
+### Other
+
+- NetEQ Overhaul: WebCodecs Support, Critical Bug Fixes, and CI Improvements ([#466](https://github.com/security-union/videocall-rs/pull/466))
+
 ## [0.6.2](https://github.com/security-union/videocall-rs/compare/neteq-v0.6.1...neteq-v0.6.2) - 2025-10-13
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/nokhwa/nokhwa-bindings-macos/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-bindings-macos/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-macos-v0.2.3...videocall-nokhwa-bindings-macos-v0.2.4) - 2025-10-30
+
+### Other
+
+- release ([#431](https://github.com/security-union/videocall-rs/pull/431))
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+- Bump all crates to 1.0.0 ([#222](https://github.com/security-union/videocall-rs/pull/222))
+- Rename to videocall cli ([#185](https://github.com/security-union/videocall-rs/pull/185))
+
 ## [0.2.3](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-macos-v0.2.2...videocall-nokhwa-bindings-macos-v0.2.3) - 2025-10-13
 
 ### Other

--- a/videocall-cli/nokhwa/nokhwa-bindings-macos/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-bindings-macos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-bindings-macos"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["l1npengtul", "Dario Lencina <dario@securityunion.dev>"]
 license = "Apache-2.0"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.27](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.26...videocall-client-v1.1.27) - 2025-10-30
+
+### Other
+
+- NetEQ Overhaul: WebCodecs Support, Critical Bug Fixes, and CI Improvements ([#466](https://github.com/security-union/videocall-rs/pull/466))
+- Fix matomo ([#454](https://github.com/security-union/videocall-rs/pull/454))
+
 ## [1.1.26](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.25...videocall-client-v1.1.26) - 2025-10-13
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.26"
+version = "1.1.27"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,8 +37,8 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.8" }
-neteq = { path = "../neteq", features = ["web"], version = "0.6.2", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.9" }
+neteq = { path = "../neteq", features = ["web"], version = "0.7.0", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.8...videocall-codecs-v0.1.9) - 2025-10-30
+
+### Other
+
+- NetEQ Overhaul: WebCodecs Support, Critical Bug Fixes, and CI Improvements ([#466](https://github.com/security-union/videocall-rs/pull/466))
+- Fix matomo ([#454](https://github.com/security-union/videocall-rs/pull/454))
+
 ## [0.1.8](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.7...videocall-codecs-v0.1.8) - 2025-10-13
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.8...videocall-sdk-v0.1.9) - 2025-10-30
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.8](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.7...videocall-sdk-v0.1.8) - 2025-10-13
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.31](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.30...videocall-ui-v1.1.31) - 2025-10-30
+
+### Other
+
+- hook-up diagnostics back ([#462](https://github.com/security-union/videocall-rs/pull/462))
+
 ## [1.1.30](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.29...videocall-ui-v1.1.30) - 2025-10-13
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.30"
+version = "1.1.31"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "3.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.26" }
+videocall-client = { path= "../videocall-client", version = "1.1.27" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.6.2", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.7.0", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `bot`: 1.0.12 -> 1.0.13
* `neteq`: 0.6.2 -> 0.7.0 (⚠ API breaking changes)
* `videocall-codecs`: 0.1.8 -> 0.1.9
* `videocall-client`: 1.1.26 -> 1.1.27 (✓ API compatible changes)
* `videocall-nokhwa-bindings-macos`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `videocall-ui`: 1.1.30 -> 1.1.31
* `videocall-sdk`: 0.1.8 -> 0.1.9

### ⚠ `neteq` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type UnifiedOpusDecoder is no longer UnwindSafe, in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/codec.rs:109
  type UnifiedOpusDecoder is no longer RefUnwindSafe, in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/codec.rs:109

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetEqConfig.additional_delay_ms in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:65
  field NetEqConfig.additional_delay_ms in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:65
  field DelayConfig.base_maximum_delay_ms in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/delay_manager.rs:57
  field DelayConfig.additional_delay_ms in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/delay_manager.rs:59

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Operation::Accelerate 3 -> 5 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:107
  variant Operation::FastAccelerate 4 -> 6 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:109
  variant Operation::PreemptiveExpand 5 -> 7 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:111
  variant Operation::ComfortNoise 6 -> 9 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:115
  variant Operation::Dtmf 7 -> 10 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:117
  variant Operation::Undefined 8 -> 11 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:119
  variant Operation::Accelerate 3 -> 5 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:107
  variant Operation::FastAccelerate 4 -> 6 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:109
  variant Operation::PreemptiveExpand 5 -> 7 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:111
  variant Operation::ComfortNoise 6 -> 9 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:115
  variant Operation::Dtmf 7 -> 10 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:117
  variant Operation::Undefined 8 -> 11 in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:119

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant Operation:ExpandStart in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:103
  variant Operation:ExpandEnd in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:105
  variant Operation:TimeStretchBuffer in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:113
  variant Operation:ExpandStart in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:103
  variant Operation:ExpandEnd in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:105
  variant Operation:TimeStretchBuffer in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/neteq.rs:113

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  DelayManager::set_packet_audio_length, previously in file /tmp/.tmpvZJqC7/neteq/src/delay_manager.rs:246

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  neteq::delay_manager::RelativeArrivalDelayTracker::update now takes 4 parameters instead of 3, in /tmp/.tmpcGCRkj/videocall-rs/neteq/src/delay_manager.rs:115

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field max_packets_in_buffer of struct DelayConfig, previously in file /tmp/.tmpvZJqC7/neteq/src/delay_manager.rs:52

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_method_added.ron

Failed in:
  trait method neteq::time_stretch::TimeStretcher::get_used_input_samples in file /tmp/.tmpcGCRkj/videocall-rs/neteq/src/time_stretch.rs:34

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_method_missing.ron

Failed in:
  method get_length_change_samples of trait TimeStretcher, previously in file /tmp/.tmpvZJqC7/neteq/src/time_stretch.rs:39
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bot`

<blockquote>

## [1.0.13](https://github.com/security-union/videocall-rs/compare/bot-v1.0.12...bot-v1.0.13) - 2025-10-30

### Other

- Fix matomo ([#454](https://github.com/security-union/videocall-rs/pull/454))
</blockquote>

## `neteq`

<blockquote>

## [0.7.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.6.2...neteq-v0.7.0) - 2025-10-30

### Other

- NetEQ Overhaul: WebCodecs Support, Critical Bug Fixes, and CI Improvements ([#466](https://github.com/security-union/videocall-rs/pull/466))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.8...videocall-codecs-v0.1.9) - 2025-10-30

### Other

- NetEQ Overhaul: WebCodecs Support, Critical Bug Fixes, and CI Improvements ([#466](https://github.com/security-union/videocall-rs/pull/466))
- Fix matomo ([#454](https://github.com/security-union/videocall-rs/pull/454))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.27](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.26...videocall-client-v1.1.27) - 2025-10-30

### Other

- NetEQ Overhaul: WebCodecs Support, Critical Bug Fixes, and CI Improvements ([#466](https://github.com/security-union/videocall-rs/pull/466))
- Fix matomo ([#454](https://github.com/security-union/videocall-rs/pull/454))
</blockquote>

## `videocall-nokhwa-bindings-macos`

<blockquote>

## [0.2.4](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-macos-v0.2.3...videocall-nokhwa-bindings-macos-v0.2.4) - 2025-10-30

### Other

- release ([#431](https://github.com/security-union/videocall-rs/pull/431))
- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
- Bump all crates to 1.0.0 ([#222](https://github.com/security-union/videocall-rs/pull/222))
- Rename to videocall cli ([#185](https://github.com/security-union/videocall-rs/pull/185))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.31](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.30...videocall-ui-v1.1.31) - 2025-10-30

### Other

- hook-up diagnostics back ([#462](https://github.com/security-union/videocall-rs/pull/462))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.8...videocall-sdk-v0.1.9) - 2025-10-30

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).