### PR TITLE
NetEq improvements

### DIFF
--- a/neteq/src/histogram.rs
+++ b/neteq/src/histogram.rs
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ *
+ * at your option.
+ *
+ * Unless you explicitly state otherwise, any contribution intentionally
+ * submitted for inclusion in the work by you, as defined in the Apache-2.0
+ * license, shall be dual licensed as above, without any additional terms or
+ * conditions.
+ */
+
+#[derive(Debug, Clone)]
+pub struct Histogram {
+    /// Buckets hold probabilities in Q30 fixed point (sum = 1 << 30).
+    buckets: Vec<i32>,
+    /// Current forget factor in Q15 (0..=32767). Matches C++ implementation.
+    forget_factor: i32,
+    /// Steady-state forget factor (base) in Q15.
+    base_forget_factor: i32,
+    /// Number of times Add() has been called since Reset or construction.
+    add_count: u32,
+    /// Optional start weight used in the original algorithm to ramp the forget factor.
+    start_forget_weight: Option<f64>,
+}
+
+impl Histogram {
+    /// Create a new Histogram with `num_buckets`, integer `forget_factor` (base) in Q15,
+    /// and optional `start_forget_weight` (same semantic as original C++).
+    pub fn new(
+        num_buckets: usize,
+        base_forget_factor: f64,
+        start_forget_weight: Option<f64>,
+    ) -> Self {
+        debug_assert!(
+            (0.0..=1.0).contains(&base_forget_factor),
+            "base_forget_factor must be in [0.0, 1.0]"
+        );
+
+        // convert f64 to i32 Q15
+        let base_forget_factor_q15 = f64_to_q(base_forget_factor, 15) as i32;
+
+        debug_assert!(base_forget_factor_q15 < (1 << 15));
+        debug_assert!(base_forget_factor_q15 >= 0);
+        Histogram {
+            buckets: vec![0i32; num_buckets],
+            forget_factor: 0,
+            base_forget_factor: base_forget_factor_q15,
+            add_count: 0,
+            start_forget_weight,
+        }
+    }
+
+    /// Add an observation with value `value` (index into buckets).
+    pub fn add(&mut self, value: usize) {
+        debug_assert!(value < self.buckets.len());
+        // Sum as we process. Use i64 temporaries for safe intermediate arithmetic.
+        let mut vector_sum: i64 = 0;
+
+        // Multiply each bucket by forget_factor (Q15).
+        for b in self.buckets.iter_mut() {
+            let tmp = ((*b as i64) * (self.forget_factor as i64)) >> 15;
+            *b = tmp as i32;
+            vector_sum += tmp;
+        }
+
+        // Add new sample: (32768 - forget_factor) << 15 (result in Q30)
+        let add_amount: i64 = ((1 << 15) as i64 - self.forget_factor as i64) << 15;
+        self.buckets[value] = (self.buckets[value] as i64 + add_amount) as i32;
+        vector_sum += add_amount;
+
+        // Desired sum is 1 << 30 (Q30).
+        vector_sum -= 1i64 << 30;
+
+        if vector_sum != 0 {
+            let flip_sign: i64 = if vector_sum > 0 { -1 } else { 1 };
+            // Modify a few values early in buckets to compensate for rounding error.
+            for b in self.buckets.iter_mut() {
+                // Add/subtract 1/16 of the element, but not more than |vector_sum|.
+                let correction = flip_sign * vector_sum.abs().min((*b as i64) >> 4).max(0);
+                *b = (*b as i64 + correction) as i32;
+                vector_sum += correction;
+                if vector_sum == 0 {
+                    break;
+                }
+            }
+        }
+        debug_assert_eq!(vector_sum, 0);
+
+        self.add_count = self.add_count.saturating_add(1);
+
+        // Update forget_factor_ (ramp towards base_forget_factor_)
+        if let Some(start_weight) = self.start_forget_weight {
+            if self.forget_factor != self.base_forget_factor {
+                let old_forget = self.forget_factor;
+
+                // Compute: (1<<15) * (1 - start_weight / (add_count + 1))
+                // Use f64 then clamp to [0, base_forget_factor]
+                let forget_f = ((1u32 << 15) as f64
+                    * (1.0 - start_weight / (self.add_count as f64 + 1.0)))
+                    .round();
+                self.forget_factor = 0.max(self.base_forget_factor.min(forget_f as i32));
+
+                // The histogram is updated recursively by forgetting the old histogram
+                // with |forget_factor_| and adding a new sample multiplied by |1 -
+                // forget_factor_|. We need to make sure that the effective weight on the
+                // new sample is no smaller than those on the old samples.
+                debug_assert!(
+                    (1 << 15) - self.forget_factor
+                        >= (((1 << 15) - old_forget) * self.forget_factor) >> 15
+                );
+            }
+        } else {
+            // forget_factor_ += (base_forget_factor_ - forget_factor_ + 3) >> 2;
+            let diff = (self.base_forget_factor - self.forget_factor + 3) >> 2;
+            self.forget_factor = self.forget_factor + diff;
+        }
+    }
+
+    /// Return the bucket index corresponding to the given quantile probability (0.0..=1.0).
+    /// Finds the smallest index such that the reverse cumulative probability >= probability.
+    pub fn quantile(&self, probability: f64) -> usize {
+        debug_assert!(
+            (0.0..=1.0).contains(&probability),
+            "probability must be in [0.0, 1.0]"
+        );
+
+        let total_q30: i64 = 1 << 30;
+
+        // Convert probability to Q30
+        let probability_q30 = f64_to_q(probability, 30);
+
+        let inverse_probability = total_q30 - probability_q30;
+        let mut index = 0;
+        let mut sum: i64 = total_q30;
+
+        sum -= self.buckets[0] as i64;
+
+        let n = self.buckets.len();
+        while sum > inverse_probability && index < n - 1 {
+            index += 1;
+            sum -= self.buckets[index] as i64;
+        }
+
+        index
+    }
+
+    /// Reset to an exponentially decaying distribution:
+    /// buckets[i] = 0.5^(i+1) in Q30, as in the original Reset().
+    pub fn reset(&mut self) {
+        // Set temp_prob to (slightly more than) 1 in Q14. This ensures that the sum is
+        // as close to 1 as possible.
+        let mut temp_prob: u32 = 0x4002;
+        for b in self.buckets.iter_mut() {
+            temp_prob >>= 1;
+            // shift left 16 to get Q30 (Q14 << 16 = Q30)
+            *b = (temp_prob << 16) as i32;
+        }
+        self.forget_factor = 0;
+        self.add_count = 0;
+    }
+
+    /// Number of buckets.
+    pub fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+}
+
+fn f64_to_q(v: f64, q: u8) -> i64 {
+    let total_q: i64 = 1 << q;
+    (v * (total_q as f64)).round() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reset_sum_is_one_q30() {
+        let mut h = Histogram::new(8, 0.5, None);
+        h.reset();
+        let sum: i64 = h.buckets.iter().map(|&b| b as i64).sum();
+        let expected = 1i64 << 30; // 1 in Q30
+
+        // Allow small rounding difference (less then 1%).
+        assert!(
+            (expected - sum).abs() <= expected / 100,
+            "sum = {}, expected ≈ {}, diff = {:.3}%",
+            sum,
+            expected,
+            (expected - sum).abs() as f64 / expected as f64 * 100.0
+        );
+    }
+
+    #[test]
+    fn test_add_and_quantile_basic() {
+        // small histogram
+        let mut h = Histogram::new(4, 0.5, None);
+        h.reset();
+
+        // call add on bucket 0 several times and ensure quantile moves toward 0.
+        for _ in 0..10 {
+            h.add(0);
+        }
+
+        let q = h.quantile(0.5);
+        // quantile should be fairly small (prefer low indices after many adds to 0).
+        assert!(q <= 1);
+    }
+
+    #[test]
+    fn test_num_buckets() {
+        let h = Histogram::new(7, 0.1, None);
+        assert_eq!(h.num_buckets(), 7);
+    }
+}

--- a/neteq/src/lib.rs
+++ b/neteq/src/lib.rs
@@ -27,6 +27,7 @@ pub mod buffer_level_filter;
 pub mod codec;
 pub mod delay_manager;
 pub mod error;
+pub mod histogram;
 pub mod neteq;
 pub mod packet;
 pub mod signal;

--- a/neteq/src/neteq.rs
+++ b/neteq/src/neteq.rs
@@ -45,6 +45,9 @@ use crate::{NetEqError, Result};
 /// - WebRTC tuned this value across diverse network conditions
 const K_DECELERATION_TARGET_LEVEL_OFFSET_MS: u32 = 85;
 
+/// Hardcoded minimum delay.
+const K_BASE_MIN_DELAY_MS: u32 = 20;
+
 /// NetEQ configuration
 #[derive(Debug, Clone)]
 pub struct NetEqConfig {
@@ -58,6 +61,8 @@ pub struct NetEqConfig {
     pub max_delay_ms: u32,
     /// Minimum delay in milliseconds
     pub min_delay_ms: u32,
+    // Fixed additional delay
+    pub additional_delay_ms: u32,
     /// Disable time stretching (for testing)
     pub for_test_no_time_stretching: bool,
     /// Bypass NetEQ processing and decode packets directly (for A/B testing)
@@ -76,6 +81,7 @@ impl Default for NetEqConfig {
             max_packets_in_buffer: 200,
             max_delay_ms: 0,
             min_delay_ms: 0,
+            additional_delay_ms: 0,
             for_test_no_time_stretching: false,
             bypass_mode: false,
             delay_config: DelayConfig::default(),
@@ -93,12 +99,18 @@ pub enum Operation {
     Merge,
     /// Expand operation (concealment)
     Expand,
+    /// First expand in a row
+    ExpandStart,
+    /// Last expand in a row
+    ExpandEnd,
     /// Accelerate operation (time compression)
     Accelerate,
     /// Fast accelerate operation
     FastAccelerate,
     /// Preemptive expand operation (time expansion)
     PreemptiveExpand,
+    /// Time strech operations return multiple frames at once, return the consecutive frames
+    TimeStretchBuffer,
     /// Comfort noise generation
     ComfortNoise,
     /// DTMF tone generation
@@ -184,14 +196,16 @@ pub struct NetEq {
     decoders: HashMap<u8, Box<dyn crate::codec::AudioDecoder + Send>>,
     /// Audio queue for bypass mode (direct decoding without jitter buffer)
     bypass_audio_queue: VecDeque<f32>,
-    /// Sample memory for time-stretching operations (matches WebRTC sample_memory_)
-    sample_memory: i32,
-    /// Flag indicating if time-scale operation was performed in previous call
-    prev_time_scale: bool,
     /// Rolling counters for packets-per-second measurement
     packets_received_this_second: u32,
     last_packets_second_instant: Instant,
     packets_per_sec_snapshot: u32,
+    // A buffer for already time streched samples. Separate from leftover_samples to avoid
+    // double time-streching.
+    leftover_time_stretched_samples: Vec<f32>,
+    /// Number of samples added by time-stretching operations (matches WebRTC sample_memory_,
+    /// but with clearer meaning for positive/negative values).
+    timestretch_added_samples: i32,
 }
 
 impl NetEq {
@@ -216,14 +230,17 @@ impl NetEq {
         );
 
         let mut delay_config = config.delay_config.clone();
-        delay_config.max_packets_in_buffer = config.max_packets_in_buffer;
-        delay_config.base_minimum_delay_ms = config.min_delay_ms;
+        delay_config.base_minimum_delay_ms = K_BASE_MIN_DELAY_MS;
+        delay_config.base_maximum_delay_ms = (config.max_packets_in_buffer * 20 * 3 / 4) as u32;
+        delay_config.additional_delay_ms = config.additional_delay_ms;
 
         let mut delay_manager = DelayManager::new(delay_config);
-        if config.max_delay_ms > 0 {
-            delay_manager.set_maximum_delay(config.max_delay_ms)?;
+        if config.min_delay_ms > 0 {
+            delay_manager.set_minimum_delay(config.min_delay_ms);
         }
-        delay_manager.set_minimum_delay(config.min_delay_ms)?;
+        if config.max_delay_ms > 0 {
+            delay_manager.set_maximum_delay(config.max_delay_ms);
+        }
 
         let statistics = StatisticsCalculator::new();
         let buffer_level_filter = BufferLevelFilter::new(config.sample_rate);
@@ -251,11 +268,11 @@ impl NetEq {
             leftover_samples: Vec::new(),
             decoders: HashMap::new(),
             bypass_audio_queue: VecDeque::new(),
-            sample_memory: 0,
-            prev_time_scale: false,
             packets_received_this_second: 0,
             last_packets_second_instant: Instant::now(),
             packets_per_sec_snapshot: 0,
+            leftover_time_stretched_samples: Vec::new(),
+            timestretch_added_samples: 0,
         })
     }
 
@@ -375,12 +392,26 @@ impl NetEq {
         let operation = self.get_decision()?;
         self.last_operation = operation;
 
+        // TODO: remove debug code
+        if operation != Operation::Normal {
+            log::info!(
+                "operation {:?} buffer: {} filtered: {} target: {}",
+                operation,
+                self.current_buffer_size_ms(),
+                self.buffer_level_filter.filtered_current_level_ms(),
+                self.delay_manager.target_delay_ms(),
+            );
+        }
+
         match operation {
             Operation::Normal => self.decode_normal(&mut frame)?,
-            Operation::Accelerate => self.decode_accelerate(&mut frame)?,
-            Operation::FastAccelerate => self.decode_fast_accelerate(&mut frame)?,
+            Operation::Accelerate => self.decode_accelerate(&mut frame, false)?,
+            Operation::FastAccelerate => self.decode_accelerate(&mut frame, true)?,
             Operation::PreemptiveExpand => self.decode_preemptive_expand(&mut frame)?,
-            Operation::Expand => self.decode_expand(&mut frame)?,
+            Operation::TimeStretchBuffer => self.return_time_stretch_buffer(&mut frame)?,
+            Operation::Expand => self.decode_expand(&mut frame, false, false)?,
+            Operation::ExpandStart => self.decode_expand(&mut frame, true, false)?,
+            Operation::ExpandEnd => self.decode_expand(&mut frame, false, true)?,
             Operation::Merge => self.decode_merge(&mut frame)?,
             Operation::ComfortNoise => self.generate_comfort_noise(&mut frame)?,
             _ => {
@@ -446,13 +477,13 @@ impl NetEq {
         self.delay_manager.target_delay_ms()
     }
 
-    /// Set minimum delay
-    pub fn set_minimum_delay(&mut self, delay_ms: u32) -> Result<bool> {
+    /// Set minimum delay, return the effective minimum delay
+    pub fn set_minimum_delay(&mut self, delay_ms: u32) -> u32 {
         self.delay_manager.set_minimum_delay(delay_ms)
     }
 
-    /// Set maximum delay
-    pub fn set_maximum_delay(&mut self, delay_ms: u32) -> Result<bool> {
+    /// Set maximum delay, return the effective maximum delay
+    pub fn set_maximum_delay(&mut self, delay_ms: u32) -> u32 {
         self.delay_manager.set_maximum_delay(delay_ms)
     }
 
@@ -464,11 +495,11 @@ impl NetEq {
         self.last_decode_timestamp = None;
         self.consecutive_expands = 0;
         self.leftover_samples.clear();
-        self.sample_memory = 0;
-        self.prev_time_scale = false;
         self.packets_received_this_second = 0;
         self.packets_per_sec_snapshot = 0;
         self.last_packets_second_instant = Instant::now();
+        self.leftover_time_stretched_samples.clear();
+        self.timestretch_added_samples = 0;
     }
 
     fn get_decision(&mut self) -> Result<Operation> {
@@ -480,21 +511,33 @@ impl NetEq {
         self.buffer_level_filter
             .set_target_buffer_level(target_delay_ms);
 
-        // Calculate time-stretched samples (matches WebRTC decision_logic.cc:233-237)
-        let mut time_stretched_samples = 0i32; // time_stretched_cn_samples in WebRTC
-        if self.prev_time_scale {
-            time_stretched_samples += self.sample_memory;
-        }
         self.buffer_level_filter
-            .update(current_buffer_samples, time_stretched_samples);
+            .update(current_buffer_samples, -self.timestretch_added_samples);
 
         // Reset for next frame (matches WebRTC decision_logic.cc:245-246)
-        self.prev_time_scale = false;
+        self.timestretch_added_samples = 0;
+
+        if !self.leftover_time_stretched_samples.is_empty() {
+            return Ok(Operation::TimeStretchBuffer);
+        }
+
+        if current_buffer_samples < self.output_frame_size_samples * 3 / 2
+            && current_buffer_samples >= self.output_frame_size_samples / 2
+            && self.consecutive_expands == 0
+        {
+            self.consecutive_expands = self.consecutive_expands.saturating_add(1);
+            return Ok(Operation::ExpandStart);
+        }
 
         // Check if we have packets
-        if self.packet_buffer.is_empty() {
+        if current_buffer_samples < self.output_frame_size_samples {
             self.consecutive_expands = self.consecutive_expands.saturating_add(1);
             return Ok(Operation::Expand);
+        }
+
+        if self.consecutive_expands > 0 {
+            self.consecutive_expands = 0;
+            return Ok(Operation::ExpandEnd);
         }
 
         // Use WebRTC-style threshold calculations
@@ -523,8 +566,10 @@ impl NetEq {
             return Ok(Operation::Accelerate);
         }
 
-        // Preemptive expand: below low limit
-        if buffer_level_samples < low_limit as usize && !self.packet_buffer.is_empty() {
+        // Preemptive expand: below low limit (requires ~30ms of audio)
+        if buffer_level_samples < low_limit as usize
+            && current_buffer_samples >= self.output_frame_size_samples * 3
+        {
             self.consecutive_expands = 0;
             return Ok(Operation::PreemptiveExpand);
         }
@@ -534,6 +579,19 @@ impl NetEq {
             // ~6 seconds at 10ms frames
             self.flush();
             return Ok(Operation::Normal);
+        }
+
+        // TODO: remove debug codes
+        // if simple_random() < 0.2 {
+        //     self.consecutive_expands = 0;
+        //     return Ok(Operation::PreemptiveExpand);
+        // }
+        if simple_random() < 0.001 {
+            if self.delay_manager.get_base_minimum_delay() == 30 {
+                self.delay_manager.set_base_minimum_delay(330);
+            } else {
+                self.delay_manager.set_base_minimum_delay(30);
+            }
         }
 
         // Normal operation
@@ -631,80 +689,69 @@ impl NetEq {
         Ok(())
     }
 
-    fn decode_accelerate(&mut self, frame: &mut AudioFrame) -> Result<()> {
+    fn decode_accelerate(&mut self, frame: &mut AudioFrame, fast_mode: bool) -> Result<()> {
         if !self.config.for_test_no_time_stretching {
+            let available_samples = self.current_buffer_size_samples();
+            let mut output_len: usize = 0;
+            let mut required_samples: usize = 0;
+            for i in (1..=3).rev() {
+                // Use 30ms if available
+                output_len = self.output_frame_size_samples * i;
+                if fast_mode {
+                    required_samples = (output_len as f32 * 2.0).ceil() as usize
+                } else {
+                    required_samples = (output_len as f32 * 1.5).ceil() as usize
+                }
+                if required_samples <= available_samples {
+                    break;
+                }
+            }
+            log::info!("accelerate {} {}", output_len, required_samples);
+
             // Get more data than we need
             let mut extended_frame = AudioFrame::new(
                 self.config.sample_rate,
                 self.config.channels,
-                (frame.samples_per_channel as f32 * 1.5) as usize,
+                required_samples,
             );
 
             self.decode_normal(&mut extended_frame)?;
+
+            // Will output up to 30ms output
+            let mut output =
+                AudioFrame::new(self.config.sample_rate, self.config.channels, output_len);
 
             // Apply accelerate algorithm
-            let mut output = Vec::new();
-            let _result = self
-                .accelerate
-                .process(&extended_frame.samples, &mut output, false);
+            let _result =
+                self.accelerate
+                    .process(&extended_frame.samples, &mut output.samples, fast_mode);
 
-            // Copy processed samples to frame
-            let copy_len = output.len().min(frame.samples.len());
-            frame.samples[..copy_len].copy_from_slice(&output[..copy_len]);
+            // Put back unused samples
+            let used_input_samples = self.accelerate.get_used_input_samples();
+            if extended_frame.samples.len() > used_input_samples {
+                self.leftover_samples.splice(
+                    0..0,
+                    extended_frame.samples[used_input_samples..].iter().cloned(),
+                );
+            }
+
+            // Fill frame with as much data as it fits
+            let frame_len = frame.samples.len();
+            frame.samples.clone_from_slice(&output.samples[..frame_len]);
+
+            // Store the remaining data to be returned as later frames
+            self.leftover_time_stretched_samples
+                .extend_from_slice(&output.samples[frame_len..]);
+
+            // Track time-stretching for buffer level filtering (matches WebRTC pattern)
+            // WebRTC sets sample_memory to available samples for time-stretching (line 1304)
+            // extended_frame has more samples than we need, representing available data
+            let samples_removed = used_input_samples as i32 - output.samples.len() as i32;
+            self.timestretch_added_samples -= samples_removed / self.config.channels as i32;
 
             // Update statistics
-            let samples_removed = self.accelerate.get_length_change_samples();
             self.statistics
                 .time_stretch_operation(TimeStretchOperation::Accelerate, samples_removed as u64);
-
-            // Track time-stretching for buffer level filtering (matches WebRTC pattern)
-            // WebRTC sets sample_memory to available samples for time-stretching (line 1304)
-            // extended_frame has more samples than we need, representing available data
-            let available_samples = extended_frame.samples.len() / self.config.channels as usize;
-            self.sample_memory = available_samples as i32;
-            self.prev_time_scale = true;
-
-            frame.speech_type = SpeechType::Normal;
-            frame.vad_activity = extended_frame.vad_activity; // Preserve VAD from decoded audio
-        } else {
-            self.decode_normal(frame)?;
-        }
-
-        Ok(())
-    }
-
-    fn decode_fast_accelerate(&mut self, frame: &mut AudioFrame) -> Result<()> {
-        if !self.config.for_test_no_time_stretching {
-            // Get more data for aggressive acceleration
-            let mut extended_frame = AudioFrame::new(
-                self.config.sample_rate,
-                self.config.channels,
-                (frame.samples_per_channel as f32 * 2.0) as usize,
-            );
-
-            self.decode_normal(&mut extended_frame)?;
-
-            // Apply fast accelerate
-            let mut output = Vec::new();
-            let _result = self.accelerate.process(
-                &extended_frame.samples,
-                &mut output,
-                true, // Fast mode
-            );
-
-            let copy_len = output.len().min(frame.samples.len());
-            frame.samples[..copy_len].copy_from_slice(&output[..copy_len]);
-
-            let samples_removed = self.accelerate.get_length_change_samples();
-            self.statistics
-                .time_stretch_operation(TimeStretchOperation::Accelerate, samples_removed as u64);
-
-            // Track time-stretching for buffer level filtering (matches WebRTC pattern)
-            // WebRTC sets sample_memory to available samples for time-stretching (line 1304)
-            // extended_frame has more samples than we need, representing available data
-            let available_samples = extended_frame.samples.len() / self.config.channels as usize;
-            self.sample_memory = available_samples as i32;
-            self.prev_time_scale = true;
 
             frame.speech_type = SpeechType::Normal;
             frame.vad_activity = extended_frame.vad_activity; // Preserve VAD from decoded audio
@@ -717,31 +764,55 @@ impl NetEq {
 
     fn decode_preemptive_expand(&mut self, frame: &mut AudioFrame) -> Result<()> {
         if !self.config.for_test_no_time_stretching {
-            // Get normal amount of data
-            self.decode_normal(frame)?;
+            // Preemtive expand requires more data (30ms)
+            let mut extended_frame = AudioFrame::new(
+                self.config.sample_rate,
+                self.config.channels,
+                (frame.samples_per_channel as f32 * 3.0) as usize,
+            );
+
+            self.decode_normal(&mut extended_frame)?;
+
+            // get output of same size as input
+            let mut output = AudioFrame::new(
+                self.config.sample_rate,
+                self.config.channels,
+                (frame.samples_per_channel as f32 * 3.0) as usize,
+            );
 
             // Apply preemptive expand
-            let input = frame.samples.clone();
-            let mut output = Vec::new();
+            let _result =
+                self.preemptive_expand
+                    .process(&extended_frame.samples, &mut output.samples, false);
 
-            let _result = self.preemptive_expand.process(&input, &mut output, false);
+            // Put back unused samples
+            let used_input_samples = self.preemptive_expand.get_used_input_samples();
+            if extended_frame.samples.len() > used_input_samples {
+                self.leftover_samples.splice(
+                    0..0,
+                    extended_frame.samples[used_input_samples..].iter().cloned(),
+                );
+            }
 
-            // Update frame with expanded audio
-            let copy_len = output.len().min(frame.samples.len());
-            frame.samples[..copy_len].copy_from_slice(&output[..copy_len]);
+            // fill frame with first half of data
+            let frame_len = frame.samples.len();
+            frame.samples.clone_from_slice(&output.samples[..frame_len]);
 
-            let samples_added = self.preemptive_expand.get_length_change_samples();
-            self.statistics.time_stretch_operation(
-                TimeStretchOperation::PreemptiveExpand,
-                samples_added as u64,
-            );
+            // store the other half for the next frame
+            self.leftover_time_stretched_samples
+                .extend_from_slice(&output.samples[frame_len..]);
 
             // Track time-stretching for buffer level filtering (matches WebRTC pattern)
             // WebRTC sets sample_memory to available samples for time-stretching (line 1304)
             // For preemptive expand, we had normal frame samples available
-            let available_samples = frame.samples.len() / self.config.channels as usize;
-            self.sample_memory = available_samples as i32;
-            self.prev_time_scale = true;
+            let samples_added = output.samples.len() as i32 - used_input_samples as i32;
+            self.timestretch_added_samples += samples_added / self.config.channels as i32;
+
+            // Update statistics
+            self.statistics.time_stretch_operation(
+                TimeStretchOperation::PreemptiveExpand,
+                samples_added as u64,
+            );
 
             frame.speech_type = SpeechType::Normal;
             // VAD activity already preserved from decode_normal call
@@ -752,7 +823,19 @@ impl NetEq {
         Ok(())
     }
 
-    fn decode_expand(&mut self, frame: &mut AudioFrame) -> Result<()> {
+    fn return_time_stretch_buffer(&mut self, frame: &mut AudioFrame) -> Result<()> {
+        if !self.leftover_time_stretched_samples.is_empty() {
+            let to_copy = frame.samples.len();
+            frame
+                .samples
+                .copy_from_slice(&self.leftover_time_stretched_samples[..to_copy]);
+            self.leftover_time_stretched_samples.drain(..to_copy);
+        }
+
+        Ok(())
+    }
+
+    fn decode_expand(&mut self, frame: &mut AudioFrame, start: bool, end: bool) -> Result<()> {
         log::trace!(
             "decode_expand: buffer before expand={}ms, packets={} (consecutive_expands={})",
             self.current_buffer_size_ms(),
@@ -761,7 +844,50 @@ impl NetEq {
         );
         // Generate concealment audio (simple noise for now)
         for sample in &mut frame.samples {
-            *sample = (simple_random() - 0.5) * 0.01; // Very quiet noise
+            *sample = (simple_random() - 0.5) * 0.0001; // Very quiet noise
+        }
+
+        if start {
+            let mut end_of_audio = AudioFrame::new(
+                self.config.sample_rate,
+                self.config.channels,
+                (frame.samples_per_channel as f32 * 0.5) as usize,
+            );
+
+            self.decode_normal(&mut end_of_audio)?;
+
+            let fade_len = end_of_audio.samples.len();
+            let start_of_frame = frame.samples[..fade_len].to_vec();
+
+            // Crossfade with end of audio
+            crate::signal::crossfade(
+                &end_of_audio.samples,
+                &start_of_frame,
+                fade_len,
+                &mut frame.samples[..fade_len],
+            );
+        }
+
+        if end {
+            let mut start_of_audio = AudioFrame::new(
+                self.config.sample_rate,
+                self.config.channels,
+                (frame.samples_per_channel as f32 * 0.5) as usize,
+            );
+
+            self.decode_normal(&mut start_of_audio)?;
+
+            let fade_len = start_of_audio.samples.len();
+            let end_of_frame_start = frame.samples.len() - fade_len;
+            let end_of_frame = frame.samples[end_of_frame_start..].to_vec();
+
+            // Crossfade with end of audio
+            crate::signal::crossfade(
+                &end_of_frame,
+                &start_of_audio.samples,
+                fade_len,
+                &mut frame.samples[end_of_frame_start..],
+            );
         }
 
         frame.speech_type = SpeechType::Expand;
@@ -805,16 +931,14 @@ impl NetEq {
     pub fn current_buffer_size_ms(&self) -> u32 {
         // Use total content duration instead of timestamp span
         // This handles cases where packets have close/identical timestamps
-        self.packet_buffer.get_total_content_duration_ms()
+        self.current_buffer_size_samples() as u32 * 1000 / self.config.sample_rate
     }
 
     /// Get current buffer size in samples
     pub fn current_buffer_size_samples(&self) -> usize {
-        // Convert milliseconds to samples for the buffer duration
-        let buffer_duration_ms = self.current_buffer_size_ms(); // Use the fixed calculation
-        let buffer_samples =
-            (buffer_duration_ms as u64 * self.config.sample_rate as u64 / 1000) as usize;
-        buffer_samples + self.leftover_samples.len()
+        self.packet_buffer.num_samples_in_buffer()
+            + self.leftover_samples.len()
+            + self.leftover_time_stretched_samples.len()
     }
 
     /// Register a decoder for a given RTP payload type.

--- a/neteq/src/signal.rs
+++ b/neteq/src/signal.rs
@@ -36,17 +36,54 @@ pub fn normalized_correlation(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
+/// Compute the best normalized cross-correlation of given length
+/// between two equal-length slices.
+pub fn best_normalized_correlation(a: &[f32], b: &[f32], len: usize) -> (usize, f32) {
+    debug_assert_eq!(a.len(), b.len());
+    debug_assert!(a.len() >= len);
+
+    let mut sum_ab = 0.0;
+    let mut sum_a2 = 0.0;
+    let mut sum_b2 = 0.0;
+    let mut best_pos = 0;
+    let mut best_corr2 = 0.0;
+    for i in 0..a.len() {
+        sum_ab += a[i] * b[i];
+        sum_a2 += a[i] * a[i];
+        sum_b2 += b[i] * b[i];
+        if i >= len {
+            sum_ab -= a[i - len] * b[i - len];
+            sum_a2 -= a[i - len] * b[i - len];
+            sum_b2 -= a[i - len] * b[i - len];
+            let corr2 = if sum_a2 == 0.0 || sum_b2 == 0.0 {
+                0.0
+            } else if sum_ab < 0.0 {
+                -(sum_ab * sum_ab / (sum_a2 * sum_b2))
+            } else {
+                sum_ab * sum_ab / (sum_a2 * sum_b2)
+            };
+
+            if corr2 > best_corr2 {
+                best_corr2 = corr2;
+                best_pos = i;
+            }
+        }
+    }
+
+    (best_pos, best_corr2)
+}
+
 /// Cross-fade `fade_len` samples between the tail of `prev` and the head of `next`,
 /// writing into `out`. `prev` and `next` must both have at least `fade_len` samples.
-pub fn crossfade(prev: &[f32], next: &[f32], fade_len: usize, out: &mut Vec<f32>) {
-    let total_prev = prev.len();
+pub fn crossfade(prev: &[f32], next: &[f32], fade_len: usize, out: &mut [f32]) {
+    let fade_start = prev.len() - fade_len;
     // copy first part (prev without last fade_len)
-    out.extend_from_slice(&prev[..total_prev - fade_len]);
+    out[..fade_start].copy_from_slice(&prev[..fade_start]);
 
     for i in 0..fade_len {
         let fade_out = 1.0 - (i as f32 / fade_len as f32);
         let fade_in = 1.0 - fade_out;
-        let sample = prev[total_prev - fade_len + i] * fade_out + next[i] * fade_in;
-        out.push(sample);
+        let sample = prev[fade_start + i] * fade_out + next[i] * fade_in;
+        out[fade_start + i] = sample;
     }
 }

--- a/neteq/src/statistics.rs
+++ b/neteq/src/statistics.rs
@@ -419,12 +419,15 @@ impl StatisticsCalculator {
             Operation::Normal => 0,
             Operation::Merge => 1,
             Operation::Expand => 2,
-            Operation::Accelerate => 3,
-            Operation::FastAccelerate => 4,
-            Operation::PreemptiveExpand => 5,
-            Operation::ComfortNoise => 6,
-            Operation::Dtmf => 7,
-            Operation::Undefined => 8,
+            Operation::ExpandStart => 3,
+            Operation::ExpandEnd => 4,
+            Operation::Accelerate => 5,
+            Operation::FastAccelerate => 6,
+            Operation::PreemptiveExpand => 7,
+            Operation::TimeStretchBuffer => 8,
+            Operation::ComfortNoise => 9,
+            Operation::Dtmf => 10,
+            Operation::Undefined => 11,
         };
 
         // Increment counter

--- a/neteq/src/web.rs
+++ b/neteq/src/web.rs
@@ -48,7 +48,7 @@ impl WebNetEq {
         let cfg = NetEqConfig {
             sample_rate: self.sample_rate,
             channels: self.channels,
-            min_delay_ms: 80,
+            additional_delay_ms: 80,
             ..Default::default()
         };
         let mut neteq = NetEq::new(cfg).map_err(Self::map_err)?;


### PR DESCRIPTION
DRAFT PR FOR DISCUSSION ONLY

Hi!

I sent a couple days on the NetEq code. I mainly plan to use this jitter buffer for TTS audio, so some of the changes might not translate well for cases when there is more noise. Please look at the PR and let me know which parts you like and would consider merging. I can open some smaller proper PRs for the relevant parts if you are interested (although not sure when I will have the time to clean it up). Also, feel free to take anything from this if you want to.

I left in some debug code on purpose, it randomly changes the minimum size of target_level_ms between 30ms and 300ms, so it triggers PreemptiveExpand and Accelerate. As I was testing, it's hardly noticable in the audio.

## Delay manager

### Algorithm changes

Updated to use a histogram, and match the webrtc algorithm.

### Opinionated/empirical changes

Updated how minimum and maximum are calculated:
- base_minimum_delay_ms and base_maximum_delay_ms are now exclusively set from NetEq, and represent the pratical limitations based on packet size and
- minimum_delay_ms and maximum_delay_ms can be set from client code. Instead of returning a success/failure, they now return the effective value after setting them
	- rationale:
		- seems more user friendly then returning an error if the max is set too high
		- I didn't like that setting minimum first and then maximum might result in different bounds than setting maximum first and then minimum

Added additional_delay_ms
- this adds the value to the calculated target_level_ms
- I mainly added this to avoid Expand operations as much as possible (min delay wasn't heling if the target_level_ms was already higher than min_delay)

## Time strech operations

### General changes

Modified all time stretch operations to return a fix length output, instead of consuming a fix length input. They now fill the supplied output buffer, consuming as much of the input as necessary in the process. This makes it possible to keep the size of the returned frames consistent (10ms).

Since both accelerate and preemtive expand works much better with 30ms audio, I changed decode_accelerate and decode_preemptive_expand to produce 30ms output if possible. The first 10ms is returned, and the remaining is stored in a buffer and returned as the next two packets. This buffer is separate from the leftover_samples buffer to avoid double time-streching.

In order to return the extra frames, I added a new TimeStretchBuffer operation.

### Accelerate changes

Optimized the accelerate algorithm. The base logic is the same: remove low energy region and fade over the remaining head and tail. I added a new algorithm that finds the longest region where the average energy is less then a threshold. Instead of removing a fixed sized region, it now removes a region up to max size, where the energy average is below the threshold. 

I tested this with TTS audio, and it works very well. Not sure if it would still work reliably if the audio contained more noise. 

The normal accelerate will do nothing if it doesn't find a low energy region worth removing. The fast accelerate will fall back to the previous method.

#### Opinionated/empirical changes

I changed the low energy threshold form 0.01 to 0.001, this value works better for me. Not sure how this would work with higher background noise.

I also changed overlap length from 5ms to 3ms. 5ms produced an under-water like sound for me, and I heard popping sounds with 2ms. 3ms seems to be a good spot.

### PreemptiveExpand changes

Optimized the algorithm:
- previously: found the best correletion assuming a fix lag (fixed number added samples)
- webrtc: if I understood it correctly: over a range of lag values, finds the best lag value where the correlation of the whole overlapping part of head and tail is the maximum
- my implementation: for each possible lag value, finds the best position for the fade, by maximizing the correlation of only the overlap_length sequence, then returns the best lag value, with the best position for the fade

#### Opinionated/empirical changes

I changed overlap length from 5ms to 3ms, same as for accelerate.

### Expand

Added fade at the start and end of a series of expands. Added two new operations for this: ExpandStart and ExpandEnd. The overlap duration is 5ms, this should probably be shortened as well.

#### Opinionated/empirical changes

Reduced the noise amplitudes from 0.01 to 0.0001. For my use case (TTS audio), the generated noise was way too loud.

## Web

Changed min_delay_ms: 80 to additional_delay_ms: 80, mainly to avoid Expand operations as much as possible. 