### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "axum",
  "clap",
@@ -6583,7 +6583,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.27"
+version = "1.1.28"
 dependencies = [
  "aes",
  "anyhow",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.31"
+version = "1.1.32"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.7.0...neteq-v0.7.1) - 2025-11-02
+
+### Other
+
+- allow using neteq wasm without the worker ([#477](https://github.com/security-union/videocall-rs/pull/477))
+
 ## [0.7.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.6.2...neteq-v0.7.0) - 2025-10-30
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.3](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.2...videocall-cli-v3.0.3) - 2025-11-02
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [3.0.2](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.1...videocall-cli-v3.0.2) - 2025-10-13
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.28](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.27...videocall-client-v1.1.28) - 2025-11-02
+
+### Other
+
+- Add OAuth ([#471](https://github.com/security-union/videocall-rs/pull/471))
+
 ## [1.1.27](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.26...videocall-client-v1.1.27) - 2025-10-30
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.27"
+version = "1.1.28"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -38,7 +38,7 @@ yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
 videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.9" }
-neteq = { path = "../neteq", features = ["web"], version = "0.7.0", optional = true,  default-features = false }
+neteq = { path = "../neteq", features = ["web"], version = "0.7.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.9...videocall-sdk-v0.1.10) - 2025-11-02
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.8...videocall-sdk-v0.1.9) - 2025-10-30
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.32](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.31...videocall-ui-v1.1.32) - 2025-11-02
+
+### Other
+
+- Add OAuth ([#471](https://github.com/security-union/videocall-rs/pull/471))
+
 ## [1.1.31](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.30...videocall-ui-v1.1.31) - 2025-10-30
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.31"
+version = "1.1.32"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "3.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.27" }
+videocall-client = { path= "../videocall-client", version = "1.1.28" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.7.0", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.7.1", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `neteq`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `videocall-client`: 1.1.27 -> 1.1.28 (✓ API compatible changes)
* `videocall-cli`: 3.0.2 -> 3.0.3 (✓ API compatible changes)
* `videocall-ui`: 1.1.31 -> 1.1.32
* `videocall-sdk`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `neteq`

<blockquote>

## [0.7.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.7.0...neteq-v0.7.1) - 2025-11-02

### Other

- allow using neteq wasm without the worker ([#477](https://github.com/security-union/videocall-rs/pull/477))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.28](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.27...videocall-client-v1.1.28) - 2025-11-02

### Other

- Add OAuth ([#471](https://github.com/security-union/videocall-rs/pull/471))
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.3](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.2...videocall-cli-v3.0.3) - 2025-11-02

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.32](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.31...videocall-ui-v1.1.32) - 2025-11-02

### Other

- Add OAuth ([#471](https://github.com/security-union/videocall-rs/pull/471))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.10](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.9...videocall-sdk-v0.1.10) - 2025-11-02

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps crate versions and aligns dependencies (notably `neteq` 0.7.1 and `videocall-client` 1.1.28), updating UI/client to use them; includes Cargo.lock refresh and changelog updates.
> 
> - **Releases**:
>   - `neteq` → `0.7.1`
>   - `videocall-client` → `1.1.28`
>   - `videocall-ui` → `1.1.32`
>   - `videocall-cli` → `3.0.3`
>   - `videocall-sdk` → `0.1.10`
> - **Dependency alignment**:
>   - Update `videocall-client` and `videocall-ui` to depend on `neteq` `0.7.1`.
>   - Update `videocall-ui` to depend on `videocall-client` `1.1.28`.
>   - Refresh `Cargo.lock`.
> - **Changelogs**:
>   - `neteq`: allow using wasm without worker.
>   - `videocall-client`/`videocall-ui`: add OAuth entries.
>   - `videocall-cli`/`videocall-sdk`: dependency update entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d05d9fc7271bbf3637ea1c1d5073ef61a89123d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->