### PR TITLE
docker compose add COOKIE_DOMAIN

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -84,6 +84,7 @@ services:
       - OAUTH_REDIRECT_URL=${OAUTH_REDIRECT_URL:-http://localhost:8080/login/callback}
       - DATABASE_ENABLED=${DATABASE_ENABLED:-true}
       - RUST_LOG=debug,async_nats=info
+      - COOKIE_DOMAIN=${COOKIE_DOMAIN:-}
       - DATABASE_URL=postgres://postgres:docker@postgres:5432/actix-api-db?sslmode=disable
       - NATS_URL=nats:4222
       - REGION=${REGION:-us-east}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `COOKIE_DOMAIN` environment variable to the `websocket-api` service in `docker/docker-compose.yaml` for configuring cookie domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 558b645ce6558329b49f42dd583a7139b59b44b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->