### PR TITLE
Fix Critical Audio Worklet Message Serialization Bug

### DIFF
--- a/videocall-client/src/audio_worklet_codec.rs
+++ b/videocall-client/src/audio_worklet_codec.rs
@@ -18,6 +18,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
+use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{Array, Function};
 use serde::Serialize;
 use wasm_bindgen_futures::JsFuture;


### PR DESCRIPTION
## The Problem
Used serde_wasm_bindgen::to_value() to serialize messages to AudioWorklet. This broke all audio worklet communication because the function does not respect serde attributes.

The change was originally introduced here: https://github.com/security-union/videocall-rs/pull/471/files#r2520631991

## Why These Functions Aren't Equivalent

serde_wasm_bindgen::to_value
Creates native JS objects in WASM memory

Ignores #[serde(tag = "command")] and #[serde(rename_all = "camelCase")]
Produces incorrectly formatted messages

Instead,

JsValue::from_serde
Uses JSON serialization under the hood
Fully respects all serde attributes including tagged unions and rename rules
Guarantees correct message format

## The Impact
Our CodecMessages enum uses #[serde(tag = "command", rename_all = "camelCase")]. The JavaScript worklet expected messages like {"command": "start"}, but serde_wasm_bindgen::to_value was producing a different format. This caused Start/Stop/Init commands to fail, breaking audio encoding/decoding.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces serde_wasm_bindgen::to_value with JsValue::from_serde in AudioWorkletCodec to ensure serde attributes are respected for worklet messages.
> 
> - **Audio worklet messaging**
>   - Replace `serde_wasm_bindgen::to_value` with `JsValue::from_serde` in `videocall-client/src/audio_worklet_codec.rs` to preserve serde tagging/rename rules.
>   - Add `gloo_utils::format::JsValueSerdeExt` import required for `from_serde`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a096d143d4cc3e45b9d7f28fe4a1bc8bd80d30d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->