### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.13"
+version = "1.0.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "axum",
  "clap",
@@ -6583,7 +6583,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.28"
+version = "1.1.29"
 dependencies = [
  "aes",
  "anyhow",
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "approx",
@@ -6664,7 +6664,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-diagnostics"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-broadcast",
  "flume",
@@ -6726,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-bindings-windows"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "once_cell",
  "videocall-nokhwa-core",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.32"
+version = "1.1.33"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.14](https://github.com/security-union/videocall-rs/compare/bot-v1.0.13...bot-v1.0.14) - 2025-11-30
+
+### Other
+
+- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
+
 ## [1.0.13](https://github.com/security-union/videocall-rs/compare/bot-v1.0.12...bot-v1.0.13) - 2025-10-30
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.13"
+version = "1.0.14"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.7.1...neteq-v0.8.0) - 2025-11-30
+
+### Other
+
+- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
+- neteq preemptive expand improvements ([#476](https://github.com/security-union/videocall-rs/pull/476))
+- improved accelerate ([#475](https://github.com/security-union/videocall-rs/pull/475))
+
 ## [0.7.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.7.0...neteq-v0.7.1) - 2025-11-02
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.4](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.3...videocall-cli-v3.0.4) - 2025-11-30
+
+### Other
+
+- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
+
 ## [3.0.3](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.2...videocall-cli-v3.0.3) - 2025-11-02
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.3"
+version = "3.0.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-cli/nokhwa/nokhwa-bindings-windows/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-bindings-windows/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-windows-v0.4.4...videocall-nokhwa-bindings-windows-v0.4.5) - 2025-11-30
+
+### Other
+
+- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
+
 ## [0.4.4](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-windows-v0.4.3...videocall-nokhwa-bindings-windows-v0.4.4) - 2025-06-23
 
 ### Other

--- a/videocall-cli/nokhwa/nokhwa-bindings-windows/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-bindings-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-bindings-windows"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["l1npengtul", "Dario Lencina <dario@securityunion.dev>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/videocall-cli/nokhwa/nokhwa-core/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.7...videocall-nokhwa-core-v0.1.8) - 2025-11-30
+
+### Other
+
+- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
+
 ## [0.1.7](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.6...videocall-nokhwa-core-v0.1.7) - 2025-06-23
 
 ### Other

--- a/videocall-cli/nokhwa/nokhwa-core/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-core"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["l1npengtul <l1npengtul@protonmail.com>", "Dario Lencina <dario@securityunion.dev>"]
 edition = "2021"
 description = "Core type definitions for nokhwa"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.29](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.28...videocall-client-v1.1.29) - 2025-11-30
+
+### Other
+
+- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
+- Optimize videocallclient and canvas integration via Yew Context ([#486](https://github.com/security-union/videocall-rs/pull/486))
+- Fix Critical Audio Worklet Message Serialization Bug ([#482](https://github.com/security-union/videocall-rs/pull/482))
+
 ## [1.1.28](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.27...videocall-client-v1.1.28) - 2025-11-02
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.28"
+version = "1.1.29"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,11 +37,11 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.9" }
-neteq = { path = "../neteq", features = ["web"], version = "0.7.1", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.10" }
+neteq = { path = "../neteq", features = ["web"], version = "0.8.0", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 serde_json = { version = "1.0" }
 async-broadcast = "0.7.2"
 

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.9...videocall-codecs-v0.1.10) - 2025-11-30
+
+### Other
+
+- updated the following local packages: videocall-diagnostics
+
 ## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.8...videocall-codecs-v0.1.9) - 2025-10-30
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -78,7 +78,7 @@ web-sys = { version = "0.3", optional = true, features = [
     "HtmlElement",
     "HtmlLinkElement",
 ] }
-videocall-diagnostics = { path = "../videocall-diagnostics", optional = true, version = "0.1.2" }
+videocall-diagnostics = { path = "../videocall-diagnostics", optional = true, version = "0.1.3" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env-libvpx-sys = { workspace = true }

--- a/videocall-diagnostics/CHANGELOG.md
+++ b/videocall-diagnostics/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.2...videocall-diagnostics-v0.1.3) - 2025-11-30
+
+### Other
+
+- Fix OAuth redirectURL ([#485](https://github.com/security-union/videocall-rs/pull/485))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.1...videocall-diagnostics-v0.1.2) - 2025-08-08
 
 ### Other

--- a/videocall-diagnostics/Cargo.toml
+++ b/videocall-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-diagnostics"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Lightweight diagnostics event bus for the videocall-rs project"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.10...videocall-sdk-v0.1.11) - 2025-11-30
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.10](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.9...videocall-sdk-v0.1.10) - 2025-11-02
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.33](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.32...videocall-ui-v1.1.33) - 2025-11-30
+
+### Other
+
+- Optimize videocallclient and canvas integration via Yew Context ([#486](https://github.com/security-union/videocall-rs/pull/486))
+- Fix OAuth redirectURL ([#485](https://github.com/security-union/videocall-rs/pull/485))
+
 ## [1.1.32](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.31...videocall-ui-v1.1.32) - 2025-11-02
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.32"
+version = "1.1.33"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,8 +16,8 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "3.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.28" }
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.2" }
+videocall-client = { path= "../videocall-client", version = "1.1.29" }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 once_cell = "1.19"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.7.1", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.8.0", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `bot`: 1.0.13 -> 1.0.14
* `neteq`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)
* `videocall-diagnostics`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `videocall-client`: 1.1.28 -> 1.1.29 (✓ API compatible changes)
* `videocall-nokhwa-core`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `videocall-nokhwa-bindings-windows`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `videocall-cli`: 3.0.3 -> 3.0.4 (✓ API compatible changes)
* `videocall-ui`: 1.1.32 -> 1.1.33
* `videocall-sdk`: 0.1.10 -> 0.1.11
* `videocall-codecs`: 0.1.9 -> 0.1.10

### ⚠ `neteq` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function neteq::signal::normalized_correlation, previously in file /tmp/.tmpECJnRg/neteq/src/signal.rs:22
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bot`

<blockquote>

## [1.0.14](https://github.com/security-union/videocall-rs/compare/bot-v1.0.13...bot-v1.0.14) - 2025-11-30

### Other

- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
</blockquote>

## `neteq`

<blockquote>

## [0.8.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.7.1...neteq-v0.8.0) - 2025-11-30

### Other

- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
- neteq preemptive expand improvements ([#476](https://github.com/security-union/videocall-rs/pull/476))
- improved accelerate ([#475](https://github.com/security-union/videocall-rs/pull/475))
</blockquote>

## `videocall-diagnostics`

<blockquote>

## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.2...videocall-diagnostics-v0.1.3) - 2025-11-30

### Other

- Fix OAuth redirectURL ([#485](https://github.com/security-union/videocall-rs/pull/485))
</blockquote>

## `videocall-client`

<blockquote>

## [1.1.29](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.28...videocall-client-v1.1.29) - 2025-11-30

### Other

- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
- Optimize videocallclient and canvas integration via Yew Context ([#486](https://github.com/security-union/videocall-rs/pull/486))
- Fix Critical Audio Worklet Message Serialization Bug ([#482](https://github.com/security-union/videocall-rs/pull/482))
</blockquote>

## `videocall-nokhwa-core`

<blockquote>

## [0.1.8](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.7...videocall-nokhwa-core-v0.1.8) - 2025-11-30

### Other

- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
</blockquote>

## `videocall-nokhwa-bindings-windows`

<blockquote>

## [0.4.5](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-windows-v0.4.4...videocall-nokhwa-bindings-windows-v0.4.5) - 2025-11-30

### Other

- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.4](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.3...videocall-cli-v3.0.4) - 2025-11-30

### Other

- Delete commented code and address clippy warnings ([#489](https://github.com/security-union/videocall-rs/pull/489))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.33](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.32...videocall-ui-v1.1.33) - 2025-11-30

### Other

- Optimize videocallclient and canvas integration via Yew Context ([#486](https://github.com/security-union/videocall-rs/pull/486))
- Fix OAuth redirectURL ([#485](https://github.com/security-union/videocall-rs/pull/485))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.11](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.10...videocall-sdk-v0.1.11) - 2025-11-30

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.10](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.9...videocall-codecs-v0.1.10) - 2025-11-30

### Other

- updated the following local packages: videocall-diagnostics
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).