### PR TITLE
Fix OAuth redirectURL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6803,6 +6803,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
+ "urlencoding",
  "videocall-client",
  "videocall-diagnostics",
  "videocall-types",

--- a/actix-api/src/auth/mod.rs
+++ b/actix-api/src/auth/mod.rs
@@ -58,6 +58,7 @@ pub struct OAuthRequest {
     pub pkce_challenge: String,
     pub pkce_verifier: String,
     pub csrf_state: String,
+    pub return_to: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -78,18 +79,20 @@ pub struct Claims {
 
 pub fn generate_and_store_oauth_request(
     pool: web::Data<PostgresPool>,
+    return_to: Option<String>,
 ) -> Anysult<(CsrfToken, PkceCodeChallenge)> {
     let mut connection = pool.get()?;
     let csrf_state = CsrfToken::new_random();
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
     connection.query(
-        "INSERT INTO oauth_requests (pkce_challenge, pkce_verifier, csrf_state)
-                       VALUES ($1, $2, $3)
+        "INSERT INTO oauth_requests (pkce_challenge, pkce_verifier, csrf_state, return_to)
+                       VALUES ($1, $2, $3, $4)
             ",
         &[
             &pkce_challenge.as_str(),
             &pkce_verifier.secret().as_str(),
             &csrf_state.secret().clone(),
+            &return_to,
         ],
     )?;
     Ok((csrf_state, pkce_challenge))
@@ -109,6 +112,7 @@ pub fn fetch_oauth_request(pool: web::Data<PostgresPool>, state: String) -> Anys
                 csrf_state: row.get("csrf_state"),
                 pkce_challenge: row.get("pkce_challenge"),
                 pkce_verifier: row.get("pkce_verifier"),
+                return_to: row.get("return_to"),
             })
         })
 }

--- a/dbmate/db/migrations/20250113000000_add_return_to_oauth_requests.sql
+++ b/dbmate/db/migrations/20250113000000_add_return_to_oauth_requests.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+ALTER TABLE oauth_requests ADD COLUMN return_to TEXT;
+
+-- migrate:down
+ALTER TABLE oauth_requests DROP COLUMN return_to;
+

--- a/videocall-diagnostics/src/lib.rs
+++ b/videocall-diagnostics/src/lib.rs
@@ -23,9 +23,6 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_futures;
-
 // === Diagnostic data structures ===
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -70,7 +67,7 @@ static SENDER: Lazy<Sender<DiagEvent>> = Lazy::new(|| {
         wasm_bindgen_futures::spawn_local(async move {
             // Keep the receiver alive to prevent channel closure
             // This receiver will consume messages but not process them
-            while let Ok(_) = receiver.recv().await {
+            while (receiver.recv().await).is_ok() {
                 // Intentionally discard messages in the background receiver
                 // This keeps the channel open for other receivers
             }

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -38,6 +38,7 @@ matomo-logger = { path = "../matomo-logger", version = "0.1.0" }
 serde-wasm-bindgen = "0.6"
 reqwasm = "0.5"
 anyhow = "1.0"
+urlencoding = "2.1"
 
 [dependencies.web-sys]
 version = "0.3.72"

--- a/yew-ui/scripts/config.js
+++ b/yew-ui/scripts/config.js
@@ -4,7 +4,7 @@ window.__APP_CONFIG = Object.freeze({
   webTransportHost: "https://127.0.0.1:4433",
   oauthEnabled: "true",
   e2eeEnabled: "false",
-  webTransportEnabled: "false",
+  webTransportEnabled: "true",
   usersAllowedToStream: "",
   serverElectionPeriodMs: 2000,
   audioBitrateKbps: 65,

--- a/yew-ui/src/components/login.rs
+++ b/yew-ui/src/components/login.rs
@@ -24,7 +24,14 @@ use crate::constants::login_url;
 #[function_component(Login)]
 pub fn login() -> Html {
     let login = Callback::from(|_: MouseEvent| match login_url() {
-        Ok(url) => {
+        Ok(mut url) => {
+            // Check if there's a returnTo parameter in the current URL
+            if let Some(win) = window().location().search().ok() {
+                if !win.is_empty() {
+                    // Append the query parameters from the current URL to the backend login URL
+                    url = format!("{}{}", url, win);
+                }
+            }
             let _ = window().location().set_href(&url);
         }
         Err(e) => log::error!("Failed to get login URL: {e:?}"),

--- a/yew-ui/src/pages/meeting.rs
+++ b/yew-ui/src/pages/meeting.rs
@@ -53,7 +53,6 @@ pub fn meeting_page(props: &MeetingPageProps) -> Html {
     // Auth check effect
     {
         let auth_checked = auth_checked.clone();
-        let navigator = navigator.clone();
         use_effect_with((), move |_| {
             log::info!("OAuth enabled check: {}", oauth_enabled().unwrap_or(false));
             if oauth_enabled().unwrap_or(false) {
@@ -66,7 +65,17 @@ pub fn meeting_page(props: &MeetingPageProps) -> Html {
                         }
                         Err(e) => {
                             log::warn!("No active session, redirecting to login. Error: {e:?}");
-                            navigator.push(&Route::Login);
+                            // Redirect to login with returnTo parameter to preserve meeting URL
+                            if let Some(win) = window() {
+                                if let Ok(current_url) = win.location().href() {
+                                    let login_url = format!(
+                                        "/login?returnTo={}",
+                                        urlencoding::encode(&current_url)
+                                    );
+                                    log::info!("Redirecting to: {}", login_url);
+                                    let _ = win.location().set_href(&login_url);
+                                }
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
Fixes https://github.com/security-union/videocall-rs/issues/481


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end returnTo support across OAuth (store in DB, use on callback) and UI (pass/encode current URL), plus enables WebTransport by default.
> 
> - **Auth/Backend**:
>   - Accepts `returnTo` in `/login` (`LoginQuery`) and persists it with OAuth request via `generate_and_store_oauth_request`.
>   - DB migration: add `oauth_requests.return_to` column.
>   - Includes `return_to` in `OAuthRequest` and reads it in `fetch_oauth_request`.
>   - After callback, redirects to stored `return_to` or falls back to `after_login_url` (default `/`).
> - **UI**:
>   - `components/login.rs`: appends current URL query to backend login URL.
>   - `pages/meeting.rs`: on no session, redirects to `/login?returnTo=<encoded current URL>`; adds `urlencoding` dependency.
>   - `scripts/config.js`: sets `webTransportEnabled` to `true`.
> - **Diagnostics**:
>   - Minor wasm receiver loop condition cleanup to keep broadcast channel alive.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e50fbbce2336679ee25cf23d89b3ed7325599ce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->