### PR TITLE
feature:  crop peer canvas video

### DIFF
--- a/yew-ui/src/components/icons/crop.rs
+++ b/yew-ui/src/components/icons/crop.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ *
+ * at your option.
+ *
+ * Unless you explicitly state otherwise, any contribution intentionally
+ * submitted for inclusion in the work by you, as defined in the Apache-2.0
+ * license, shall be dual licensed as above, without any additional terms or
+ * conditions.
+ */
+
+use yew::prelude::*;
+
+#[function_component(CropIcon)]
+pub fn crop_icon() -> Html {
+    html! {
+        <svg
+            class="w-8"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+        >
+            <path d="M6 3v12a3 3 0 003 3h12" />
+            <path d="M18 21V9a3 3 0 00-3-3H3" />
+        </svg>
+    }
+}

--- a/yew-ui/src/components/icons/mod.rs
+++ b/yew-ui/src/components/icons/mod.rs
@@ -20,5 +20,6 @@ pub mod digital_ocean;
 pub mod discord;
 pub mod mic;
 pub mod peer;
+pub mod crop;
 pub mod push_pin;
 pub mod youtube;

--- a/yew-ui/static/global.css
+++ b/yew-ui/static/global.css
@@ -38,6 +38,10 @@
   width: 100vw;
   height: 100vh;
   z-index: 0;
+
+  /* No borders for full bleed */
+  border-width: 0;
+  border-radius: 0;
 }
 .grid-item.full-bleed .canvas-container,
 .grid-item.full-bleed canvas {
@@ -1251,10 +1255,40 @@ body {
   display: block !important;
 }
 
+.grid-item .canvas-container .crop-icon {
+  position: absolute !important;
+  top: 8px !important;
+  right: 88px !important; /* 8px edge + mic + pin + 8px gaps */
+  left: auto !important;
+  transform: none !important;
+  opacity: 0.6 !important;
+  background-color: rgba(0, 0, 0, 0.6) !important;
+  border-radius: 50% !important;
+  padding: 6px !important;
+  text-align: center !important;
+  line-height: 1 !important;
+  cursor: pointer !important;
+  z-index: 10 !important;
+  transition: opacity 0.2s ease !important;
+  border: none !important;
+  visibility: hidden !important;
+}
+
+.grid-item .canvas-container .crop-icon svg {
+  width: 20px !important;
+  height: 20px !important;
+  display: block !important;
+}
+
 /* Hide pin icon by default on desktop, show on hover */
 @media (min-width: 768px) {
   .grid-item .canvas-container .pin-icon { opacity: 0 !important; }
   .grid-item .canvas-container:hover .pin-icon {
+    visibility: visible !important;
+    opacity: 0.6 !important;
+  }
+  .grid-item .canvas-container .crop-icon { opacity: 0 !important; }
+  .grid-item .canvas-container:hover .crop-icon {
     visibility: visible !important;
     opacity: 0.6 !important;
   }
@@ -1263,7 +1297,11 @@ body {
 /* Hide pin icon on mobile – tap tile to pin instead */
 @media (max-width: 767px) {
   .grid-item .canvas-container .pin-icon { display: none !important; }
+  .grid-item .canvas-container .crop-icon { display: none !important; }
 }
+
+.grid-item .canvas-container canvas.cropped { object-fit: cover !important; }
+.grid-item .canvas-container canvas.uncropped { object-fit: contain !important; }
 
 /* Copy toast and sparkles animation (Apple-style subtle pop + sparkles) */
 .copy-button {

--- a/yew-ui/static/style.css
+++ b/yew-ui/static/style.css
@@ -188,6 +188,13 @@ h3 {
   align-items: center;
   overflow: hidden; /* Prevent content like oversized canvas from breaking layout */
   background-color: #2d2d2d; /* Slightly different background for items */
+
+  /* Border for visual separation */
+  border-width: 2px;
+  border-style: solid;
+  border-color: rgb(68, 68, 68);
+  border-image: initial;
+  border-radius: 10px;
 }
 
 /* --- Layouts for specific number of peers --- */
@@ -471,7 +478,6 @@ h3 {
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
 }
 
 canvas {
@@ -691,6 +697,27 @@ select {
   align-items: center;
   justify-content: center;
   z-index: 2;
+}
+
+.crop-icon {
+  visibility: hidden;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2em;
+  opacity: 0.6;
+  background-color: black;
+  border-radius: 50%;
+  padding: 10px;
+  text-align: center;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.grid-item:hover .crop-icon {
+  visibility: visible;
 }
 
 /* No additional local positioning; unified in global.css to match mic size */
@@ -1408,4 +1435,3 @@ select {
     right: 6px;
   }
 }
-


### PR DESCRIPTION
- cleaned up the merge mess I was dragging around on #491 
- crop button for each canvas
- rounded corners on each canvas

uncropped:
<img width="1330" height="826" alt="image" src="https://github.com/user-attachments/assets/975f7402-b103-4814-8935-da5c370b0c04" />

crop button:
<img width="118" height="68" alt="image" src="https://github.com/user-attachments/assets/958375f6-fabd-422a-91ae-50b391e5f569" />

cropped one canvas:
<img width="1327" height="834" alt="image" src="https://github.com/user-attachments/assets/b48180e1-099f-4888-a7af-9d133308c029" />