### PR TITLE
Add Pre push

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script is run before a push to the remote repository.
+# It runs cargo fmt and cargo clippy to ensure the code is formatted and free of warnings.
+# If the code is not formatted or free of warnings, the push is aborted.
+
+set -e 
+echo "Running Clippy before push..."
+cargo clippy -- -D warnings
+echo "Running Fmt before push..."
+cargo fmt -- --check
+echo "Pushing to remote repository..."

--- a/yew-ui/src/main.rs
+++ b/yew-ui/src/main.rs
@@ -109,3 +109,4 @@ fn main() {
     console_error_panic_hook::set_once();
     yew::Renderer::<AppRoot>::new().render();
 }
+ 


### PR DESCRIPTION
This pull request adds pre-push for verifying user code. The hook will prevent pushes that contain Clippy warnings or errors and also format the rust code.

Reference issue #501 