### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum",
  "clap",
@@ -7085,7 +7085,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -7106,7 +7106,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "1.1.29"
+version = "2.0.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "approx",
@@ -7251,7 +7251,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7276,7 +7276,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "3.0.1"
+version = "4.0.0"
 dependencies = [
  "protobuf 3.7.1",
  "serde",
@@ -7286,7 +7286,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.33"
+version = "1.1.34"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,7 +54,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-types = { path= "../videocall-types", version = "3.0.1" }
+videocall-types = { path= "../videocall-types", version = "4.0.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = { workspace = true }
@@ -64,7 +64,7 @@ postgres-types = { version = "0.2.11", features = ["with-chrono-0_4"] }
 [dev-dependencies]
 url = "2"
 serial_test = "3"
-videocall-types = { path = "../videocall-types", version = "3.0.1", features = ["testing"] }
+videocall-types = { path = "../videocall-types", version = "4.0.0", features = ["testing"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
 

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.15](https://github.com/security-union/videocall-rs/compare/bot-v1.0.14...bot-v1.0.15) - 2026-01-27
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.0.14](https://github.com/security-union/videocall-rs/compare/bot-v1.0.13...bot-v1.0.14) - 2025-11-30
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.14"
+version = "1.0.15"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 # Remove WebSocket, add WebTransport
 web-transport-quinn = { workspace = true }
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "3.0.1" }
+videocall-types = { path= "../videocall-types", version = "4.0.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.0...neteq-v0.8.1) - 2026-01-27
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.8.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.7.1...neteq-v0.8.0) - 2025-11-30
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.5](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.4...videocall-cli-v3.0.5) - 2026-01-27
+
+### Other
+
+- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
+
 ### Changed
 
 - **BREAKING**: Updated protobuf enums with `_UNKNOWN = 0` variants. Enum values shifted by 1. Must update server simultaneously.

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.4"
+version = "3.0.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -41,5 +41,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "3.0.1"
+version = "4.0.0"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.29...videocall-client-v2.0.0) - 2026-01-27
+
+### Other
+
+- breaking change: Protobuf enums should always have an _UNSPECIFIED = 0 variant ([#537](https://github.com/security-union/videocall-rs/pull/537))
+- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
+- Revert "Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))" ([#534](https://github.com/security-union/videocall-rs/pull/534))
+- Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))
+- Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))
+- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
+
 ## [1.1.29](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.28...videocall-client-v1.1.29) - 2025-11-30
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "1.1.29"
+version = "2.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "3.0.1" }
+videocall-types = { path= "../videocall-types", version = "4.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
@@ -37,8 +37,8 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.10" }
-neteq = { path = "../neteq", features = ["web"], version = "0.8.0", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.11" }
+neteq = { path = "../neteq", features = ["web"], version = "0.8.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.10...videocall-codecs-v0.1.11) - 2026-01-27
+
+### Other
+
+- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
+
 ## [0.1.10](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.9...videocall-codecs-v0.1.10) - 2025-11-30
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.11...videocall-sdk-v0.1.12) - 2026-01-27
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.11](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.10...videocall-sdk-v0.1.11) - 2025-11-30
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "3.0.1" }
+videocall-types = { path = "../videocall-types", version = "4.0.0" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v3.0.1...videocall-types-v4.0.0) - 2026-01-27
+
+### Other
+
+- breaking change: Protobuf enums should always have an _UNSPECIFIED = 0 variant ([#537](https://github.com/security-union/videocall-rs/pull/537))
+- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
+- Fix GLIBC compatibility and make DATABASE_ENABLED optional ([#519](https://github.com/security-union/videocall-rs/pull/519))
+- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
+
 ## [3.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v3.0.0...videocall-types-v3.0.1) - 2025-08-18
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.34](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.33...videocall-ui-v1.1.34) - 2026-01-27
+
+### Added
+
+- self video is a canvas tile ([#517](https://github.com/security-union/videocall-rs/pull/517))
+
+### Other
+
+- revert feature: self video is a canvas tile ([#538](https://github.com/security-union/videocall-rs/pull/538))
+- adding feature flag for firefox support ([#536](https://github.com/security-union/videocall-rs/pull/536))
+- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
+- Revert "Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))" ([#534](https://github.com/security-union/videocall-rs/pull/534))
+- Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))
+- Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))
+- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
+- Add Pre push script ([#502](https://github.com/security-union/videocall-rs/pull/502))
+
 ## [1.1.33](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.32...videocall-ui-v1.1.33) - 2025-11-30
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.33"
+version = "1.1.34"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -15,8 +15,8 @@ readme = "../README.md"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-types = { path= "../videocall-types", version = "3.0.1" }
-videocall-client = { path= "../videocall-client", version = "1.1.29" }
+videocall-types = { path= "../videocall-types", version = "4.0.0" }
+videocall-client = { path= "../videocall-client", version = "2.0.0" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
@@ -25,7 +25,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.8.0", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.8.1", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 3.0.1 -> 4.0.0 (⚠ API breaking changes)
* `bot`: 1.0.14 -> 1.0.15
* `neteq`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `videocall-codecs`: 0.1.10 -> 0.1.11
* `videocall-client`: 1.1.29 -> 2.0.0 (⚠ API breaking changes)
* `videocall-cli`: 3.0.4 -> 3.0.5 (✓ API compatible changes)
* `videocall-ui`: 1.1.33 -> 1.1.34
* `videocall-sdk`: 0.1.11 -> 0.1.12

### ⚠ `videocall-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VideoMetadata.codec in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/media_packet.rs:582

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant MediaType::VIDEO 0 -> 1 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/media_packet.rs:304
  variant MediaType::AUDIO 1 -> 2 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/media_packet.rs:306
  variant MediaType::SCREEN 2 -> 3 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/media_packet.rs:308
  variant MediaType::HEARTBEAT 3 -> 4 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/media_packet.rs:310
  variant MediaType::RTT 4 -> 5 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/media_packet.rs:312
  variant PacketType::RSA_PUB_KEY 0 -> 1 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:193
  variant PacketType::AES_KEY 1 -> 2 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:195
  variant PacketType::MEDIA 2 -> 3 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:197
  variant PacketType::CONNECTION 3 -> 4 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:199
  variant PacketType::DIAGNOSTICS 4 -> 5 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:201
  variant PacketType::HEALTH 5 -> 6 in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:203

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant MediaType:MEDIA_TYPE_UNKNOWN in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/media_packet.rs:302
  variant PacketType:PACKET_TYPE_UNKNOWN in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:191
  variant PacketType:MEETING in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:205
```

### ⚠ `videocall-client` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VideoCallClientOptions.on_meeting_info in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-client/src/client/video_call_client.rs:118
  field VideoCallClientOptions.on_meeting_ended in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-client/src/client/video_call_client.rs:121

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant PeerDecodeError:UnknownMediaType in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-client/src/decode/peer_decode_manager.rs:51
  variant PeerDecodeError:UnknownPacketType in /tmp/.tmpNMo5ZQ/videocall-rs/videocall-client/src/decode/peer_decode_manager.rs:52

--- failure pub_static_missing: pub static is missing ---

Description:
A public static is missing, renamed, or made private.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_static_missing.ron

Failed in:
  VIDEO_CODEC in file /tmp/.tmprrmJzS/videocall-client/src/constants.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v3.0.1...videocall-types-v4.0.0) - 2026-01-27

### Other

- breaking change: Protobuf enums should always have an _UNSPECIFIED = 0 variant ([#537](https://github.com/security-union/videocall-rs/pull/537))
- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
- Fix GLIBC compatibility and make DATABASE_ENABLED optional ([#519](https://github.com/security-union/videocall-rs/pull/519))
- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
</blockquote>

## `bot`

<blockquote>

## [1.0.15](https://github.com/security-union/videocall-rs/compare/bot-v1.0.14...bot-v1.0.15) - 2026-01-27

### Other

- update Cargo.lock dependencies
</blockquote>

## `neteq`

<blockquote>

## [0.8.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.0...neteq-v0.8.1) - 2026-01-27

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.11](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.10...videocall-codecs-v0.1.11) - 2026-01-27

### Other

- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
</blockquote>

## `videocall-client`

<blockquote>

## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.29...videocall-client-v2.0.0) - 2026-01-27

### Other

- breaking change: Protobuf enums should always have an _UNSPECIFIED = 0 variant ([#537](https://github.com/security-union/videocall-rs/pull/537))
- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
- Revert "Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))" ([#534](https://github.com/security-union/videocall-rs/pull/534))
- Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))
- Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))
- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.5](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.4...videocall-cli-v3.0.5) - 2026-01-27

### Other

- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))

### Changed

- **BREAKING**: Updated protobuf enums with `_UNKNOWN = 0` variants. Enum values shifted by 1. Must update server simultaneously.
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.34](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.33...videocall-ui-v1.1.34) - 2026-01-27

### Added

- self video is a canvas tile ([#517](https://github.com/security-union/videocall-rs/pull/517))

### Other

- revert feature: self video is a canvas tile ([#538](https://github.com/security-union/videocall-rs/pull/538))
- adding feature flag for firefox support ([#536](https://github.com/security-union/videocall-rs/pull/536))
- Fix firefox support by sending vp8 instead of vp9 ([#535](https://github.com/security-union/videocall-rs/pull/535))
- Revert "Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))" ([#534](https://github.com/security-union/videocall-rs/pull/534))
- Revert "Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))" ([#533](https://github.com/security-union/videocall-rs/pull/533))
- Firefox support ([#522](https://github.com/security-union/videocall-rs/pull/522))
- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
- Add Pre push script ([#502](https://github.com/security-union/videocall-rs/pull/502))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.11...videocall-sdk-v0.1.12) - 2026-01-27

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).