### PR TITLE
fix problem when user cancel share screen and After disabling screenshare, the peer screen did not turn full fullscreen. #465

### DIFF
--- a/yew-ui/src/components/video_control_buttons.rs
+++ b/yew-ui/src/components/video_control_buttons.rs
@@ -111,15 +111,26 @@ pub fn camera_button(props: &CameraButtonProps) -> Html {
 #[derive(Properties, PartialEq)]
 pub struct ScreenShareButtonProps {
     pub active: bool,
+    pub disabled: bool,
     pub onclick: Callback<MouseEvent>,
 }
 
 #[function_component(ScreenShareButton)]
 pub fn screen_share_button(props: &ScreenShareButtonProps) -> Html {
-    let class = classes!("video-control-button", props.active.then_some("active"));
+    let mut class = classes!("video-control-button", props.active.then_some("active"));
+    
+    let onclick = if props.disabled {
+        Callback::noop()
+    } else {
+        props.onclick.clone()
+    };
+
+    if props.disabled {
+       class.push("disabled");
+    }
 
     html! {
-        <button {class} onclick={props.onclick.clone()}>
+        <button {class} disabled={props.disabled} onclick={onclick}>
             {
                 if props.active {
                     html! {


### PR DESCRIPTION
Prepare fix for several small bugs:
-  Bug with share screen button: when user press share screen button and then cancel window where should select what to share, screen share button remains on;
- After disabling screenshare, the peer screen did not turn full fullscreen;
-  bug when browser bar with stop sharing button is not always disactivated when user stop share of screen.