### PR TITLE
tweaks necessary to make overhauled charts work

### DIFF
--- a/helm-videocall-deployment/infrastructure/cert-manager-issuer/route53-issuer.yaml
+++ b/helm-videocall-deployment/infrastructure/cert-manager-issuer/route53-issuer.yaml
@@ -1,4 +1,4 @@
-piVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-prod

--- a/helm-videocall-deployment/us-east/grafana/values.yaml
+++ b/helm-videocall-deployment/us-east/grafana/values.yaml
@@ -36,7 +36,7 @@ grafana:
     enabled: true
     ingressClassName: nginx
     annotations:
-      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      cert-manager.io/issuer: "letsencrypt-prod"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
     hosts:
       - grafana.videocall.rs

--- a/helm/K3S_DEPLOYMENT_GUIDE.md
+++ b/helm/K3S_DEPLOYMENT_GUIDE.md
@@ -117,7 +117,7 @@ echo "Ingress IP Address: $IPADDR"
 Ensure you validate this IP address before proceeding, reset the environment variable if necessary.  Then install NGINX:
 ```bash
 # Install NGINX Ingress Controller
-helm install ingress-nginx helm/ingress-nginx \
+helm install ingress-nginx helm-videocall-deployment/infrastructure/ingress-nginx \
   --create-namespace \
   --namespace ingress-nginx \
   --version 4.13.0 \

--- a/helm/videocall/templates/_helpers.tpl
+++ b/helm/videocall/templates/_helpers.tpl
@@ -91,18 +91,18 @@ Generate the config.js content for the UI component.
 This is injected as a ConfigMap and mounted into the UI container.
 */}}
 {{- define "videocall.ui.configjs" -}}
-window.CONFIG = {
-  API_BASE_URL: {{ .Values.ui.runtimeConfig.apiBaseUrl | quote }},
-  WS_URL: {{ .Values.ui.runtimeConfig.wsUrl | quote }},
-  WEB_TRANSPORT_HOST: {{ .Values.ui.runtimeConfig.webTransportHost | quote }},
-  OAUTH_ENABLED: {{ .Values.ui.runtimeConfig.oauthEnabled | quote }},
-  E2EE_ENABLED: {{ .Values.ui.runtimeConfig.e2eeEnabled | quote }},
-  WEB_TRANSPORT_ENABLED: {{ .Values.ui.runtimeConfig.webTransportEnabled | quote }},
-  USERS_ALLOWED_TO_STREAM: {{ .Values.ui.runtimeConfig.usersAllowedToStream | quote }},
-  SERVER_ELECTION_PERIOD_MS: {{ .Values.ui.runtimeConfig.serverElectionPeriodMs }},
-  AUDIO_BITRATE_KBPS: {{ .Values.ui.runtimeConfig.audioBitrateKbps }},
-  VIDEO_BITRATE_KBPS: {{ .Values.ui.runtimeConfig.videoBitrateKbps }},
-  SCREEN_BITRATE_KBPS: {{ .Values.ui.runtimeConfig.screenBitrateKbps }}
+window.__APP_CONFIG = {
+  apiBaseUrl: {{ .Values.ui.runtimeConfig.apiBaseUrl | quote }},
+  wsUrl: {{ .Values.ui.runtimeConfig.wsUrl | quote }},
+  webTransportHost: {{ .Values.ui.runtimeConfig.webTransportHost | quote }},
+  oauthEnabled: {{ .Values.ui.runtimeConfig.oauthEnabled | quote }},
+  e2eeEnabled: {{ .Values.ui.runtimeConfig.e2eeEnabled | quote }},
+  webTransportEnabled: {{ .Values.ui.runtimeConfig.webTransportEnabled | quote }},
+  usersAllowedToStream: {{ .Values.ui.runtimeConfig.usersAllowedToStream | quote }},
+  serverElectionPeriodMs: {{ .Values.ui.runtimeConfig.serverElectionPeriodMs }},
+  audioBitrateKbps: {{ .Values.ui.runtimeConfig.audioBitrateKbps }},
+  videoBitrateKbps: {{ .Values.ui.runtimeConfig.videoBitrateKbps }},
+  screenBitrateKbps: {{ .Values.ui.runtimeConfig.screenBitrateKbps }}
 };
 {{- end }}
 

--- a/helm/videocall/templates/webtransport-certificate.yaml
+++ b/helm/videocall/templates/webtransport-certificate.yaml
@@ -9,7 +9,7 @@ spec:
   secretName: {{ .Values.webtransport.tlsSecret }}
   issuerRef:
     name: {{ .Values.webtransport.certificate.issuerName }}
-    kind: ClusterIssuer
+    kind: Issuer
   dnsNames:
     - {{ .Values.webtransport.certificateDomain }}
 {{- end }}


### PR DESCRIPTION
* use only the namespace scoped cert manager `issuer`
* fix ui config.js (camelcase names vs all caps)
* correct path to ingress chart