### PR TITLE
Revert "Firefox support"

### DIFF
--- a/videocall-client/src/encode/microphone_encoder.rs
+++ b/videocall-client/src/encode/microphone_encoder.rs
@@ -277,27 +277,15 @@ impl MicrophoneEncoder {
             let track_settings = audio_track.get_settings();
 
             // Sample Rate hasn't been added to the web_sys crate
-            // Firefox doesn't report sampleRate in MediaTrackSettings, so we need a fallback
             let input_rate: u32 =
                 match js_sys::Reflect::get(&track_settings, &JsValue::from_str("sampleRate")) {
                     Ok(v) => match v.as_f64() {
                         Some(f) => f as u32,
                         None => {
-                            // Firefox fallback: create a temporary AudioContext to get system sample rate
-                            log::info!("sampleRate not in track settings (Firefox), using AudioContext default");
-                            match AudioContext::new() {
-                                Ok(temp_ctx) => {
-                                    let rate = temp_ctx.sample_rate() as u32;
-                                    let _ = temp_ctx.close();
-                                    rate
-                                }
-                                Err(e) => {
-                                    if let Some(cb) = &on_error {
-                                        cb.emit(format!("Could not determine microphone sample rate: {e:?}"));
-                                    }
-                                    return;
-                                }
+                            if let Some(cb) = &on_error {
+                                cb.emit("Could not determine microphone sample rate".to_string());
                             }
+                            return;
                         }
                     },
                     Err(e) => {

--- a/yew-ui/src/components/browser_compatibility.rs
+++ b/yew-ui/src/components/browser_compatibility.rs
@@ -60,9 +60,16 @@ impl BrowserCompatibility {
     fn check_browser_compatibility() -> Option<String> {
         let window = web_sys::window().unwrap();
 
+        // First check if this is Firefox and block it specifically
+        if Self::is_firefox() {
+            return Some(
+                "🦊 Firefox Detected! Unfortunately, videocall.rs doesn't support Firefox due to incomplete MediaStreamTrackProcessor implementation. Please use Desktop Chrome, Chromium, Brave, or Edge for the best experience. 🚀".to_string()
+            );
+        }
+
         let mut missing_features = Vec::new();
 
-        // Check for MediaStreamTrackProcessor (native or polyfill from index.html)
+        // Check for MediaStreamTrackProcessor
         if js_sys::Reflect::get(&window, &JsValue::from_str("MediaStreamTrackProcessor"))
             .unwrap()
             .is_undefined()
@@ -70,7 +77,7 @@ impl BrowserCompatibility {
             missing_features.push("MediaStreamTrackProcessor");
         }
 
-        // Check for VideoEncoder (WebCodecs API - supported in Firefox 130+, Chrome 94+)
+        // Check for VideoEncoder
         if js_sys::Reflect::get(&window, &JsValue::from_str("VideoEncoder"))
             .unwrap()
             .is_undefined()
@@ -78,33 +85,10 @@ impl BrowserCompatibility {
             missing_features.push("VideoEncoder");
         }
 
-        // Check for VideoDecoder (WebCodecs API)
-        if js_sys::Reflect::get(&window, &JsValue::from_str("VideoDecoder"))
-            .unwrap()
-            .is_undefined()
-        {
-            missing_features.push("VideoDecoder");
-        }
-
-        // Check for OffscreenCanvas (required by MediaStreamTrackProcessor polyfill)
-        if js_sys::Reflect::get(&window, &JsValue::from_str("OffscreenCanvas"))
-            .unwrap()
-            .is_undefined()
-        {
-            missing_features.push("OffscreenCanvas");
-        }
-
         if !missing_features.is_empty() {
-            let browser_hint = if Self::is_firefox() {
-                "Firefox 130+ is required for WebCodecs support."
-            } else {
-                "We recommend using Desktop Chrome, Chromium, Brave, Edge, or Firefox 130+."
-            };
-
             Some(format!(
-                "Hey friend! 👋 Thanks for trying videocall.rs! We're working hard to support your browser, but we need a few more modern features to make the magic happen. Your browser is missing: {}. {} 🚀",
-                missing_features.join(", "),
-                browser_hint
+                "Hey friend! 👋 Thanks for trying videocall.rs! We're working hard to support your browser, but we need a few more modern features to make the magic happen. Your browser is missing: {}. We recommend using Desktop Chrome, Chromium, Brave, or Edge for the best experience. 🚀",
+                missing_features.join(", ")
             ))
         } else {
             None


### PR DESCRIPTION
Reverts security-union/videocall-rs#522

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts prior Firefox accommodations and explicitly blocks Firefox usage.
> 
> - Microphone encoder: removes fallback AudioContext-based sample rate detection; if `sampleRate` is absent in track settings, emit error and abort initialization
> - Browser compatibility: detects Firefox via UA and returns a hard block message; trims feature checks to `MediaStreamTrackProcessor` and `VideoEncoder` and updates guidance to recommend Chrome/Chromium/Brave/Edge
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f09f586447f37a89de18cbd9bf7e60fa0dabb9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->