### PR TITLE
fix: NetEQ diagnostics — operation counters, RFC 3550 jitter, click-to-zoom charts

### DIFF
--- a/neteq/src/web.rs
+++ b/neteq/src/web.rs
@@ -117,9 +117,9 @@ impl WebNetEq {
     /// Get current NetEq statistics as a JS object.
     #[wasm_bindgen(js_name = getStatistics)]
     pub fn get_statistics(&self) -> Result<JsValue, JsValue> {
-        let neteq_ref = self.neteq.borrow();
+        let mut neteq_ref = self.neteq.borrow_mut();
         let neteq = neteq_ref
-            .as_ref()
+            .as_mut()
             .ok_or_else(|| JsValue::from_str("NetEq not initialized. Call init() first."))?;
 
         let stats = neteq.get_statistics();

--- a/yew-ui/src/constants.rs
+++ b/yew-ui/src/constants.rs
@@ -50,6 +50,10 @@ pub struct RuntimeConfig {
     pub video_bitrate_kbps: u32,
     #[serde(rename = "screenBitrateKbps")]
     pub screen_bitrate_kbps: u32,
+    #[serde(rename = "matomoBaseUrl", default)]
+    pub matomo_base_url: Option<String>,
+    #[serde(rename = "matomoSiteId", default)]
+    pub matomo_site_id: Option<u32>,
     // ui_url intentionally omitted; unused by the UI
 }
 

--- a/yew-ui/src/pages/home.rs
+++ b/yew-ui/src/pages/home.rs
@@ -47,7 +47,7 @@ pub fn home() -> Html {
         load_username_from_storage().unwrap_or_default()
     };
 
-    // If we already have a stored username, set the Matomo user id early
+    // If we already have a stored username, set the Matomo user id early (no-op when Matomo disabled)
     use_effect_with((), {
         let uid = existing_username.clone();
         move |_| {
@@ -75,7 +75,7 @@ pub fn home() -> Html {
             }
             save_username_to_storage(&username);
             username_ctx.set(Some(username));
-            // Set Matomo user id for attribution
+            // Set Matomo user id for attribution (no-op when Matomo disabled)
             if let Some(name) = &*username_ctx {
                 matomo_logger::set_user_id(name);
             }
@@ -118,7 +118,7 @@ pub fn home() -> Html {
             let meeting_id = generate_meeting_id();
             save_username_to_storage(&username);
             username_ctx.set(Some(username));
-            // Set Matomo user id for attribution
+            // Set Matomo user id for attribution (no-op when Matomo disabled)
             if let Some(name) = &*username_ctx {
                 matomo_logger::set_user_id(name);
             }

--- a/yew-ui/static/style.css
+++ b/yew-ui/static/style.css
@@ -1098,6 +1098,80 @@ select {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   min-height: 300px;
   padding: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.chart-container:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Chart Zoom Modal */
+.chart-zoom-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.85);
+  z-index: 2100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chart-zoom-modal {
+  background-color: #242526;
+  border-radius: 12px;
+  padding: 0;
+  width: 85vw;
+  height: 80vh;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+}
+
+.chart-zoom-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  background-color: #18191a;
+  border-bottom: 1px solid #3a3b3c;
+  flex-shrink: 0;
+}
+
+.chart-zoom-header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: white;
+}
+
+.chart-zoom-content {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  overflow: hidden;
+}
+
+.chart-zoom-content .neteq-advanced-chart {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.chart-zoom-content .neteq-advanced-chart svg {
+  max-width: none;
+  flex: 1;
+  width: 100%;
+  height: 100%;
 }
 
 /* Peer Selection Styles */


### PR DESCRIPTION
## Summary

- **Fix operation counter bugs**: Array index mapping mismatch caused operation rates (accelerate, preemptive expand, etc.) to be attributed to wrong counters. Out-of-bounds indices for ComfortNoise/Dtmf/Undefined variants.
- **Fix rate freeze after mute**: Windowed per-second rates (normal/s, expand/s, etc.) froze at last value when peer muted because `update_operation_rates()` was only called from `record_decode_operation()`. Added `maybe_decay_stale_rates()` called from `get_statistics()`.
- **Replace jitter with RFC 3550**: Wall-clock inter-arrival jitter measured browser scheduling noise (min always 0, mute transitions gave 9000ms+ spikes). Replaced with RFC 3550 §6.4.1 interarrival jitter using RTP timestamps and EWMA smoothing.
- **Add diagnostics panel improvements**: Stale data detection hides frozen metrics when peer is muted. All graph titles clarified as audio-specific. Jitter chart simplified to single RFC 3550 line. "JITTER PEAKS" renamed to "JITTER SPIKES" (windowed counter that resets on >1s gaps).
- **Click-to-zoom charts**: Click any 290×200px chart to open it in an 85vw×80vh modal overlay. SVG scaling with viewBox fills the modal.
- **5s throttled worker logging**: Structured stats logged every 5 seconds from NetEQ worker for diagnostics (stats emission to UI remains at 1Hz).
- **Make Matomo analytics configurable**: Matomo base URL and site ID are now read from runtime config (`matomoBaseUrl`, `matomoSiteId` in `window.__APP_CONFIG`). If neither is set, Matomo is fully disabled (no snippet injected, logging level Off). To enable Matomo, add both fields to `config.js` or the Helm configmap.

## Test plan

- [ ] Start a 2-party call with audio, verify diagnostics panel shows live metrics
- [ ] Verify operation rates (normal/s, expand/s, accel/s) update in real-time
- [ ] Mute peer audio, verify rates decay to 0 and stale metrics show "--"
- [ ] Unmute, verify metrics resume
- [ ] Check jitter value is stable (RFC 3550 EWMA, not jumping wildly)
- [ ] Click a chart, verify it opens full-size in modal overlay
- [ ] Close modal via backdrop click, close button
- [ ] Check browser console for `[NetEQ Worker]` log lines every ~5s (not 1s)
- [ ] Verify app loads without Matomo config (no errors, analytics disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)