### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.0.15"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7106,7 +7106,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -7251,7 +7251,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7286,7 +7286,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.34"
+version = "1.1.35"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/security-union/videocall-rs/compare/bot-v1.0.15...bot-v1.1.0) - 2026-02-04
+
+### Added
+
+- *(actix-api)* Consolidate WebTransport to use actor model ([#551](https://github.com/security-union/videocall-rs/pull/551))
+
 ## [1.0.15](https://github.com/security-union/videocall-rs/compare/bot-v1.0.14...bot-v1.0.15) - 2026-01-27
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.0.15"
+version = "1.1.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v2.0.0...videocall-client-v3.0.0) - 2026-02-04
+
+### Other
+
+- Add screen share state callback to videocall-client ([#546](https://github.com/security-union/videocall-rs/pull/546))
+
 ## [2.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v1.1.29...videocall-client-v2.0.0) - 2026-01-27
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.12...videocall-sdk-v0.1.13) - 2026-02-04
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.11...videocall-sdk-v0.1.12) - 2026-01-27
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.35](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.34...videocall-ui-v1.1.35) - 2026-02-04
+
+### Other
+
+- Add screen share state callback to videocall-client ([#546](https://github.com/security-union/videocall-rs/pull/546))
+
 ## [1.1.34](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.33...videocall-ui-v1.1.34) - 2026-01-27
 
 ### Added

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.34"
+version = "1.1.35"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "4.0.0" }
-videocall-client = { path= "../videocall-client", version = "2.0.0" }
+videocall-client = { path= "../videocall-client", version = "3.0.0" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `bot`: 1.0.15 -> 1.1.0
* `videocall-client`: 2.0.0 -> 3.0.0 (⚠ API breaking changes)
* `videocall-ui`: 1.1.34 -> 1.1.35
* `videocall-sdk`: 0.1.12 -> 0.1.13

### ⚠ `videocall-client` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  videocall_client::encode::ScreenEncoder::new now takes 4 parameters instead of 3, in /tmp/.tmppgHJ6x/videocall-rs/videocall-client/src/encode/screen_encoder.rs:99
  videocall_client::ScreenEncoder::new now takes 4 parameters instead of 3, in /tmp/.tmppgHJ6x/videocall-rs/videocall-client/src/encode/screen_encoder.rs:99
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `bot`

<blockquote>

## [1.1.0](https://github.com/security-union/videocall-rs/compare/bot-v1.0.15...bot-v1.1.0) - 2026-02-04

### Added

- *(actix-api)* Consolidate WebTransport to use actor model ([#551](https://github.com/security-union/videocall-rs/pull/551))
</blockquote>

## `videocall-client`

<blockquote>

## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v2.0.0...videocall-client-v3.0.0) - 2026-02-04

### Other

- Add screen share state callback to videocall-client ([#546](https://github.com/security-union/videocall-rs/pull/546))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.35](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.34...videocall-ui-v1.1.35) - 2026-02-04

### Other

- Add screen share state callback to videocall-client ([#546](https://github.com/security-union/videocall-rs/pull/546))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.12...videocall-sdk-v0.1.13) - 2026-02-04

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).