### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7106,7 +7106,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "approx",
@@ -7251,7 +7251,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7286,7 +7286,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.35"
+version = "1.1.36"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v3.0.0...videocall-client-v3.0.1) - 2026-02-07
+
+### Other
+
+- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
+
 ## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v2.0.0...videocall-client-v3.0.0) - 2026-02-04
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,7 +37,7 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.11" }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.12" }
 neteq = { path = "../neteq", features = ["web"], version = "0.8.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.11...videocall-codecs-v0.1.12) - 2026-02-07
+
+### Other
+
+- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
+
 ## [0.1.11](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.10...videocall-codecs-v0.1.11) - 2026-01-27
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.13...videocall-sdk-v0.1.14) - 2026-02-07
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.12...videocall-sdk-v0.1.13) - 2026-02-04
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.36](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.35...videocall-ui-v1.1.36) - 2026-02-07
+
+### Other
+
+- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
+
 ## [1.1.35](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.34...videocall-ui-v1.1.35) - 2026-02-04
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.35"
+version = "1.1.36"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -16,7 +16,7 @@ readme = "../README.md"
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
 videocall-types = { path= "../videocall-types", version = "4.0.0" }
-videocall-client = { path= "../videocall-client", version = "3.0.0" }
+videocall-client = { path= "../videocall-client", version = "3.0.1" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-codecs`: 0.1.11 -> 0.1.12
* `videocall-client`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `videocall-ui`: 1.1.35 -> 1.1.36
* `videocall-sdk`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-codecs`

<blockquote>

## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.11...videocall-codecs-v0.1.12) - 2026-02-07

### Other

- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
</blockquote>

## `videocall-client`

<blockquote>

## [3.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v3.0.0...videocall-client-v3.0.1) - 2026-02-07

### Other

- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.36](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.35...videocall-ui-v1.1.36) - 2026-02-07

### Other

- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.13...videocall-sdk-v0.1.14) - 2026-02-07

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).