### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "approx",
@@ -7328,7 +7328,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-meeting-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
 ]
@@ -7407,7 +7407,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7442,7 +7442,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.35"
+version = "1.1.36"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.0" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
 videocall-types = { path= "../videocall-types", version = "4.0.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/meeting-api/Cargo.toml
+++ b/meeting-api/Cargo.toml
@@ -18,7 +18,7 @@ name = "meeting-api"
 path = "src/main.rs"
 
 [dependencies]
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.0" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
 
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v3.0.0...videocall-client-v4.0.0) - 2026-02-15
+
+### Other
+
+- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
+- Add component and integration testing for yew-ui ([#568](https://github.com/security-union/videocall-rs/pull/568))
+- Fix device selection ([#566](https://github.com/security-union/videocall-rs/pull/566))
+- Fix/screenshare integration branch ([#563](https://github.com/security-union/videocall-rs/pull/563))
+- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
+
 ## [3.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v2.0.0...videocall-client-v3.0.0) - 2026-02-04
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -37,7 +37,7 @@ yew = { version = "0.21" }
 yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.11" }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.12" }
 neteq = { path = "../neteq", features = ["web"], version = "0.8.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.11...videocall-codecs-v0.1.12) - 2026-02-15
+
+### Other
+
+- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
+
 ## [0.1.11](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.10...videocall-codecs-v0.1.11) - 2026-01-27
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-meeting-client/CHANGELOG.md
+++ b/videocall-meeting-client/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-meeting-client-v0.1.0) - 2026-02-15
+
+### Other
+
+- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))

--- a/videocall-meeting-client/Cargo.toml
+++ b/videocall-meeting-client/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 description = "Cross-platform REST client for the videocall.rs meeting API"
 
 [dependencies]
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.0" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/videocall-meeting-types/CHANGELOG.md
+++ b/videocall-meeting-types/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.0...videocall-meeting-types-v0.1.1) - 2026-02-15
+
+### Other
+
+- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))

--- a/videocall-meeting-types/Cargo.toml
+++ b/videocall-meeting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-meeting-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.13...videocall-sdk-v0.1.14) - 2026-02-15
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.12...videocall-sdk-v0.1.13) - 2026-02-04
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.36](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.35...videocall-ui-v1.1.36) - 2026-02-15
+
+### Other
+
+- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
+- Meeting backend API ([#601](https://github.com/security-union/videocall-rs/pull/601))
+- Add component and integration testing for yew-ui ([#568](https://github.com/security-union/videocall-rs/pull/568))
+- Fix device selection ([#566](https://github.com/security-union/videocall-rs/pull/566))
+- Fix/screenshare integration branch ([#563](https://github.com/security-union/videocall-rs/pull/563))
+- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
+
 ## [1.1.35](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.34...videocall-ui-v1.1.35) - 2026-02-04
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.35"
+version = "1.1.36"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -21,10 +21,10 @@ path = "src/main.rs"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path= "../videocall-client", version = "3.0.0" }
+videocall-client = { path= "../videocall-client", version = "4.0.0" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.0" }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.0" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
 videocall-types = { path= "../videocall-types", version = "4.0.0" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-meeting-types`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `videocall-meeting-client`: 0.1.0
* `videocall-codecs`: 0.1.11 -> 0.1.12
* `videocall-client`: 3.0.0 -> 4.0.0 (⚠ API breaking changes)
* `videocall-ui`: 1.1.35 -> 1.1.36 (✓ API compatible changes)
* `videocall-sdk`: 0.1.13 -> 0.1.14

### ⚠ `videocall-client` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  videocall_client::encode::CameraEncoder::new now takes 5 parameters instead of 4, in /tmp/.tmpKwnNWm/videocall-rs/videocall-client/src/encode/camera_encoder.rs:97
  videocall_client::CameraEncoder::new now takes 5 parameters instead of 4, in /tmp/.tmpKwnNWm/videocall-rs/videocall-client/src/encode/camera_encoder.rs:97
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-meeting-types`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.0...videocall-meeting-types-v0.1.1) - 2026-02-15

### Other

- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
</blockquote>

## `videocall-meeting-client`

<blockquote>

## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-meeting-client-v0.1.0) - 2026-02-15

### Other

- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.11...videocall-codecs-v0.1.12) - 2026-02-15

### Other

- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v3.0.0...videocall-client-v4.0.0) - 2026-02-15

### Other

- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
- Add component and integration testing for yew-ui ([#568](https://github.com/security-union/videocall-rs/pull/568))
- Fix device selection ([#566](https://github.com/security-union/videocall-rs/pull/566))
- Fix/screenshare integration branch ([#563](https://github.com/security-union/videocall-rs/pull/563))
- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.36](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.35...videocall-ui-v1.1.36) - 2026-02-15

### Other

- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
- Meeting backend API ([#601](https://github.com/security-union/videocall-rs/pull/601))
- Add component and integration testing for yew-ui ([#568](https://github.com/security-union/videocall-rs/pull/568))
- Fix device selection ([#566](https://github.com/security-union/videocall-rs/pull/566))
- Fix/screenshare integration branch ([#563](https://github.com/security-union/videocall-rs/pull/563))
- Fix/ci cargo registry cache ([#559](https://github.com/security-union/videocall-rs/pull/559))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.13...videocall-sdk-v0.1.14) - 2026-02-15

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).