### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "axum 0.7.9",
  "clap",
@@ -7244,7 +7244,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -7408,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7443,7 +7443,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.36"
+version = "1.1.37"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.1...neteq-v0.8.2) - 2026-02-16
+
+### Other
+
+- Neteq expand improvements ([#614](https://github.com/security-union/videocall-rs/pull/614))
+
 ## [0.8.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.0...neteq-v0.8.1) - 2026-01-27
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.0...videocall-client-v4.0.1) - 2026-02-16
+
+### Other
+
+- updated the following local packages: neteq
+
 ## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-client-v3.0.0...videocall-client-v4.0.0) - 2026-02-15
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A client for the videocall project"
@@ -38,7 +38,7 @@ yew-websocket = "1.21.0"
 yew-webtransport = "0.21.1"
 prost = "0.11"
 videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.12" }
-neteq = { path = "../neteq", features = ["web"], version = "0.8.1", optional = true,  default-features = false }
+neteq = { path = "../neteq", features = ["web"], version = "0.8.2", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.14...videocall-sdk-v0.1.15) - 2026-02-16
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.13...videocall-sdk-v0.1.14) - 2026-02-15
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.37](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.36...videocall-ui-v1.1.37) - 2026-02-16
+
+### Other
+
+- Liquid glass for login and join screen ([#613](https://github.com/security-union/videocall-rs/pull/613))
+- add generic oauth support ([#610](https://github.com/security-union/videocall-rs/pull/610))
+
 ## [1.1.36](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.35...videocall-ui-v1.1.36) - 2026-02-15
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.36"
+version = "1.1.37"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path= "../videocall-client", version = "4.0.0" }
+videocall-client = { path= "../videocall-client", version = "4.0.1" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.0" }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
@@ -33,7 +33,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.8.1", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.8.2", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `neteq`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `videocall-ui`: 1.1.36 -> 1.1.37 (✓ API compatible changes)
* `videocall-sdk`: 0.1.14 -> 0.1.15
* `videocall-client`: 4.0.0 -> 4.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `neteq`

<blockquote>

## [0.8.2](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.1...neteq-v0.8.2) - 2026-02-16

### Other

- Neteq expand improvements ([#614](https://github.com/security-union/videocall-rs/pull/614))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.37](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.36...videocall-ui-v1.1.37) - 2026-02-16

### Other

- Liquid glass for login and join screen ([#613](https://github.com/security-union/videocall-rs/pull/613))
- add generic oauth support ([#610](https://github.com/security-union/videocall-rs/pull/610))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.15](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.14...videocall-sdk-v0.1.15) - 2026-02-16

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.0...videocall-client-v4.0.1) - 2026-02-16

### Other

- updated the following local packages: neteq
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).