### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7170,7 +7170,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -7191,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "anyhow",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7395,7 +7395,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "protobuf 3.7.1",
@@ -7405,7 +7405,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.37"
+version = "1.1.38"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
-videocall-types = { path= "../videocall-types", version = "4.0.0" }
+videocall-types = { path= "../videocall-types", version = "4.0.1" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = { workspace = true }
@@ -65,7 +65,7 @@ chrono = "0.4"
 url = "2"
 serial_test = "3"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
-videocall-types = { path = "../videocall-types", version = "4.0.0", features = ["testing"] }
+videocall-types = { path = "../videocall-types", version = "4.0.1", features = ["testing"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
 meeting-api = { path = "../meeting-api" }

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/security-union/videocall-rs/compare/bot-v1.1.0...bot-v1.1.1) - 2026-02-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.1.0](https://github.com/security-union/videocall-rs/compare/bot-v1.0.15...bot-v1.1.0) - 2026-02-04
 
 ### Added

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 # Remove WebSocket, add WebTransport
 web-transport-quinn = { workspace = true }
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "4.0.0" }
+videocall-types = { path= "../videocall-types", version = "4.0.1" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.6](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.5...videocall-cli-v3.0.6) - 2026-02-19
+
+### Other
+
+- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
+
 ## [3.0.5](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.4...videocall-cli-v3.0.5) - 2026-01-27
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.5"
+version = "3.0.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -41,5 +41,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "4.0.0"
+version = "4.0.1"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.2](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.1...videocall-client-v4.0.2) - 2026-02-19
+
+### Other
+
+- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))
+- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
+
 ## [4.0.1](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.0...videocall-client-v4.0.1) - 2026-02-16
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.1"
+version = "4.0.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-performance WebAssembly video conferencing client for videocall.rs, supporting WebTransport and WebSocket."
@@ -28,7 +28,7 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "4.0.0" }
+videocall-types = { path= "../videocall-types", version = "4.0.1" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.15...videocall-sdk-v0.1.16) - 2026-02-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.15](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.14...videocall-sdk-v0.1.15) - 2026-02-16
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "4.0.0" }
+videocall-types = { path = "../videocall-types", version = "4.0.1" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-transport/CHANGELOG.md
+++ b/videocall-transport/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-transport-v0.1.0) - 2026-02-19
+
+### Other
+
+- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))

--- a/videocall-transport/Cargo.toml
+++ b/videocall-transport/Cargo.toml
@@ -28,7 +28,7 @@ gloo-console = "0.3"
 js-sys = "0.3"
 log = "0.4"
 thiserror = "1.0"
-videocall-types = { path = "../videocall-types", version = "4.0.0" }
+videocall-types = { path = "../videocall-types", version = "4.0.1" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v4.0.0...videocall-types-v4.0.1) - 2026-02-19
+
+### Other
+
+- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))
+
 ## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v3.0.1...videocall-types-v4.0.0) - 2026-01-27
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.38](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.37...videocall-ui-v1.1.38) - 2026-02-19
+
+### Other
+
+- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))
+- Nixify videocall.rs website ([#631](https://github.com/security-union/videocall-rs/pull/631))
+- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
+- Fix profile dropdown layout and focus styling ([#624](https://github.com/security-union/videocall-rs/pull/624))
+- Add login component to home page if unauthenticated ([#620](https://github.com/security-union/videocall-rs/pull/620))
+
 ## [1.1.37](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.36...videocall-ui-v1.1.37) - 2026-02-16
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.37"
+version = "1.1.38"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -21,11 +21,11 @@ path = "src/main.rs"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path= "../videocall-client", version = "4.0.1" }
+videocall-client = { path= "../videocall-client", version = "4.0.2" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.0" }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
-videocall-types = { path= "../videocall-types", version = "4.0.0" }
+videocall-types = { path= "../videocall-types", version = "4.0.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 once_cell = "1.19"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 4.0.0 -> 4.0.1 (✓ API compatible changes)
* `bot`: 1.1.0 -> 1.1.1
* `videocall-transport`: 0.1.0
* `videocall-client`: 4.0.1 -> 4.0.2 (✓ API compatible changes)
* `videocall-cli`: 3.0.5 -> 3.0.6 (✓ API compatible changes)
* `videocall-ui`: 1.1.37 -> 1.1.38 (✓ API compatible changes)
* `videocall-sdk`: 0.1.15 -> 0.1.16

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [4.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v4.0.0...videocall-types-v4.0.1) - 2026-02-19

### Other

- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))
</blockquote>

## `bot`

<blockquote>

## [1.1.1](https://github.com/security-union/videocall-rs/compare/bot-v1.1.0...bot-v1.1.1) - 2026-02-19

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-transport`

<blockquote>

## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-transport-v0.1.0) - 2026-02-19

### Other

- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.2](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.1...videocall-client-v4.0.2) - 2026-02-19

### Other

- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))
- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.6](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.5...videocall-cli-v3.0.6) - 2026-02-19

### Other

- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.38](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.37...videocall-ui-v1.1.38) - 2026-02-19

### Other

- Decouple yew from videocall client ([#633](https://github.com/security-union/videocall-rs/pull/633))
- Nixify videocall.rs website ([#631](https://github.com/security-union/videocall-rs/pull/631))
- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
- Fix profile dropdown layout and focus styling ([#624](https://github.com/security-union/videocall-rs/pull/624))
- Add login component to home page if unauthenticated ([#620](https://github.com/security-union/videocall-rs/pull/620))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.16](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.15...videocall-sdk-v0.1.16) - 2026-02-19

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).