### PR TITLE
feat: show inline login prompt when meetings API returns 401

### DIFF
--- a/yew-ui/src/components/login.rs
+++ b/yew-ui/src/components/login.rs
@@ -31,7 +31,7 @@ use crate::constants::{login_url, oauth_provider};
 
 /// Build the login callback that redirects to the backend OAuth endpoint,
 /// forwarding any `returnTo` query parameter from the current URL.
-fn build_login_callback() -> Callback<MouseEvent> {
+pub fn build_login_callback() -> Callback<MouseEvent> {
     Callback::from(|_: MouseEvent| match login_url() {
         Ok(mut url) => {
             if let Ok(search) = window().location().search() {
@@ -46,7 +46,7 @@ fn build_login_callback() -> Callback<MouseEvent> {
 }
 
 /// Render the sign-in button for the configured OAuth provider.
-fn render_provider_button(onclick: Callback<MouseEvent>) -> Html {
+pub fn render_provider_button(onclick: Callback<MouseEvent>) -> Html {
     match oauth_provider().as_deref() {
         Some("google") => html! { <GoogleSignInButton {onclick} /> },
         Some("okta") => html! { <OktaSignInButton {onclick} /> },

--- a/yew-ui/static/style.css
+++ b/yew-ui/static/style.css
@@ -1763,11 +1763,27 @@ select {
 
 .meetings-loading,
 .meetings-error,
-.meetings-empty {
+.meetings-empty,
+.meetings-auth-prompt {
   padding: 1rem;
   text-align: center;
   color: var(--text-tertiary, #8E8E93);
   font-size: 0.8125rem;
+}
+
+.meetings-auth-prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem 1rem;
+}
+
+.meetings-auth-text {
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin: 0;
 }
 
 .meetings-loading {


### PR DESCRIPTION
## Summary

When the MeetingsList component on the home page receives a 401 from the meetings API, it now shows a contextual sign-in button inline instead of a generic error message. This lets unauthenticated users log in without navigating away from the home page.

<img width="1624" height="1061" alt="Screenshot 2026-02-16 at 10 36 03" src="https://github.com/user-attachments/assets/cb8375d1-dc8e-4481-8241-be7957a21091" />
<img width="1624" height="1061" alt="Screenshot 2026-02-16 at 10 35 58" src="https://github.com/user-attachments/assets/b77953b7-bc6b-45c7-b4eb-4aa7e169a2cc" />


## Test plan

- [x] `make yew-tests-docker` — all 31 tests pass (including the 2 new ones)
- [ ] Manual: deploy with OAuth enabled, clear cookies, visit home page — sign-in button should appear in the "My Meetings" section
- [ ] Manual: sign in, visit home page — meetings list (or "No meetings yet") should appear, no sign-in button