### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum 0.7.9",
  "clap",
@@ -7170,7 +7170,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -7191,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.2"
+version = "4.0.3"
 dependencies = [
  "aes",
  "anyhow",
@@ -7226,7 +7226,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "approx",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7378,7 +7378,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-transport"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -7405,7 +7405,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.38"
+version = "1.1.39"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/security-union/videocall-rs/compare/bot-v1.1.1...bot-v1.1.2) - 2026-02-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [1.1.1](https://github.com/security-union/videocall-rs/compare/bot-v1.1.0...bot-v1.1.1) - 2026-02-19
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.2...neteq-v0.8.3) - 2026-02-19
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.8.2](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.1...neteq-v0.8.2) - 2026-02-16
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.7](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.6...videocall-cli-v3.0.7) - 2026-02-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [3.0.6](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.5...videocall-cli-v3.0.6) - 2026-02-19
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.6"
+version = "3.0.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.3](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.2...videocall-client-v4.0.3) - 2026-02-19
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [4.0.2](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.1...videocall-client-v4.0.2) - 2026-02-19
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.2"
+version = "4.0.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-performance WebAssembly video conferencing client for videocall.rs, supporting WebTransport and WebSocket."
@@ -33,10 +33,10 @@ wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
 serde = { version = "1", features = ["derive"] }
-videocall-transport = { path = "../videocall-transport", version = "0.1.0" }
+videocall-transport = { path = "../videocall-transport", version = "0.1.1" }
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.12" }
-neteq = { path = "../neteq", features = ["web"], version = "0.8.2", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.13" }
+neteq = { path = "../neteq", features = ["web"], version = "0.8.3", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.12...videocall-codecs-v0.1.13) - 2026-02-19
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.12](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.11...videocall-codecs-v0.1.12) - 2026-02-15
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.16...videocall-sdk-v0.1.17) - 2026-02-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.16](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.15...videocall-sdk-v0.1.16) - 2026-02-19
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/videocall-transport/CHANGELOG.md
+++ b/videocall-transport/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.0...videocall-transport-v0.1.1) - 2026-02-19
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-transport-v0.1.0) - 2026-02-19
 
 ### Other

--- a/videocall-transport/Cargo.toml
+++ b/videocall-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-transport"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT OR Apache-2.0"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.39](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.38...videocall-ui-v1.1.39) - 2026-02-19
+
+### Other
+
+- yew-ui ([#635](https://github.com/security-union/videocall-rs/pull/635))
+
 ## [1.1.38](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.37...videocall-ui-v1.1.38) - 2026-02-19
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.38"
+version = "1.1.39"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path= "../videocall-client", version = "4.0.2" }
+videocall-client = { path= "../videocall-client", version = "4.0.3" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.0" }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
@@ -33,7 +33,7 @@ log = "0.4.19"
 gloo-timers = "0.2.6"
 gloo-utils = "0.1"
 yew-router = "0.18"
-neteq = { path = "../neteq", version = "0.8.2", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.8.3", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 enum-display = "0.1.4"
 futures = "0.3.31"


### PR DESCRIPTION



## 🤖 New release

* `bot`: 1.1.1 -> 1.1.2
* `neteq`: 0.8.2 -> 0.8.3 (✓ API compatible changes)
* `videocall-codecs`: 0.1.12 -> 0.1.13
* `videocall-transport`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `videocall-client`: 4.0.2 -> 4.0.3 (✓ API compatible changes)
* `videocall-cli`: 3.0.6 -> 3.0.7 (✓ API compatible changes)
* `videocall-ui`: 1.1.38 -> 1.1.39 (✓ API compatible changes)
* `videocall-sdk`: 0.1.16 -> 0.1.17

<details><summary><i><b>Changelog</b></i></summary><p>

## `bot`

<blockquote>

## [1.1.2](https://github.com/security-union/videocall-rs/compare/bot-v1.1.1...bot-v1.1.2) - 2026-02-19

### Other

- update Cargo.lock dependencies
</blockquote>

## `neteq`

<blockquote>

## [0.8.3](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.2...neteq-v0.8.3) - 2026-02-19

### Other

- update Cargo.toml dependencies
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.12...videocall-codecs-v0.1.13) - 2026-02-19

### Other

- update Cargo.toml dependencies
</blockquote>

## `videocall-transport`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.0...videocall-transport-v0.1.1) - 2026-02-19

### Other

- update Cargo.toml dependencies
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.3](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.2...videocall-client-v4.0.3) - 2026-02-19

### Other

- update Cargo.toml dependencies
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.7](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.6...videocall-cli-v3.0.7) - 2026-02-19

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.39](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.38...videocall-ui-v1.1.39) - 2026-02-19

### Other

- yew-ui ([#635](https://github.com/security-union/videocall-rs/pull/635))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.17](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.16...videocall-sdk-v0.1.17) - 2026-02-19

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).