### PR TITLE
fix: prevent duplicate rust-tests container race in make tests_run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMPOSE_IT := docker/docker-compose.integration.yaml
 .PHONY: tests_up test up down build connect_to_db connect_to_nats clippy-fix fmt check clean clean-docker rebuild rebuild-up
 
 tests_run:
-	docker compose -f $(COMPOSE_IT) up -d && docker compose -f $(COMPOSE_IT) run --rm rust-tests \
+	docker compose -f $(COMPOSE_IT) up -d postgres nats && docker compose -f $(COMPOSE_IT) run --rm rust-tests \
 		nix develop /app#backend-dev --command bash -c "\
 		cd /app/dbmate && dbmate wait && dbmate up && \
 		cd /app/actix-api && \


### PR DESCRIPTION
## Summary

- Only start `postgres` and `nats` with `docker compose up -d`, not all services.

Previously `up -d` (with no service names) also started `rust-tests` via its `command:` in the compose file. Then `docker compose run --rm rust-tests` launched a second container. Both shared the same cargo registry volume and raced on unpacking crates, causing intermittent `File exists (os error 17)` failures.

## Type of Change

- [x] Bug fix

## Testing

- [x] `make tests_run` passes locally