### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8315,7 +8315,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.7"
+version = "3.0.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.3"
+version = "4.0.4"
 dependencies = [
  "aes",
  "anyhow",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-meeting-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log",
  "reqwest 0.12.26",
@@ -8419,7 +8419,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-meeting-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
 ]
@@ -8498,7 +8498,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8550,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.39"
+version = "1.1.40"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
 videocall-types = { path= "../videocall-types", version = "4.0.1" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/dioxus-ui/CHANGELOG.md
+++ b/dioxus-ui/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/dioxus-ui-v0.1.0) - 2026-02-23
+
+### Added
+
+- Publish UI as a standalone crate and incorporate into single videocall workspace ([#228](https://github.com/security-union/videocall-rs/pull/228))
+
+### Fixed
+
+- fix-leptos-website ([#172](https://github.com/security-union/videocall-rs/pull/172))
+- fix instructions ([#161](https://github.com/security-union/videocall-rs/pull/161))
+
+### Other
+
+- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
+- Nixify videocall.rs website ([#631](https://github.com/security-union/videocall-rs/pull/631))
+- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
+- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
+- Add component and integration testing for yew-ui ([#568](https://github.com/security-union/videocall-rs/pull/568))
+- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
+- Add config.js to version control along with instructions ([#381](https://github.com/security-union/videocall-rs/pull/381))
+- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
+- Add the rawdawg to contributors ([#276](https://github.com/security-union/videocall-rs/pull/276))
+- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
+- Add digital ocean both in the readme and main page ([#260](https://github.com/security-union/videocall-rs/pull/260))
+- Update README.md
+- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
+- Rewrite Docs ([#203](https://github.com/security-union/videocall-rs/pull/203))
+- Add website ([#169](https://github.com/security-union/videocall-rs/pull/169))
+- Update README.md ([#159](https://github.com/security-union/videocall-rs/pull/159))
+- Add @ronen to contributors list on the readme file ([#152](https://github.com/security-union/videocall-rs/pull/152))
+- Update README.md
+- Update README.md ([#151](https://github.com/security-union/videocall-rs/pull/151))
+- Clean up scripts for local development ([#146](https://github.com/security-union/videocall-rs/pull/146))
+- RFC 1 Q3 Q4 2023 planning ([#110](https://github.com/security-union/videocall-rs/pull/110))
+- Use cargo workspace ([#113](https://github.com/security-union/videocall-rs/pull/113))
+- Update README.md ([#102](https://github.com/security-union/videocall-rs/pull/102))
+- Update README.md ([#100](https://github.com/security-union/videocall-rs/pull/100))
+- Update README.md ([#99](https://github.com/security-union/videocall-rs/pull/99))
+- Update README.md instructions for non-local server ([#66](https://github.com/security-union/videocall-rs/pull/66))
+- add leone as a contributor ([#55](https://github.com/security-union/videocall-rs/pull/55))
+- Update README.md ([#46](https://github.com/security-union/videocall-rs/pull/46))
+- Add YouTube link
+- Adding @griffin to the contributors list ([#13](https://github.com/security-union/videocall-rs/pull/13))
+- Fix screenshots
+- Add credit to Victor ([#6](https://github.com/security-union/videocall-rs/pull/6))
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md
+- Update README.md
+- Initial commit
+
+### Removed
+
+- removed E2E encryption from description ([#249](https://github.com/security-union/videocall-rs/pull/249))

--- a/dioxus-ui/Cargo.toml
+++ b/dioxus-ui/Cargo.toml
@@ -21,10 +21,10 @@ path = "src/main.rs"
 [dependencies]
 dioxus = { version = "0.7.3", default-features = false, features = ["web", "router", "launch", "logger", "lib"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path = "../videocall-client", version = "4.0.2", default-features = false }
+videocall-client = { path = "../videocall-client", version = "4.0.4", default-features = false }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
-videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.0" }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
+videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.1" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
 videocall-types = { path = "../videocall-types", version = "4.0.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"

--- a/meeting-api/Cargo.toml
+++ b/meeting-api/Cargo.toml
@@ -18,7 +18,7 @@ name = "meeting-api"
 path = "src/main.rs"
 
 [dependencies]
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
 
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.8](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.7...videocall-cli-v3.0.8) - 2026-02-23
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [3.0.7](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.6...videocall-cli-v3.0.7) - 2026-02-19
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.7"
+version = "3.0.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.4](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.3...videocall-client-v4.0.4) - 2026-02-23
+
+### Other
+
+- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
+
 ## [4.0.3](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.2...videocall-client-v4.0.3) - 2026-02-19
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.3"
+version = "4.0.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-performance WebAssembly video conferencing client for videocall.rs, supporting WebTransport and WebSocket."

--- a/videocall-meeting-client/CHANGELOG.md
+++ b/videocall-meeting-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-meeting-client-v0.1.0...videocall-meeting-client-v0.1.1) - 2026-02-23
+
+### Other
+
+- updated the following local packages: videocall-meeting-types
+
 ## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/videocall-meeting-client-v0.1.0) - 2026-02-15
 
 ### Other

--- a/videocall-meeting-client/Cargo.toml
+++ b/videocall-meeting-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-meeting-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 description = "Cross-platform REST client for the videocall.rs meeting API"
 
 [dependencies]
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/videocall-meeting-types/CHANGELOG.md
+++ b/videocall-meeting-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.1...videocall-meeting-types-v0.1.2) - 2026-02-23
+
+### Other
+
+- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.0...videocall-meeting-types-v0.1.1) - 2026-02-15
 
 ### Other

--- a/videocall-meeting-types/Cargo.toml
+++ b/videocall-meeting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-meeting-types"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.17...videocall-sdk-v0.1.18) - 2026-02-23
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.17](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.16...videocall-sdk-v0.1.17) - 2026-02-19
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.40](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.39...videocall-ui-v1.1.40) - 2026-02-23
+
+### Other
+
+- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
+
 ## [1.1.39](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.38...videocall-ui-v1.1.39) - 2026-02-19
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.39"
+version = "1.1.40"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -21,10 +21,10 @@ path = "src/main.rs"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path= "../videocall-client", version = "4.0.3" }
+videocall-client = { path= "../videocall-client", version = "4.0.4" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
-videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.0" }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.1" }
+videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.1" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
 videocall-types = { path= "../videocall-types", version = "4.0.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"


### PR DESCRIPTION



## 🤖 New release

* `videocall-meeting-types`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `videocall-client`: 4.0.3 -> 4.0.4 (✓ API compatible changes)
* `videocall-cli`: 3.0.7 -> 3.0.8 (✓ API compatible changes)
* `videocall-ui`: 1.1.39 -> 1.1.40 (✓ API compatible changes)
* `dioxus-ui`: 0.1.0
* `videocall-sdk`: 0.1.17 -> 0.1.18
* `videocall-meeting-client`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-meeting-types`

<blockquote>

## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.1...videocall-meeting-types-v0.1.2) - 2026-02-23

### Other

- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.4](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.3...videocall-client-v4.0.4) - 2026-02-23

### Other

- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.8](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.7...videocall-cli-v3.0.8) - 2026-02-23

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.40](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.39...videocall-ui-v1.1.40) - 2026-02-23

### Other

- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
</blockquote>

## `dioxus-ui`

<blockquote>

## [0.1.0](https://github.com/security-union/videocall-rs/releases/tag/dioxus-ui-v0.1.0) - 2026-02-23

### Added

- Publish UI as a standalone crate and incorporate into single videocall workspace ([#228](https://github.com/security-union/videocall-rs/pull/228))

### Fixed

- fix-leptos-website ([#172](https://github.com/security-union/videocall-rs/pull/172))
- fix instructions ([#161](https://github.com/security-union/videocall-rs/pull/161))

### Other

- dioxus UI client ([#646](https://github.com/security-union/videocall-rs/pull/646))
- Nixify videocall.rs website ([#631](https://github.com/security-union/videocall-rs/pull/631))
- SEO improvement ([#630](https://github.com/security-union/videocall-rs/pull/630))
- add UI integration to the new meetings API ([#550](https://github.com/security-union/videocall-rs/pull/550)) ([#609](https://github.com/security-union/videocall-rs/pull/609))
- Add component and integration testing for yew-ui ([#568](https://github.com/security-union/videocall-rs/pull/568))
- Meeting Ownership Project (behind feature flag) ([#503](https://github.com/security-union/videocall-rs/pull/503))
- Add config.js to version control along with instructions ([#381](https://github.com/security-union/videocall-rs/pull/381))
- Add new decoder and Add MIT - Apache 2 license to all files ([#285](https://github.com/security-union/videocall-rs/pull/285))
- Add the rawdawg to contributors ([#276](https://github.com/security-union/videocall-rs/pull/276))
- Test media track stream processor add wasm opus encoder to support Safari for realz ([#266](https://github.com/security-union/videocall-rs/pull/266))
- Add digital ocean both in the readme and main page ([#260](https://github.com/security-union/videocall-rs/pull/260))
- Update README.md
- Diagnostics P2 ([#208](https://github.com/security-union/videocall-rs/pull/208))
- Rewrite Docs ([#203](https://github.com/security-union/videocall-rs/pull/203))
- Add website ([#169](https://github.com/security-union/videocall-rs/pull/169))
- Update README.md ([#159](https://github.com/security-union/videocall-rs/pull/159))
- Add @ronen to contributors list on the readme file ([#152](https://github.com/security-union/videocall-rs/pull/152))
- Update README.md
- Update README.md ([#151](https://github.com/security-union/videocall-rs/pull/151))
- Clean up scripts for local development ([#146](https://github.com/security-union/videocall-rs/pull/146))
- RFC 1 Q3 Q4 2023 planning ([#110](https://github.com/security-union/videocall-rs/pull/110))
- Use cargo workspace ([#113](https://github.com/security-union/videocall-rs/pull/113))
- Update README.md ([#102](https://github.com/security-union/videocall-rs/pull/102))
- Update README.md ([#100](https://github.com/security-union/videocall-rs/pull/100))
- Update README.md ([#99](https://github.com/security-union/videocall-rs/pull/99))
- Update README.md instructions for non-local server ([#66](https://github.com/security-union/videocall-rs/pull/66))
- add leone as a contributor ([#55](https://github.com/security-union/videocall-rs/pull/55))
- Update README.md ([#46](https://github.com/security-union/videocall-rs/pull/46))
- Add YouTube link
- Adding @griffin to the contributors list ([#13](https://github.com/security-union/videocall-rs/pull/13))
- Fix screenshots
- Add credit to Victor ([#6](https://github.com/security-union/videocall-rs/pull/6))
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Update README.md
- Initial commit

### Removed

- removed E2E encryption from description ([#249](https://github.com/security-union/videocall-rs/pull/249))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.18](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.17...videocall-sdk-v0.1.18) - 2026-02-23

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-meeting-client`

<blockquote>

## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-meeting-client-v0.1.0...videocall-meeting-client-v0.1.1) - 2026-02-23

### Other

- updated the following local packages: videocall-meeting-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).