### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bot"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8281,7 +8281,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -8302,7 +8302,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "aes",
  "anyhow",
@@ -8464,7 +8464,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8489,7 +8489,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-transport"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -8506,7 +8506,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "4.0.1"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "protobuf 3.7.1",
@@ -8516,7 +8516,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-ui"
-version = "1.1.40"
+version = "1.1.41"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
-videocall-types = { path= "../videocall-types", version = "4.0.1" }
+videocall-types = { path= "../videocall-types", version = "5.0.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = { workspace = true }
@@ -65,7 +65,7 @@ chrono = "0.4"
 url = "2"
 serial_test = "3"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
-videocall-types = { path = "../videocall-types", version = "4.0.1", features = ["testing"] }
+videocall-types = { path = "../videocall-types", version = "5.0.0", features = ["testing"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
 meeting-api = { path = "../meeting-api" }

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/security-union/videocall-rs/compare/bot-v1.1.2...bot-v1.1.3) - 2026-02-23
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [1.1.2](https://github.com/security-union/videocall-rs/compare/bot-v1.1.1...bot-v1.1.2) - 2026-02-19
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 # Remove WebSocket, add WebTransport
 web-transport-quinn = { workspace = true }
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "4.0.1" }
+videocall-types = { path= "../videocall-types", version = "5.0.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/dioxus-ui/Cargo.toml
+++ b/dioxus-ui/Cargo.toml
@@ -22,11 +22,11 @@ path = "src/main.rs"
 [dependencies]
 dioxus = { version = "0.7.3", default-features = false, features = ["web", "router", "launch", "logger", "lib"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path = "../videocall-client", version = "4.0.4", default-features = false }
+videocall-client = { path = "../videocall-client", version = "4.0.5", default-features = false }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.1" }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
-videocall-types = { path = "../videocall-types", version = "4.0.1" }
+videocall-types = { path = "../videocall-types", version = "5.0.0" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 once_cell = "1.19"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.9](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.8...videocall-cli-v3.0.9) - 2026-02-23
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [3.0.8](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.7...videocall-cli-v3.0.8) - 2026-02-23
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.8"
+version = "3.0.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -41,5 +41,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "4.0.1"
+version = "5.0.0"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.5](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.4...videocall-client-v4.0.5) - 2026-02-23
+
+### Other
+
+- Same-display-name peers can't see each other (Closes #412) ([#649](https://github.com/security-union/videocall-rs/pull/649))
+- Fix dioxus crate name and lint ([#652](https://github.com/security-union/videocall-rs/pull/652))
+
 ## [4.0.4](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.3...videocall-client-v4.0.4) - 2026-02-23
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.4"
+version = "4.0.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-performance WebAssembly video conferencing client for videocall.rs, supporting WebTransport and WebSocket."
@@ -28,12 +28,12 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "4.0.1" }
+videocall-types = { path= "../videocall-types", version = "5.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
 serde = { version = "1", features = ["derive"] }
-videocall-transport = { path = "../videocall-transport", version = "0.1.1" }
+videocall-transport = { path = "../videocall-transport", version = "0.1.2" }
 prost = "0.11"
 videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.13" }
 neteq = { path = "../neteq", features = ["web"], version = "0.8.3", optional = true,  default-features = false }

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.18...videocall-sdk-v0.1.19) - 2026-02-23
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.18](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.17...videocall-sdk-v0.1.18) - 2026-02-23
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "4.0.1" }
+videocall-types = { path = "../videocall-types", version = "5.0.0" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-transport/CHANGELOG.md
+++ b/videocall-transport/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.1...videocall-transport-v0.1.2) - 2026-02-23
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.0...videocall-transport-v0.1.1) - 2026-02-19
 
 ### Other

--- a/videocall-transport/Cargo.toml
+++ b/videocall-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-transport"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ gloo-console = "0.3"
 js-sys = "0.3"
 log = "0.4"
 thiserror = "1.0"
-videocall-types = { path = "../videocall-types", version = "4.0.1" }
+videocall-types = { path = "../videocall-types", version = "5.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v4.0.1...videocall-types-v5.0.0) - 2026-02-23
+
+### Other
+
+- Same-display-name peers can't see each other (Closes #412) ([#649](https://github.com/security-union/videocall-rs/pull/649))
+
 ## [4.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v4.0.0...videocall-types-v4.0.1) - 2026-02-19
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "4.0.1"
+version = "5.0.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/yew-ui/CHANGELOG.md
+++ b/yew-ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.41](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.40...videocall-ui-v1.1.41) - 2026-02-23
+
+### Other
+
+- Same-display-name peers can't see each other (Closes #412) ([#649](https://github.com/security-union/videocall-rs/pull/649))
+
 ## [1.1.40](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.39...videocall-ui-v1.1.40) - 2026-02-23
 
 ### Other

--- a/yew-ui/Cargo.toml
+++ b/yew-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-ui"
-version = "1.1.40"
+version = "1.1.41"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A Yew UI for the videocall project"
@@ -21,11 +21,11 @@ path = "src/main.rs"
 [dependencies]
 yew = { version = "0.21", features = ["csr"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path= "../videocall-client", version = "4.0.4" }
+videocall-client = { path= "../videocall-client", version = "4.0.5" }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
 videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.1" }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
-videocall-types = { path= "../videocall-types", version = "4.0.1" }
+videocall-types = { path= "../videocall-types", version = "5.0.0" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 once_cell = "1.19"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 4.0.1 -> 5.0.0 (⚠ API breaking changes)
* `videocall-client`: 4.0.4 -> 4.0.5 (✓ API compatible changes)
* `videocall-ui`: 1.1.40 -> 1.1.41 (✓ API compatible changes)
* `videocall-sdk`: 0.1.18 -> 0.1.19
* `bot`: 1.1.2 -> 1.1.3
* `videocall-transport`: 0.1.1 -> 0.1.2
* `videocall-cli`: 3.0.8 -> 3.0.9

### ⚠ `videocall-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PacketWrapper.session_id in /tmp/.tmprIPgzk/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:38

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant PacketType:SESSION_ASSIGNED in /tmp/.tmprIPgzk/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:225
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [5.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v4.0.1...videocall-types-v5.0.0) - 2026-02-23

### Other

- Same-display-name peers can't see each other (Closes #412) ([#649](https://github.com/security-union/videocall-rs/pull/649))
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.5](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.4...videocall-client-v4.0.5) - 2026-02-23

### Other

- Same-display-name peers can't see each other (Closes #412) ([#649](https://github.com/security-union/videocall-rs/pull/649))
- Fix dioxus crate name and lint ([#652](https://github.com/security-union/videocall-rs/pull/652))
</blockquote>

## `videocall-ui`

<blockquote>

## [1.1.41](https://github.com/security-union/videocall-rs/compare/videocall-ui-v1.1.40...videocall-ui-v1.1.41) - 2026-02-23

### Other

- Same-display-name peers can't see each other (Closes #412) ([#649](https://github.com/security-union/videocall-rs/pull/649))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.19](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.18...videocall-sdk-v0.1.19) - 2026-02-23

### Other

- update Cargo.lock dependencies
</blockquote>

## `bot`

<blockquote>

## [1.1.3](https://github.com/security-union/videocall-rs/compare/bot-v1.1.2...bot-v1.1.3) - 2026-02-23

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-transport`

<blockquote>

## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.1...videocall-transport-v0.1.2) - 2026-02-23

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-cli`

<blockquote>

## [3.0.9](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.8...videocall-cli-v3.0.9) - 2026-02-23

### Other

- updated the following local packages: videocall-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).