### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "bot"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7989,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.9"
+version = "3.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -8010,7 +8010,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "aes",
  "anyhow",
@@ -8045,7 +8045,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "approx",
@@ -8068,7 +8068,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-diagnostics"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-broadcast",
  "flume",
@@ -8081,7 +8081,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-meeting-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log",
  "reqwest 0.12.26",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-meeting-types"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
@@ -8172,7 +8172,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8197,7 +8197,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-transport"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -8214,7 +8214,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "protobuf 3.7.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "bot"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "axum 0.7.9",
  "clap",
@@ -7987,7 +7987,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "3.0.9"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -8008,7 +8008,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "aes",
  "anyhow",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "approx",
@@ -8066,7 +8066,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-diagnostics"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-broadcast",
  "flume",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-meeting-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log",
  "reqwest 0.12.26",
@@ -8091,7 +8091,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-meeting-types"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
@@ -8170,7 +8170,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8195,7 +8195,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-transport"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -8212,7 +8212,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "protobuf 3.7.1",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -54,8 +54,8 @@ serde_json = "1.0.82"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
-videocall-types = { path= "../videocall-types", version = "5.0.0" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.0" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = { workspace = true }
@@ -65,7 +65,7 @@ chrono = "0.4"
 url = "2"
 serial_test = "3"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
-videocall-types = { path = "../videocall-types", version = "5.0.0", features = ["testing"] }
+videocall-types = { path = "../videocall-types", version = "6.0.0", features = ["testing"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
 meeting-api = { path = "../meeting-api" }

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4](https://github.com/security-union/videocall-rs/compare/bot-v1.1.3...bot-v1.1.4) - 2026-04-03
+
+### Fixed
+
+- resolve clippy warnings and fmt issues across workspace ([#794](https://github.com/security-union/videocall-rs/pull/794))
+
 ## [1.1.3](https://github.com/security-union/videocall-rs/compare/bot-v1.1.2...bot-v1.1.3) - 2026-02-23
 
 ### Other

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/security-union/videocall-rs/compare/bot-v1.1.3...bot-v1.2.0) - 2026-06-30
+
+### Added
+
+- remove C libopus (audiopus-sys) across the board — pure-Rust ropus codec ([#872](https://github.com/security-union/videocall-rs/pull/872))
+
+### Fixed
+
+- resolve clippy warnings and fmt issues across workspace ([#794](https://github.com/security-union/videocall-rs/pull/794))
+
 ## [1.1.3](https://github.com/security-union/videocall-rs/compare/bot-v1.1.2...bot-v1.1.3) - 2026-02-23
 
 ### Other

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 # Remove WebSocket, add WebTransport
 web-transport-quinn = { workspace = true }
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "5.0.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 # Remove WebSocket, add WebTransport
 web-transport-quinn = { workspace = true }
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "5.0.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.0" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"

--- a/dioxus-ui/Cargo.toml
+++ b/dioxus-ui/Cargo.toml
@@ -22,11 +22,11 @@ path = "src/main.rs"
 [dependencies]
 dioxus = { version = "0.7.3", default-features = false, features = ["web", "router", "launch", "logger", "lib"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path = "../videocall-client", version = "4.0.5", default-features = false }
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
-videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.1" }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
-videocall-types = { path = "../videocall-types", version = "5.0.0" }
+videocall-client = { path = "../videocall-client", version = "4.0.6", default-features = false }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.4" }
+videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.2" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.0" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 log = "0.4.19"

--- a/dioxus-ui/Cargo.toml
+++ b/dioxus-ui/Cargo.toml
@@ -22,17 +22,17 @@ path = "src/main.rs"
 [dependencies]
 dioxus = { version = "0.7.3", default-features = false, features = ["web", "router", "launch", "logger", "lib"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path = "../videocall-client", version = "4.0.5", default-features = false }
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
-videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.1" }
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
-videocall-types = { path = "../videocall-types", version = "5.0.0" }
+videocall-client = { path = "../videocall-client", version = "4.0.6", default-features = false }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.4" }
+videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.2" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.0" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 log = "0.4.19"
 gloo-timers = { version = "0.2.6", features = ["futures"] }
 gloo-utils = "0.1"
-neteq = { path = "../neteq", version = "0.8.2", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.9.0", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 futures = "0.3.31"
 web-time = "1.1.0"

--- a/meeting-api/Cargo.toml
+++ b/meeting-api/Cargo.toml
@@ -18,8 +18,8 @@ name = "meeting-api"
 path = "src/main.rs"
 
 [dependencies]
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
-videocall-types = { path = "../videocall-types", version = "5.0.0" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.0" }
 
 async-nats = "0.42.0"
 protobuf = "3.3.0"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.3...neteq-v0.9.0) - 2026-06-30
+
+### Added
+
+- remove C libopus (audiopus-sys) across the board — pure-Rust ropus codec ([#872](https://github.com/security-union/videocall-rs/pull/872))
+
 ## [0.8.3](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.2...neteq-v0.8.3) - 2026-02-19
 
 ### Other

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.10](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.9...videocall-cli-v3.0.10) - 2026-04-03
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+
 ## [3.0.9](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.8...videocall-cli-v3.0.9) - 2026-02-23
 
 ### Other

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.9...videocall-cli-v4.0.0) - 2026-06-30
+
+### Added
+
+- remove C libopus (audiopus-sys) across the board — pure-Rust ropus codec ([#872](https://github.com/security-union/videocall-rs/pull/872))
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+
+### Other
+
+- *(videocall-cli)* add Rust prerequisite and macOS deps to README ([#871](https://github.com/security-union/videocall-rs/pull/871))
+
 ## [3.0.9](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.8...videocall-cli-v3.0.9) - 2026-02-23
 
 ### Other

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.9"
+version = "3.0.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -41,5 +41,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "5.0.0"
+version = "6.0.0"
 

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "3.0.9"
+version = "4.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -41,5 +41,5 @@ videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-nat
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "5.0.0"
+version = "6.0.0"
 

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.6](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.5...videocall-client-v4.0.6) - 2026-04-03
+
+### Added
+
+- refine speaker highlight ([#746](https://github.com/security-union/videocall-rs/pull/746))
+
+### Fixed
+
+- resolve clippy warnings and fmt issues across workspace ([#794](https://github.com/security-union/videocall-rs/pull/794))
+- stop media tracks after permission check to release camera/mic hardware ([#764](https://github.com/security-union/videocall-rs/pull/764))
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- Update share screen functionality ([#817](https://github.com/security-union/videocall-rs/pull/817))
+- Disable RED audio ([#787](https://github.com/security-union/videocall-rs/pull/787))
+- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
+- Revert "Revert "perf 05: encoder adaptation, client wiring, and UI integratio…" ([#773](https://github.com/security-union/videocall-rs/pull/773))
+- Revert "Revert "Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))" ([#772](https://github.com/security-union/videocall-rs/pull/772))" ([#774](https://github.com/security-union/videocall-rs/pull/774))
+- Revert "Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))" ([#772](https://github.com/security-union/videocall-rs/pull/772))
+- Revert "perf 05: encoder adaptation, client wiring, and UI integration ([#762](https://github.com/security-union/videocall-rs/pull/762))" ([#771](https://github.com/security-union/videocall-rs/pull/771))
+- Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))
+- perf 05: encoder adaptation, client wiring, and UI integration ([#762](https://github.com/security-union/videocall-rs/pull/762))
+- perf 04: decoder improvements - PLI keyframe requests, RED audio unpack, visibility skip ([#761](https://github.com/security-union/videocall-rs/pull/761))
+- perf 01: adaptive quality foundation - constants, quality manager, PID integration ([#758](https://github.com/security-union/videocall-rs/pull/758))
+- Feature/highlight speaker refinement ([#750](https://github.com/security-union/videocall-rs/pull/750))
+- Feature/highlight speaker refinement ([#748](https://github.com/security-union/videocall-rs/pull/748))
+- Upgrade PID controller (pidgeon 0.3.1) and fix adaptive bitrate control ([#747](https://github.com/security-union/videocall-rs/pull/747))
+- Feature/UI tile 594 ([#730](https://github.com/security-union/videocall-rs/pull/730)) ([#745](https://github.com/security-union/videocall-rs/pull/745))
+- Fix display name input suggestions and validation ([#642](https://github.com/security-union/videocall-rs/pull/642))
+- Feature/highlighting speaker ([#704](https://github.com/security-union/videocall-rs/pull/704))
+- Revert NIX backend images from prod ([#668](https://github.com/security-union/videocall-rs/pull/668))
+- Revert "Publish all images for both arm and amd ([#663](https://github.com/security-union/videocall-rs/pull/663))" ([#665](https://github.com/security-union/videocall-rs/pull/665))
+- Publish all images for both arm and amd ([#663](https://github.com/security-union/videocall-rs/pull/663))
+- Fix phantom user appears in meeting ([#658](https://github.com/security-union/videocall-rs/pull/658))
+
 ## [4.0.5](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.4...videocall-client-v4.0.5) - 2026-02-23
 
 ### Other

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.6](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.5...videocall-client-v4.0.6) - 2026-06-30
+
+### Added
+
+- refine speaker highlight ([#746](https://github.com/security-union/videocall-rs/pull/746))
+
+### Fixed
+
+- resolve clippy warnings and fmt issues across workspace ([#794](https://github.com/security-union/videocall-rs/pull/794))
+- stop media tracks after permission check to release camera/mic hardware ([#764](https://github.com/security-union/videocall-rs/pull/764))
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- Update share screen functionality ([#817](https://github.com/security-union/videocall-rs/pull/817))
+- Disable RED audio ([#787](https://github.com/security-union/videocall-rs/pull/787))
+- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
+- Revert "Revert "perf 05: encoder adaptation, client wiring, and UI integratio…" ([#773](https://github.com/security-union/videocall-rs/pull/773))
+- Revert "Revert "Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))" ([#772](https://github.com/security-union/videocall-rs/pull/772))" ([#774](https://github.com/security-union/videocall-rs/pull/774))
+- Revert "Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))" ([#772](https://github.com/security-union/videocall-rs/pull/772))
+- Revert "perf 05: encoder adaptation, client wiring, and UI integration ([#762](https://github.com/security-union/videocall-rs/pull/762))" ([#771](https://github.com/security-union/videocall-rs/pull/771))
+- Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))
+- perf 05: encoder adaptation, client wiring, and UI integration ([#762](https://github.com/security-union/videocall-rs/pull/762))
+- perf 04: decoder improvements - PLI keyframe requests, RED audio unpack, visibility skip ([#761](https://github.com/security-union/videocall-rs/pull/761))
+- perf 01: adaptive quality foundation - constants, quality manager, PID integration ([#758](https://github.com/security-union/videocall-rs/pull/758))
+- Feature/highlight speaker refinement ([#750](https://github.com/security-union/videocall-rs/pull/750))
+- Feature/highlight speaker refinement ([#748](https://github.com/security-union/videocall-rs/pull/748))
+- Upgrade PID controller (pidgeon 0.3.1) and fix adaptive bitrate control ([#747](https://github.com/security-union/videocall-rs/pull/747))
+- Feature/UI tile 594 ([#730](https://github.com/security-union/videocall-rs/pull/730)) ([#745](https://github.com/security-union/videocall-rs/pull/745))
+- Fix display name input suggestions and validation ([#642](https://github.com/security-union/videocall-rs/pull/642))
+- Feature/highlighting speaker ([#704](https://github.com/security-union/videocall-rs/pull/704))
+- Revert NIX backend images from prod ([#668](https://github.com/security-union/videocall-rs/pull/668))
+- Revert "Publish all images for both arm and amd ([#663](https://github.com/security-union/videocall-rs/pull/663))" ([#665](https://github.com/security-union/videocall-rs/pull/665))
+- Publish all images for both arm and amd ([#663](https://github.com/security-union/videocall-rs/pull/663))
+- Fix phantom user appears in meeting ([#658](https://github.com/security-union/videocall-rs/pull/658))
+
 ## [4.0.5](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.4...videocall-client-v4.0.5) - 2026-02-23
 
 ### Other

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.5"
+version = "4.0.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-performance WebAssembly video conferencing client for videocall.rs, supporting WebTransport and WebSocket."
@@ -28,18 +28,18 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "5.0.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
 serde = { version = "1", features = ["derive"] }
-videocall-transport = { path = "../videocall-transport", version = "0.1.2" }
+videocall-transport = { path = "../videocall-transport", version = "0.2.0" }
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.13" }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.14" }
 neteq = { path = "../neteq", features = ["web"], version = "0.8.3", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.4" }
 serde_json = { version = "1.0" }
 async-broadcast = "0.7.2"
 

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.5"
+version = "4.0.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-performance WebAssembly video conferencing client for videocall.rs, supporting WebTransport and WebSocket."
@@ -28,18 +28,18 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "5.0.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
 serde = { version = "1", features = ["derive"] }
-videocall-transport = { path = "../videocall-transport", version = "0.1.2" }
+videocall-transport = { path = "../videocall-transport", version = "0.2.0" }
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.13" }
-neteq = { path = "../neteq", features = ["web"], version = "0.8.3", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.14" }
+neteq = { path = "../neteq", features = ["web"], version = "0.9.0", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
-videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.3" }
+videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.4" }
 serde_json = { version = "1.0" }
 async-broadcast = "0.7.2"
 

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.13...videocall-codecs-v0.1.14) - 2026-04-03
+
+### Other
+
+- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
+
 ## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.12...videocall-codecs-v0.1.13) - 2026-02-19
 
 ### Other

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.13...videocall-codecs-v0.1.14) - 2026-06-30
+
+### Other
+
+- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
+
 ## [0.1.13](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.12...videocall-codecs-v0.1.13) - 2026-02-19
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -79,7 +79,7 @@ web-sys = { version = "0.3", optional = true, features = [
     "HtmlElement",
     "HtmlLinkElement",
 ] }
-videocall-diagnostics = { path = "../videocall-diagnostics", optional = true, version = "0.1.3" }
+videocall-diagnostics = { path = "../videocall-diagnostics", optional = true, version = "0.1.4" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env-libvpx-sys = { workspace = true }

--- a/videocall-diagnostics/CHANGELOG.md
+++ b/videocall-diagnostics/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.3...videocall-diagnostics-v0.1.4) - 2026-04-03
+
+### Fixed
+
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- remove yew-ui ([#788](https://github.com/security-union/videocall-rs/pull/788)) ([#789](https://github.com/security-union/videocall-rs/pull/789))
+
 ## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.2...videocall-diagnostics-v0.1.3) - 2025-11-30
 
 ### Other

--- a/videocall-diagnostics/CHANGELOG.md
+++ b/videocall-diagnostics/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.3...videocall-diagnostics-v0.1.4) - 2026-06-30
+
+### Fixed
+
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- remove yew-ui ([#788](https://github.com/security-union/videocall-rs/pull/788)) ([#789](https://github.com/security-union/videocall-rs/pull/789))
+
 ## [0.1.3](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.2...videocall-diagnostics-v0.1.3) - 2025-11-30
 
 ### Other

--- a/videocall-diagnostics/Cargo.toml
+++ b/videocall-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-diagnostics"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Lightweight diagnostics event bus for the videocall-rs project"

--- a/videocall-meeting-client/CHANGELOG.md
+++ b/videocall-meeting-client/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-meeting-client-v0.1.1...videocall-meeting-client-v0.1.2) - 2026-04-03
+
+### Added
+
+- allow host to set waiting room option ([#696](https://github.com/security-union/videocall-rs/pull/696))
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- remove yew-ui ([#788](https://github.com/security-union/videocall-rs/pull/788)) ([#789](https://github.com/security-union/videocall-rs/pull/789))
+- meeting settings page ([#699](https://github.com/security-union/videocall-rs/pull/699))
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-meeting-client-v0.1.0...videocall-meeting-client-v0.1.1) - 2026-02-23
 
 ### Other

--- a/videocall-meeting-client/CHANGELOG.md
+++ b/videocall-meeting-client/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-meeting-client-v0.1.1...videocall-meeting-client-v0.1.2) - 2026-06-30
+
+### Added
+
+- allow host to set waiting room option ([#696](https://github.com/security-union/videocall-rs/pull/696))
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- remove yew-ui ([#788](https://github.com/security-union/videocall-rs/pull/788)) ([#789](https://github.com/security-union/videocall-rs/pull/789))
+- meeting settings page ([#699](https://github.com/security-union/videocall-rs/pull/699))
+
 ## [0.1.1](https://github.com/security-union/videocall-rs/compare/videocall-meeting-client-v0.1.0...videocall-meeting-client-v0.1.1) - 2026-02-23
 
 ### Other

--- a/videocall-meeting-client/Cargo.toml
+++ b/videocall-meeting-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-meeting-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 description = "Cross-platform REST client for the videocall.rs meeting API"
 
 [dependencies]
-videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.1.2" }
+videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/videocall-meeting-types/CHANGELOG.md
+++ b/videocall-meeting-types/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.2...videocall-meeting-types-v0.2.0) - 2026-04-03
+
+### Added
+
+- allow host to set waiting room option ([#696](https://github.com/security-union/videocall-rs/pull/696))
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- meeting settings page ([#699](https://github.com/security-union/videocall-rs/pull/699))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.1...videocall-meeting-types-v0.1.2) - 2026-02-23
 
 ### Other

--- a/videocall-meeting-types/CHANGELOG.md
+++ b/videocall-meeting-types/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.2...videocall-meeting-types-v0.2.0) - 2026-06-30
+
+### Added
+
+- allow host to set waiting room option ([#696](https://github.com/security-union/videocall-rs/pull/696))
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- meeting settings page ([#699](https://github.com/security-union/videocall-rs/pull/699))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.1...videocall-meeting-types-v0.1.2) - 2026-02-23
 
 ### Other

--- a/videocall-meeting-types/Cargo.toml
+++ b/videocall-meeting-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-meeting-types"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.19...videocall-sdk-v0.1.20) - 2026-04-03
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.19](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.18...videocall-sdk-v0.1.19) - 2026-02-23
 
 ### Other

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.19...videocall-sdk-v0.1.20) - 2026-06-30
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.19](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.18...videocall-sdk-v0.1.19) - 2026-02-23
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "5.0.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.0" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-transport/CHANGELOG.md
+++ b/videocall-transport/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.2...videocall-transport-v0.2.0) - 2026-04-03
+
+### Other
+
+- Fix host and attendants re-renders on audio level changes + refactor webtransport writes ([#816](https://github.com/security-union/videocall-rs/pull/816))
+- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.1...videocall-transport-v0.1.2) - 2026-02-23
 
 ### Other

--- a/videocall-transport/CHANGELOG.md
+++ b/videocall-transport/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.2...videocall-transport-v0.2.0) - 2026-06-30
+
+### Other
+
+- Fix host and attendants re-renders on audio level changes + refactor webtransport writes ([#816](https://github.com/security-union/videocall-rs/pull/816))
+- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
+
 ## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.1...videocall-transport-v0.1.2) - 2026-02-23
 
 ### Other

--- a/videocall-transport/Cargo.toml
+++ b/videocall-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-transport"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ gloo-console = "0.3"
 js-sys = "0.3"
 log = "0.4"
 thiserror = "1.0"
-videocall-types = { path = "../videocall-types", version = "5.0.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.0" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v5.0.0...videocall-types-v6.0.0) - 2026-04-03
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- perf 04: decoder improvements - PLI keyframe requests, RED audio unpack, visibility skip ([#761](https://github.com/security-union/videocall-rs/pull/761))
+- Fix display name input suggestions and validation ([#642](https://github.com/security-union/videocall-rs/pull/642))
+- Feature/highlighting speaker ([#704](https://github.com/security-union/videocall-rs/pull/704))
+
 ## [5.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v4.0.1...videocall-types-v5.0.0) - 2026-02-23
 
 ### Other

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v5.0.0...videocall-types-v6.0.0) - 2026-06-30
+
+### Fixed
+
+- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
+- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))
+
+### Other
+
+- perf 04: decoder improvements - PLI keyframe requests, RED audio unpack, visibility skip ([#761](https://github.com/security-union/videocall-rs/pull/761))
+- Fix display name input suggestions and validation ([#642](https://github.com/security-union/videocall-rs/pull/642))
+- Feature/highlighting speaker ([#704](https://github.com/security-union/videocall-rs/pull/704))
+
 ## [5.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v4.0.1...videocall-types-v5.0.0) - 2026-02-23
 
 ### Other

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "5.0.0"
+version = "6.0.0"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"


### PR DESCRIPTION



## 🤖 New release

* `videocall-meeting-types`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `videocall-types`: 5.0.0 -> 6.0.0 (⚠ API breaking changes)
* `bot`: 1.1.3 -> 1.2.0
* `videocall-meeting-client`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `neteq`: 0.8.3 -> 0.9.0 (⚠ API breaking changes)
* `videocall-diagnostics`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `videocall-codecs`: 0.1.13 -> 0.1.14
* `videocall-transport`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `videocall-client`: 4.0.5 -> 4.0.6 (✓ API compatible changes)
* `videocall-cli`: 3.0.9 -> 4.0.0 (⚠ API breaking changes)
* `videocall-sdk`: 0.1.19 -> 0.1.20

### ⚠ `videocall-meeting-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MeetingInfoResponse.host_user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:95
  field MeetingInfoResponse.waiting_room_enabled in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:97
  field MeetingInfoResponse.participant_count in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:98
  field MeetingInfoResponse.waiting_count in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:99
  field MeetingInfoResponse.started_at in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:101
  field MeetingInfoResponse.ended_at in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:104
  field ProfileResponse.user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:198
  field RoomAccessTokenClaims.observer in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/token.rs:62
  field RoomAccessTokenClaims.observer in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/token.rs:62
  field MeetingSummary.waiting_room_enabled in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:137
  field CreateMeetingRequest.waiting_room_enabled in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/requests.rs:40
  field ParticipantStatusResponse.user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:146
  field ParticipantStatusResponse.observer_token in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:163
  field ParticipantStatusResponse.waiting_room_enabled in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:166
  field ParticipantStatusResponse.host_display_name in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:169
  field ParticipantStatusResponse.host_user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:172
  field AdmitRequest.user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/requests.rs:64
  field CreateMeetingResponse.waiting_room_enabled in /tmp/.tmpF7sei7/videocall-rs/videocall-meeting-types/src/responses.rs:82

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field email of struct ParticipantStatusResponse, previously in file /tmp/.tmpo0nIJC/videocall-meeting-types/src/responses.rs:133
  field email of struct ProfileResponse, previously in file /tmp/.tmpo0nIJC/videocall-meeting-types/src/responses.rs:171
  field email of struct AdmitRequest, previously in file /tmp/.tmpo0nIJC/videocall-meeting-types/src/requests.rs:51
```

### ⚠ `videocall-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RsaPacket.user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/rsa_packet.rs:34
  field PacketWrapper.user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:34
  field MediaPacket.user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/media_packet.rs:34
  field HealthPacket.reporting_user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/health_packet.rs:996
  field MeetingPacket.target_user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:46
  field MeetingPacket.room_token in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:49
  field MeetingPacket.session_id in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:51
  field MeetingPacket.display_name in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:54
  field ConnectionMetadata.user_id in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/server_connection_packet.rs:176
  field HeartbeatMetadata.is_speaking in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/media_packet.rs:731

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant MediaType:KEYFRAME_REQUEST in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/media_packet.rs:314
  variant MeetingEventType:MEETING_ACTIVATED in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:331
  variant MeetingEventType:PARTICIPANT_ADMITTED in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:333
  variant MeetingEventType:PARTICIPANT_REJECTED in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:335
  variant MeetingEventType:WAITING_ROOM_UPDATED in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/meeting_packet.rs:337
  variant PacketType:CONGESTION in /tmp/.tmpF7sei7/videocall-rs/videocall-types/src/protos/packet_wrapper.rs:227

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  SYSTEM_USER_EMAIL in file /tmp/.tmpo0nIJC/videocall-types/src/lib.rs:35

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field username of struct RsaPacket, previously in file /tmp/.tmpo0nIJC/videocall-types/src/protos/rsa_packet.rs:34
  field email of struct PacketWrapper, previously in file /tmp/.tmpo0nIJC/videocall-types/src/protos/packet_wrapper.rs:34
  field reporting_peer of struct HealthPacket, previously in file /tmp/.tmpo0nIJC/videocall-types/src/protos/health_packet.rs:996
  field email of struct MediaPacket, previously in file /tmp/.tmpo0nIJC/videocall-types/src/protos/media_packet.rs:34
  field customer_email of struct ConnectionMetadata, previously in file /tmp/.tmpo0nIJC/videocall-types/src/protos/server_connection_packet.rs:176
```

### ⚠ `neteq` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature opus in the package's Cargo.toml
```

### ⚠ `videocall-transport` breaking changes

```text
--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum WebSocketStatus in /tmp/.tmpF7sei7/videocall-rs/videocall-transport/src/websocket.rs:43

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant WebSocketStatus::Closed in /tmp/.tmpF7sei7/videocall-rs/videocall-transport/src/websocket.rs:55
```

### ⚠ `videocall-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Info.list_audio_devices in /tmp/.tmpF7sei7/videocall-rs/videocall-cli/src/cli_args.rs:197
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-meeting-types`

<blockquote>

## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-meeting-types-v0.1.2...videocall-meeting-types-v0.2.0) - 2026-06-30

### Added

- allow host to set waiting room option ([#696](https://github.com/security-union/videocall-rs/pull/696))

### Fixed

- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))

### Other

- meeting settings page ([#699](https://github.com/security-union/videocall-rs/pull/699))
</blockquote>

## `videocall-types`

<blockquote>

## [6.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v5.0.0...videocall-types-v6.0.0) - 2026-06-30

### Fixed

- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))

### Other

- perf 04: decoder improvements - PLI keyframe requests, RED audio unpack, visibility skip ([#761](https://github.com/security-union/videocall-rs/pull/761))
- Fix display name input suggestions and validation ([#642](https://github.com/security-union/videocall-rs/pull/642))
- Feature/highlighting speaker ([#704](https://github.com/security-union/videocall-rs/pull/704))
</blockquote>

## `bot`

<blockquote>

## [1.2.0](https://github.com/security-union/videocall-rs/compare/bot-v1.1.3...bot-v1.2.0) - 2026-06-30

### Added

- remove C libopus (audiopus-sys) across the board — pure-Rust ropus codec ([#872](https://github.com/security-union/videocall-rs/pull/872))

### Fixed

- resolve clippy warnings and fmt issues across workspace ([#794](https://github.com/security-union/videocall-rs/pull/794))
</blockquote>

## `videocall-meeting-client`

<blockquote>

## [0.1.2](https://github.com/security-union/videocall-rs/compare/videocall-meeting-client-v0.1.1...videocall-meeting-client-v0.1.2) - 2026-06-30

### Added

- allow host to set waiting room option ([#696](https://github.com/security-union/videocall-rs/pull/696))

### Fixed

- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))

### Other

- remove yew-ui ([#788](https://github.com/security-union/videocall-rs/pull/788)) ([#789](https://github.com/security-union/videocall-rs/pull/789))
- meeting settings page ([#699](https://github.com/security-union/videocall-rs/pull/699))
</blockquote>

## `neteq`

<blockquote>

## [0.9.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.3...neteq-v0.9.0) - 2026-06-30

### Added

- remove C libopus (audiopus-sys) across the board — pure-Rust ropus codec ([#872](https://github.com/security-union/videocall-rs/pull/872))
</blockquote>

## `videocall-diagnostics`

<blockquote>

## [0.1.4](https://github.com/security-union/videocall-rs/compare/videocall-diagnostics-v0.1.3...videocall-diagnostics-v0.1.4) - 2026-06-30

### Fixed

- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))

### Other

- remove yew-ui ([#788](https://github.com/security-union/videocall-rs/pull/788)) ([#789](https://github.com/security-union/videocall-rs/pull/789))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.13...videocall-codecs-v0.1.14) - 2026-06-30

### Other

- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
</blockquote>

## `videocall-transport`

<blockquote>

## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.2...videocall-transport-v0.2.0) - 2026-06-30

### Other

- Fix host and attendants re-renders on audio level changes + refactor webtransport writes ([#816](https://github.com/security-union/videocall-rs/pull/816))
- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.6](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.5...videocall-client-v4.0.6) - 2026-06-30

### Added

- refine speaker highlight ([#746](https://github.com/security-union/videocall-rs/pull/746))

### Fixed

- resolve clippy warnings and fmt issues across workspace ([#794](https://github.com/security-union/videocall-rs/pull/794))
- stop media tracks after permission check to release camera/mic hardware ([#764](https://github.com/security-union/videocall-rs/pull/764))
- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))
- performance improvements ([#705](https://github.com/security-union/videocall-rs/pull/705))

### Other

- Update share screen functionality ([#817](https://github.com/security-union/videocall-rs/pull/817))
- Disable RED audio ([#787](https://github.com/security-union/videocall-rs/pull/787))
- Misc fixes from full review of webtransport and websocket video conferencing app ([#793](https://github.com/security-union/videocall-rs/pull/793))
- Revert "Revert "perf 05: encoder adaptation, client wiring, and UI integratio…" ([#773](https://github.com/security-union/videocall-rs/pull/773))
- Revert "Revert "Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))" ([#772](https://github.com/security-union/videocall-rs/pull/772))" ([#774](https://github.com/security-union/videocall-rs/pull/774))
- Revert "Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))" ([#772](https://github.com/security-union/videocall-rs/pull/772))
- Revert "perf 05: encoder adaptation, client wiring, and UI integration ([#762](https://github.com/security-union/videocall-rs/pull/762))" ([#771](https://github.com/security-union/videocall-rs/pull/771))
- Perf stack ([#767](https://github.com/security-union/videocall-rs/pull/767))
- perf 05: encoder adaptation, client wiring, and UI integration ([#762](https://github.com/security-union/videocall-rs/pull/762))
- perf 04: decoder improvements - PLI keyframe requests, RED audio unpack, visibility skip ([#761](https://github.com/security-union/videocall-rs/pull/761))
- perf 01: adaptive quality foundation - constants, quality manager, PID integration ([#758](https://github.com/security-union/videocall-rs/pull/758))
- Feature/highlight speaker refinement ([#750](https://github.com/security-union/videocall-rs/pull/750))
- Feature/highlight speaker refinement ([#748](https://github.com/security-union/videocall-rs/pull/748))
- Upgrade PID controller (pidgeon 0.3.1) and fix adaptive bitrate control ([#747](https://github.com/security-union/videocall-rs/pull/747))
- Feature/UI tile 594 ([#730](https://github.com/security-union/videocall-rs/pull/730)) ([#745](https://github.com/security-union/videocall-rs/pull/745))
- Fix display name input suggestions and validation ([#642](https://github.com/security-union/videocall-rs/pull/642))
- Feature/highlighting speaker ([#704](https://github.com/security-union/videocall-rs/pull/704))
- Revert NIX backend images from prod ([#668](https://github.com/security-union/videocall-rs/pull/668))
- Revert "Publish all images for both arm and amd ([#663](https://github.com/security-union/videocall-rs/pull/663))" ([#665](https://github.com/security-union/videocall-rs/pull/665))
- Publish all images for both arm and amd ([#663](https://github.com/security-union/videocall-rs/pull/663))
- Fix phantom user appears in meeting ([#658](https://github.com/security-union/videocall-rs/pull/658))
</blockquote>

## `videocall-cli`

<blockquote>

## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.9...videocall-cli-v4.0.0) - 2026-06-30

### Added

- remove C libopus (audiopus-sys) across the board — pure-Rust ropus codec ([#872](https://github.com/security-union/videocall-rs/pull/872))

### Fixed

- email, userid, session usage confusion ([#724](https://github.com/security-union/videocall-rs/pull/724))

### Other

- *(videocall-cli)* add Rust prerequisite and macOS deps to README ([#871](https://github.com/security-union/videocall-rs/pull/871))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.20](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.19...videocall-sdk-v0.1.20) - 2026-06-30

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).