### PR TITLE
Fix X platform builds

### DIFF
--- a/Dockerfile.actix
+++ b/Dockerfile.actix
@@ -2,6 +2,9 @@ FROM nixos/nix:2.33.2 AS builder
 
 ENV NIX_CONFIG="experimental-features = nix-command flakes"
 
+# filter-syscalls = false required for QEMU-emulated arm64 builds (seccomp fails under emulation)
+RUN mkdir -p /etc/nix && echo 'filter-syscalls = false' >> /etc/nix/nix.conf
+
 WORKDIR /app
 
 COPY flake.nix flake.lock ./

--- a/Dockerfile.dioxus
+++ b/Dockerfile.dioxus
@@ -2,6 +2,8 @@ FROM nixos/nix:2.33.2 AS builder
 
 ENV NIX_CONFIG="experimental-features = nix-command flakes"
 
+RUN mkdir -p /etc/nix && echo 'filter-syscalls = false' >> /etc/nix/nix.conf
+
 WORKDIR /app
 
 COPY flake.nix flake.lock ./

--- a/Dockerfile.meeting-api
+++ b/Dockerfile.meeting-api
@@ -2,6 +2,9 @@ FROM nixos/nix:2.33.2 AS builder
 
 ENV NIX_CONFIG="experimental-features = nix-command flakes"
 
+# filter-syscalls = false required for QEMU-emulated arm64 builds (seccomp fails under emulation)
+RUN mkdir -p /etc/nix && echo 'filter-syscalls = false' >> /etc/nix/nix.conf
+
 WORKDIR /app
 
 COPY flake.nix flake.lock ./

--- a/Dockerfile.yew
+++ b/Dockerfile.yew
@@ -2,6 +2,9 @@ FROM nixos/nix:2.33.2 AS builder
 
 ENV NIX_CONFIG="experimental-features = nix-command flakes"
 
+# filter-syscalls = false required for QEMU-emulated arm64 builds (seccomp fails under emulation)
+RUN mkdir -p /etc/nix && echo 'filter-syscalls = false' >> /etc/nix/nix.conf
+
 WORKDIR /app
 
 COPY flake.nix flake.lock ./

--- a/docker/Dockerfile.website
+++ b/docker/Dockerfile.website
@@ -2,6 +2,9 @@ FROM nixos/nix:2.33.2 AS builder
 
 ENV NIX_CONFIG="experimental-features = nix-command flakes"
 
+# filter-syscalls = false required for QEMU-emulated arm64 builds (seccomp fails under emulation)
+RUN mkdir -p /etc/nix && echo 'filter-syscalls = false' >> /etc/nix/nix.conf
+
 WORKDIR /app
 
 COPY flake.nix flake.lock ./


### PR DESCRIPTION
we were missing:

# filter-syscalls = false required for QEMU-emulated arm64 builds (seccomp fails under emulation)
RUN mkdir -p /etc/nix && echo 'filter-syscalls = false' >> /etc/nix/nix.conf
