### PR TITLE
fix: make session cookie name configurable to prevent PR preview 401 collision

### DIFF
--- a/.github/workflows/pr-deploy-reusable.yaml
+++ b/.github/workflows/pr-deploy-reusable.yaml
@@ -510,6 +510,8 @@ jobs:
             --set "env[10].value=0.0.0.0:8081" \
             --set "env[11].name=RUST_LOG" \
             --set "env[11].value=info" \
+            --set "env[12].name=COOKIE_NAME" \
+            --set "env[12].value=pr${SLOT}-session" \
             --set "ingress.hosts[0].host=pr${SLOT}-api.sandbox.videocall.rs" \
             --set "ingress.hosts[0].paths[0].path=/" \
             --set "ingress.hosts[0].paths[0].pathType=Prefix" \

--- a/helm/meeting-api/values.yaml
+++ b/helm/meeting-api/values.yaml
@@ -34,6 +34,12 @@ env:
     value: "true"
   - name: COOKIE_DOMAIN
     value: ".videocall.rs"
+  # Name of the session cookie (default: "session").
+  # Override in PR preview environments to avoid collision with the production
+  # cookie which is also named "session" on the parent domain.
+  # Example: set to "pr-session" for *.sandbox.videocall.rs previews.
+  - name: COOKIE_NAME
+    value: "session"
   - name: CORS_ALLOWED_ORIGIN
     value: "https://app.videocall.rs"
   # --- OAuth / OIDC ---

--- a/meeting-api/src/auth.rs
+++ b/meeting-api/src/auth.rs
@@ -52,7 +52,7 @@ impl FromRequestParts<AppState> for AuthUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let token = extract_session_token(parts)
+        let token = extract_session_token(parts, &state.cookie_name)
             .ok_or_else(|| AppError::new(StatusCode::UNAUTHORIZED, APIError::unauthorized()))?;
 
         let claims = token::decode_session_token(&state.jwt_secret, &token)?;
@@ -67,18 +67,19 @@ impl FromRequestParts<AppState> for AuthUser {
 /// Extract the raw session JWT from the request.
 ///
 /// Checks (in order):
-/// 1. `Cookie: session=<jwt>`
+/// 1. `Cookie: <cookie_name>=<jwt>`
 /// 2. `Authorization: Bearer <jwt>`
-fn extract_session_token(parts: &Parts) -> Option<String> {
-    // 1. Try the `session` cookie.
+fn extract_session_token(parts: &Parts, cookie_name: &str) -> Option<String> {
+    // 1. Try the configured session cookie name.
     if let Some(cookie_header) = parts
         .headers
         .get(header::COOKIE)
         .and_then(|v| v.to_str().ok())
     {
+        let prefix = format!("{cookie_name}=");
         for pair in cookie_header.split(';') {
             let pair = pair.trim();
-            if let Some(value) = pair.strip_prefix("session=") {
+            if let Some(value) = pair.strip_prefix(prefix.as_str()) {
                 let value = value.trim();
                 if !value.is_empty() {
                     return Some(value.to_string());
@@ -126,6 +127,7 @@ mod tests {
             oauth: None,
             jwks_cache: None,
             cookie_domain: None,
+            cookie_name: "session".to_string(),
             cookie_secure: false,
         }
     }

--- a/meeting-api/src/auth.rs
+++ b/meeting-api/src/auth.rs
@@ -113,6 +113,10 @@ mod tests {
     const TEST_SECRET: &str = "test-secret-for-auth-tests";
 
     fn make_test_state() -> AppState {
+        make_state_with_cookie_name("session")
+    }
+
+    fn make_state_with_cookie_name(name: &str) -> AppState {
         // connect_lazy creates a pool handle without actually connecting.
         // The URL is never used because no queries are executed in unit tests.
         let db = PgPoolOptions::new()
@@ -127,20 +131,27 @@ mod tests {
             oauth: None,
             jwks_cache: None,
             cookie_domain: None,
-            cookie_name: "session".to_string(),
+            cookie_name: name.to_string(),
             cookie_secure: false,
         }
     }
 
     async fn extract_with_cookie(cookie: Option<&str>) -> Result<AuthUser, AppError> {
         let state = make_test_state();
+        extract_with_cookie_and_state(cookie, &state).await
+    }
+
+    async fn extract_with_cookie_and_state(
+        cookie: Option<&str>,
+        state: &AppState,
+    ) -> Result<AuthUser, AppError> {
         let mut builder = Request::builder().uri("/test").method("GET");
         if let Some(val) = cookie {
             builder = builder.header(header::COOKIE, val);
         }
         let req = builder.body(()).unwrap();
         let (mut parts, _) = req.into_parts();
-        AuthUser::from_request_parts(&mut parts, &state).await
+        AuthUser::from_request_parts(&mut parts, state).await
     }
 
     async fn extract_with_bearer(token: &str) -> Result<AuthUser, AppError> {
@@ -270,5 +281,83 @@ mod tests {
             .await
             .expect("should find session in middle");
         assert_eq!(auth.email, "multi@test.com");
+    }
+
+    // -----------------------------------------------------------------------
+    // Custom cookie name tests (PR preview collision fix)
+    // -----------------------------------------------------------------------
+
+    /// PR preview API configured with "pr1-session" accepts a pr1-session= cookie.
+    #[tokio::test]
+    async fn custom_cookie_name_is_accepted() {
+        let state = make_state_with_cookie_name("pr1-session");
+        let jwt = generate_session_token(TEST_SECRET, "alice@test.com", "Alice", 3600).unwrap();
+        let auth = extract_with_cookie_and_state(Some(&format!("pr1-session={jwt}")), &state)
+            .await
+            .expect("pr1-session cookie should be accepted");
+        assert_eq!(auth.email, "alice@test.com");
+    }
+
+    /// Core regression test: PR preview API configured with "pr1-session" must
+    /// reject a "session=" cookie — exactly what the production API sets with
+    /// Domain=.videocall.rs, which the browser would otherwise send to
+    /// pr1-api.sandbox.videocall.rs causing a 401.
+    #[tokio::test]
+    async fn production_session_cookie_rejected_by_preview_api() {
+        let state = make_state_with_cookie_name("pr1-session");
+        let production_jwt =
+            generate_session_token(TEST_SECRET, "alice@test.com", "Alice", 3600).unwrap();
+        // Even with a valid JWT, the wrong cookie name must be rejected.
+        let err =
+            extract_with_cookie_and_state(Some(&format!("session={production_jwt}")), &state)
+                .await
+                .unwrap_err();
+        assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    }
+
+    /// Slot isolation: pr2-session= is rejected when the API expects pr1-session=.
+    #[tokio::test]
+    async fn different_slot_cookie_rejected() {
+        let state = make_state_with_cookie_name("pr1-session");
+        let jwt = generate_session_token(TEST_SECRET, "alice@test.com", "Alice", 3600).unwrap();
+        let err = extract_with_cookie_and_state(Some(&format!("pr2-session={jwt}")), &state)
+            .await
+            .unwrap_err();
+        assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    }
+
+    /// Custom cookie name is found correctly when mixed with other cookies,
+    /// including a same-named-prefix cookie that should not match.
+    #[tokio::test]
+    async fn custom_cookie_name_among_other_cookies() {
+        let state = make_state_with_cookie_name("pr1-session");
+        let jwt = generate_session_token(TEST_SECRET, "multi@test.com", "Multi", 3600).unwrap();
+        // "session" appears as a prefix of "pr1-session" in the cookie header —
+        // verify we match the full name and don't accidentally split on it.
+        let auth = extract_with_cookie_and_state(
+            Some(&format!("lang=en; session=garbage; pr1-session={jwt}; theme=dark")),
+            &state,
+        )
+        .await
+        .expect("should find pr1-session and ignore session=garbage");
+        assert_eq!(auth.email, "multi@test.com");
+    }
+
+    /// Bearer token still works regardless of cookie_name configuration.
+    #[tokio::test]
+    async fn bearer_works_with_custom_cookie_name() {
+        let state = make_state_with_cookie_name("pr1-session");
+        let jwt = generate_session_token(TEST_SECRET, "bob@test.com", "Bob", 3600).unwrap();
+        let req = Request::builder()
+            .uri("/test")
+            .method("GET")
+            .header(header::AUTHORIZATION, format!("Bearer {jwt}"))
+            .body(())
+            .unwrap();
+        let (mut parts, _) = req.into_parts();
+        let auth = AuthUser::from_request_parts(&mut parts, &state)
+            .await
+            .expect("bearer should work regardless of cookie_name");
+        assert_eq!(auth.email, "bob@test.com");
     }
 }

--- a/meeting-api/src/config.rs
+++ b/meeting-api/src/config.rs
@@ -34,6 +34,10 @@ pub struct Config {
     pub oauth: Option<OAuthConfig>,
     /// Cookie domain (optional, e.g. ".example.com").
     pub cookie_domain: Option<String>,
+    /// Name of the session cookie (default: "session").
+    /// Override in PR preview environments to avoid collisions with the
+    /// production cookie (which also uses `session` on a parent domain).
+    pub cookie_name: String,
     /// Whether to set the `Secure` flag on cookies (default: true).
     /// Set `COOKIE_SECURE=false` for local development over HTTP.
     pub cookie_secure: bool,
@@ -76,6 +80,8 @@ impl Config {
     /// - `LISTEN_ADDR` (default: `"0.0.0.0:8081"`)
     /// - `TOKEN_TTL_SECS` (default: `"60"`)
     /// - `COOKIE_DOMAIN`
+    /// - `COOKIE_NAME` (default: `"session"`) — set to a unique value (e.g. `"pr-session"`)
+    ///   in PR preview environments to avoid collision with the production cookie
     /// - OAuth: `OAUTH_CLIENT_ID`, `OAUTH_SECRET` (optional), `OAUTH_REDIRECT_URL`,
     ///   `OAUTH_ISSUER`, `OAUTH_AUTH_URL`, `OAUTH_TOKEN_URL`, `OAUTH_JWKS_URL`,
     ///   `OAUTH_USERINFO_URL`, `OAUTH_SCOPES` (default: `"openid email profile"`),
@@ -97,6 +103,10 @@ impl Config {
             .parse::<i64>()
             .map_err(|_| "SESSION_TTL_SECS must be a valid integer")?;
         let cookie_domain = env::var("COOKIE_DOMAIN").ok().filter(|s| !s.is_empty());
+        let cookie_name = env::var("COOKIE_NAME")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "session".to_string());
         let cookie_secure = env::var("COOKIE_SECURE")
             .map(|v| v != "false" && v != "0")
             .unwrap_or(true);
@@ -169,6 +179,7 @@ impl Config {
             session_ttl_secs,
             oauth,
             cookie_domain,
+            cookie_name,
             cookie_secure,
             cors_allowed_origin,
         })

--- a/meeting-api/src/routes/oauth.rs
+++ b/meeting-api/src/routes/oauth.rs
@@ -40,8 +40,14 @@ use crate::token;
 // ---------------------------------------------------------------------------
 
 /// Build a `Set-Cookie` header value for the session JWT.
-fn build_session_cookie(jwt: &str, ttl_secs: i64, domain: Option<&str>, secure: bool) -> String {
-    let mut cookie = format!("session={jwt}; Path=/; HttpOnly; SameSite=Lax; Max-Age={ttl_secs}");
+fn build_session_cookie(
+    name: &str,
+    jwt: &str,
+    ttl_secs: i64,
+    domain: Option<&str>,
+    secure: bool,
+) -> String {
+    let mut cookie = format!("{name}={jwt}; Path=/; HttpOnly; SameSite=Lax; Max-Age={ttl_secs}");
     if secure {
         cookie.push_str("; Secure");
     }
@@ -51,9 +57,9 @@ fn build_session_cookie(jwt: &str, ttl_secs: i64, domain: Option<&str>, secure: 
     cookie
 }
 
-/// Build a `Set-Cookie` header that clears the `session` cookie.
-fn build_clear_session_cookie(domain: Option<&str>, secure: bool) -> String {
-    let mut cookie = "session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0".to_string();
+/// Build a `Set-Cookie` header that clears the session cookie.
+fn build_clear_session_cookie(name: &str, domain: Option<&str>, secure: bool) -> String {
+    let mut cookie = format!("{name}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0");
     if secure {
         cookie.push_str("; Secure");
     }
@@ -227,6 +233,7 @@ pub async fn callback(
     };
 
     let session_cookie = build_session_cookie(
+        &state.cookie_name,
         &session_jwt,
         state.session_ttl_secs,
         state.cookie_domain.as_deref(),
@@ -268,7 +275,11 @@ pub async fn get_profile(AuthUser { email, name }: AuthUser) -> Json<APIResponse
 
 /// GET /logout -- clears the session cookie.
 pub async fn logout(State(state): State<AppState>) -> Result<Response, AppError> {
-    let clear = build_clear_session_cookie(state.cookie_domain.as_deref(), state.cookie_secure);
+    let clear = build_clear_session_cookie(
+        &state.cookie_name,
+        state.cookie_domain.as_deref(),
+        state.cookie_secure,
+    );
     let mut response = StatusCode::OK.into_response();
     response.headers_mut().append(
         header::SET_COOKIE,

--- a/meeting-api/src/routes/oauth.rs
+++ b/meeting-api/src/routes/oauth.rs
@@ -292,3 +292,83 @@ pub async fn logout(State(state): State<AppState>) -> Result<Response, AppError>
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- build_session_cookie ---
+
+    #[test]
+    fn session_cookie_contains_name_and_jwt() {
+        let cookie = build_session_cookie("session", "my.jwt.token", 3600, None, false);
+        assert!(cookie.starts_with("session=my.jwt.token;"));
+    }
+
+    #[test]
+    fn session_cookie_custom_name() {
+        let cookie = build_session_cookie("pr1-session", "my.jwt.token", 3600, None, false);
+        assert!(cookie.starts_with("pr1-session=my.jwt.token;"));
+        // Must not accidentally also contain the old name.
+        assert!(!cookie.contains("session=my.jwt.token;") || cookie.starts_with("pr1-session="));
+    }
+
+    #[test]
+    fn session_cookie_includes_required_attributes() {
+        let cookie = build_session_cookie("session", "tok", 3600, None, false);
+        assert!(cookie.contains("Path=/"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert!(cookie.contains("Max-Age=3600"));
+    }
+
+    #[test]
+    fn session_cookie_secure_flag_added_when_true() {
+        let cookie = build_session_cookie("session", "tok", 3600, None, true);
+        assert!(cookie.contains("; Secure"));
+    }
+
+    #[test]
+    fn session_cookie_no_secure_flag_when_false() {
+        let cookie = build_session_cookie("session", "tok", 3600, None, false);
+        assert!(!cookie.contains("Secure"));
+    }
+
+    #[test]
+    fn session_cookie_domain_appended() {
+        let cookie = build_session_cookie("session", "tok", 3600, Some(".sandbox.videocall.rs"), false);
+        assert!(cookie.contains("Domain=.sandbox.videocall.rs"));
+    }
+
+    #[test]
+    fn session_cookie_no_domain_when_none() {
+        let cookie = build_session_cookie("session", "tok", 3600, None, false);
+        assert!(!cookie.contains("Domain="));
+    }
+
+    // --- build_clear_session_cookie ---
+
+    #[test]
+    fn clear_cookie_uses_name() {
+        let cookie = build_clear_session_cookie("session", None, false);
+        assert!(cookie.starts_with("session=;"));
+    }
+
+    #[test]
+    fn clear_cookie_custom_name() {
+        let cookie = build_clear_session_cookie("pr1-session", None, false);
+        assert!(cookie.starts_with("pr1-session=;"));
+    }
+
+    #[test]
+    fn clear_cookie_sets_max_age_zero() {
+        let cookie = build_clear_session_cookie("session", None, false);
+        assert!(cookie.contains("Max-Age=0"));
+    }
+
+    #[test]
+    fn clear_cookie_domain_appended() {
+        let cookie = build_clear_session_cookie("session", Some(".videocall.rs"), false);
+        assert!(cookie.contains("Domain=.videocall.rs"));
+    }
+}

--- a/meeting-api/src/state.rs
+++ b/meeting-api/src/state.rs
@@ -37,6 +37,10 @@ pub struct AppState {
     pub jwks_cache: Option<Arc<JwksCache>>,
     /// Cookie domain (e.g. ".example.com"), or `None` for default.
     pub cookie_domain: Option<String>,
+    /// Name of the session cookie (default: "session").
+    /// Set to a unique value in PR preview environments to avoid collision
+    /// with the production cookie that shares the same parent domain.
+    pub cookie_name: String,
     /// Whether to set the `Secure` flag on cookies.
     pub cookie_secure: bool,
 }
@@ -57,6 +61,7 @@ impl AppState {
             oauth: config.oauth.clone(),
             jwks_cache,
             cookie_domain: config.cookie_domain.clone(),
+            cookie_name: config.cookie_name.clone(),
             cookie_secure: config.cookie_secure,
         }
     }

--- a/meeting-api/tests/test_helpers.rs
+++ b/meeting-api/tests/test_helpers.rs
@@ -61,6 +61,7 @@ pub fn build_app(pool: PgPool) -> Router {
         oauth: None,
         jwks_cache: None,
         cookie_domain: None,
+        cookie_name: "session".to_string(),
         cookie_secure: false,
     };
     routes::router().with_state(state)


### PR DESCRIPTION
@darioalessandro  this fixes the issue we saw with cookie collision in PR Previews - presently PR Previews best work in incognito to avoid cookie name collision.

## Summary

- Production `api.videocall.rs` sets a `session` cookie with `Domain=.videocall.rs`. PR preview APIs at `pr{N}-api.sandbox.videocall.rs` are subdomains of `videocall.rs`, so browsers send the production cookie there too. The preview API validates it with a different `JWT_SECRET` → 401.
- Confirmed by: auth works in incognito (no production cookies), fails in a normal browser session.
- Fix: add `COOKIE_NAME` env var (default: `"session"`). PR previews set `COOKIE_NAME=pr${SLOT}-session` (e.g. `pr1-session`, `pr2-session`) — distinct from production and from each other.

## Changes

- `meeting-api/src/config.rs` — add `cookie_name` field, read from `COOKIE_NAME` env var
- `meeting-api/src/state.rs` — propagate `cookie_name` through `AppState`
- `meeting-api/src/routes/oauth.rs` — use `state.cookie_name` in `Set-Cookie` headers
- `meeting-api/src/auth.rs` — use `state.cookie_name` when parsing `Cookie` header
- `helm/meeting-api/values.yaml` — document `COOKIE_NAME` with default `"session"`
- `.github/workflows/pr-deploy-reusable.yaml` — set `COOKIE_NAME=pr${SLOT}-session` for preview deployments

## Test plan

- [ ] 66 unit tests pass (`cargo test -p meeting-api`)
- [ ] New regression test `production_session_cookie_rejected_by_preview_api` explicitly guards against the collision bug
- [ ] New tests for `build_session_cookie` / `build_clear_session_cookie` cookie builders
- [ ] After merge, redeploy a PR preview and confirm OAuth login no longer returns 401

> **Note:** The workflow change in `.github/workflows/pr-deploy-reusable.yaml` must be merged to `main` before it takes effect — `issue_comment` triggered workflows always run from the default branch.
