### PR TITLE
fix: use pull_request_target for welcome comment on fork PRs

### DIFF
--- a/.github/workflows/pr-welcome.yaml
+++ b/.github/workflows/pr-welcome.yaml
@@ -1,7 +1,7 @@
 name: Welcome New PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
## Summary

- The `pr-welcome.yaml` workflow used `on: pull_request`, which GitHub restricts to a **read-only** `GITHUB_TOKEN` for PRs from forks
- This caused the `issues.createComment` call to fail with `403 Resource not accessible by integration`
- Changed to `on: pull_request_target`, which runs in the base-repo context and respects the `pull-requests: write` permission already declared

## Security Note

`pull_request_target` is safe here because this workflow **never checks out or executes code from the fork** — it only reads PR metadata and posts a comment. This is the standard GitHub-recommended pattern for this use case.

## Test plan

- [ ] Open a new PR from a fork and verify the welcome comment is posted successfully