### PR TITLE
fix: remove trailing whitespace after backslash in helm meeting-api deploy step

### DIFF
--- a/.github/workflows/pr-deploy-reusable.yaml
+++ b/.github/workflows/pr-deploy-reusable.yaml
@@ -513,7 +513,7 @@ jobs:
             --set "env[12].name=COOKIE_NAME" \
             --set "env[12].value=pr${SLOT}-session" \
             --set "env[13].name=ALLOWED_REDIRECT_URLS" \
-            --set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs" \            
+            --set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs" \
             --set "ingress.hosts[0].host=pr${SLOT}-api.sandbox.videocall.rs" \
             --set "ingress.hosts[0].paths[0].path=/" \
             --set "ingress.hosts[0].paths[0].pathType=Prefix" \


### PR DESCRIPTION
## Problem

A trailing-whitespace-after-backslash typo on the `ALLOWED_REDIRECT_URLS` line of the `Deploy Meeting API` step causes `bash` to terminate the `helm upgrade` command early, dropping all ingress and TLS flags. The orphaned `--set` flags on subsequent lines then fail as invalid shell commands, producing:

```
Error: "helm upgrade" requires 2 argument
```

## Root cause

In bash, `\<newline>` is a line continuation. But `\<spaces><newline>` is **not** — the `\` escapes the first space, and the newline terminates the command. This line in `pr-deploy-reusable.yaml` had 12 trailing spaces after the `\`:

```
--set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs" \            
                                                               ^^^^^^^^^^^^
```

Introduced in #682 when `ALLOWED_REDIRECT_URLS` was added.

## Fix

Remove the trailing spaces so the backslash is immediately followed by the newline, restoring the line continuation.

## Test plan

- [ ] Open a PR to trigger the preview deploy workflow — `Deploy Meeting API` step should complete without `"helm upgrade" requires 2 argument` error
- [ ] Ingress and TLS flags are now correctly passed to helm