### PR TITLE
feat: deploy Dioxus UI alongside Yew in PR previews

### DIFF
--- a/.github/workflows/pr-build-and-deploy.yaml
+++ b/.github/workflows/pr-build-and-deploy.yaml
@@ -139,6 +139,9 @@ jobs:
           - name: web-ui
             dockerfile: Dockerfile.yew
             image: videocall-web-ui
+          - name: dioxus-ui
+            dockerfile: Dockerfile.dioxus
+            image: videocall-dioxus-ui
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v4
@@ -185,6 +188,7 @@ jobs:
             - \`ghcr.io/${{ github.repository_owner }}/videocall-media-server:pr-${prNumber}\`
             - \`ghcr.io/${{ github.repository_owner }}/videocall-meeting-api:pr-${prNumber}\`
             - \`ghcr.io/${{ github.repository_owner }}/videocall-web-ui:pr-${prNumber}\`
+            - \`ghcr.io/${{ github.repository_owner }}/videocall-dioxus-ui:pr-${prNumber}\`
 
             🚀 **Starting deployment...**
 

--- a/.github/workflows/pr-deploy-reusable.yaml
+++ b/.github/workflows/pr-deploy-reusable.yaml
@@ -200,6 +200,7 @@ jobs:
             "videocall-media-server"
             "videocall-meeting-api"
             "videocall-web-ui"
+            "videocall-dioxus-ui"
           )
 
           rm -f /tmp/missing_images_${PR_NUM}
@@ -344,7 +345,7 @@ jobs:
               requests.memory: "1Gi"
               limits.cpu: "1000m"
               limits.memory: "2Gi"
-              pods: "10"
+              pods: "12"
           EOF
 
           echo "✅ ResourceQuota applied to slot ${SLOT}"
@@ -491,7 +492,7 @@ jobs:
             --set "env[1].valueFrom.secretKeyRef.name=jwt-secret" \
             --set "env[1].valueFrom.secretKeyRef.key=secret" \
             --set "env[2].name=CORS_ALLOWED_ORIGIN" \
-            --set "env[2].value=https://pr${SLOT}.sandbox.videocall.rs" \
+            --set "env[2].value=https://pr${SLOT}.sandbox.videocall.rs,https://pr${SLOT}-dx.sandbox.videocall.rs" \
             --set "env[3].name=COOKIE_DOMAIN" \
             --set "env[3].value=.sandbox.videocall.rs" \
             --set "env[4].name=OAUTH_ISSUER" \
@@ -513,7 +514,7 @@ jobs:
             --set "env[12].name=COOKIE_NAME" \
             --set "env[12].value=pr${SLOT}-session" \
             --set "env[13].name=ALLOWED_REDIRECT_URLS" \
-            --set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs" \
+            --set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs,https://pr${SLOT}-dx.sandbox.videocall.rs" \
             --set "ingress.hosts[0].host=pr${SLOT}-api.sandbox.videocall.rs" \
             --set "ingress.hosts[0].paths[0].path=/" \
             --set "ingress.hosts[0].paths[0].pathType=Prefix" \
@@ -567,6 +568,44 @@ jobs:
 
           echo "✅ UI deployed to slot ${SLOT} with OAuth"
 
+      - name: Deploy Dioxus UI
+        run: |
+          PR_NUM=${{ inputs.pr_number }}
+          SLOT=${{ steps.assign-slot.outputs.SLOT }}
+          NAMESPACE="preview-slot-${SLOT}"
+
+          echo "Deploying Dioxus UI to slot ${SLOT}..."
+
+          helm upgrade --install preview-${PR_NUM}-dx helm/videocall-ui/ \
+            --namespace ${NAMESPACE} \
+            --set image.repository=ghcr.io/${{ github.repository_owner }}/videocall-dioxus-ui \
+            --set image.tag=pr-${PR_NUM} \
+            --set fullnameOverride=dx-pr-${PR_NUM} \
+            --set "runtimeConfig.apiBaseUrl=https://pr${SLOT}-api.sandbox.videocall.rs" \
+            --set "runtimeConfig.meetingApiBaseUrl=https://pr${SLOT}-api.sandbox.videocall.rs" \
+            --set "runtimeConfig.wsUrl=wss://pr${SLOT}-ws.sandbox.videocall.rs" \
+            --set "runtimeConfig.webTransportHost=" \
+            --set-string "runtimeConfig.webTransportEnabled=false" \
+            --set-string "runtimeConfig.oauthEnabled=true" \
+            --set-string "runtimeConfig.oauthProvider=google" \
+            --set-string "runtimeConfig.e2eeEnabled=false" \
+            --set-string "runtimeConfig.firefoxEnabled=false" \
+            --set "runtimeConfig.usersAllowedToStream=" \
+            --set "runtimeConfig.serverElectionPeriodMs=2000" \
+            --set "runtimeConfig.audioBitrateKbps=65" \
+            --set "runtimeConfig.videoBitrateKbps=1000" \
+            --set "runtimeConfig.screenBitrateKbps=1000" \
+            --set "ingress.hosts[0].host=pr${SLOT}-dx.sandbox.videocall.rs" \
+            --set "ingress.hosts[0].paths[0].path=/" \
+            --set "ingress.hosts[0].paths[0].pathType=Prefix" \
+            --set "ingress.tls[0].secretName=sandbox-wildcard-tls" \
+            --set "ingress.tls[0].hosts[0]=pr${SLOT}-dx.sandbox.videocall.rs" \
+            --set "ingress.annotations.cert-manager\.io/issuer=null" \
+            --set "ingress.annotations.kubernetes\.io/tls-acme=null" \
+            --wait --timeout 5m
+
+          echo "✅ Dioxus UI deployed to slot ${SLOT}"
+
       - name: Wait for all pods to be ready
         run: |
           SLOT=${{ steps.assign-slot.outputs.SLOT }}
@@ -612,7 +651,8 @@ jobs:
               body: `✅ **Preview ${deploymentType} to slot ${slot}** ${slotStatus}
 
             🌐 **Preview URLs:**
-            - **UI:** https://pr${slot}.sandbox.videocall.rs
+            - **Yew UI:** https://pr${slot}.sandbox.videocall.rs
+            - **Dioxus UI:** https://pr${slot}-dx.sandbox.videocall.rs
             - **API:** https://pr${slot}-api.sandbox.videocall.rs
             - **WebSocket:** wss://pr${slot}-ws.sandbox.videocall.rs
 

--- a/.github/workflows/pr-deploy-reusable.yaml
+++ b/.github/workflows/pr-deploy-reusable.yaml
@@ -492,7 +492,7 @@ jobs:
             --set "env[1].valueFrom.secretKeyRef.name=jwt-secret" \
             --set "env[1].valueFrom.secretKeyRef.key=secret" \
             --set "env[2].name=CORS_ALLOWED_ORIGIN" \
-            --set "env[2].value=https://pr${SLOT}.sandbox.videocall.rs,https://pr${SLOT}-dx.sandbox.videocall.rs" \
+            --set "env[2].value=https://pr${SLOT}.sandbox.videocall.rs\,https://pr${SLOT}-dx.sandbox.videocall.rs" \
             --set "env[3].name=COOKIE_DOMAIN" \
             --set "env[3].value=.sandbox.videocall.rs" \
             --set "env[4].name=OAUTH_ISSUER" \
@@ -514,7 +514,7 @@ jobs:
             --set "env[12].name=COOKIE_NAME" \
             --set "env[12].value=pr${SLOT}-session" \
             --set "env[13].name=ALLOWED_REDIRECT_URLS" \
-            --set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs,https://pr${SLOT}-dx.sandbox.videocall.rs" \
+            --set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs\,https://pr${SLOT}-dx.sandbox.videocall.rs" \
             --set "ingress.hosts[0].host=pr${SLOT}-api.sandbox.videocall.rs" \
             --set "ingress.hosts[0].paths[0].path=/" \
             --set "ingress.hosts[0].paths[0].pathType=Prefix" \


### PR DESCRIPTION
We have a similar workflow on an internal hosted agent and it works properly, this one should as well, but the devil is in the details....

## Summary

- Each PR preview slot now deploys **both** the Yew UI and the Dioxus UI side by side
- Yew UI: `pr{N}.sandbox.videocall.rs` (unchanged)
- Dioxus UI: `pr{N}-dx.sandbox.videocall.rs` (new)
- Both UIs share the same Meeting API and WebSocket backend in the slot

## Changes

**`pr-build-and-deploy.yaml`**
- Added `dioxus-ui` matrix entry (`Dockerfile.dioxus` → `videocall-dioxus-ui` image on GHCR)
- Build success comment now lists all 4 images

**`pr-deploy-reusable.yaml`**
- `videocall-dioxus-ui` added to the GHCR verify-images pre-flight check
- `CORS_ALLOWED_ORIGIN` on the Meeting API now includes both Yew and Dioxus origins — without this the browser blocks API calls from the Dioxus UI
- `ALLOWED_REDIRECT_URLS` includes both origins so OAuth `returnTo` works correctly from either UI
- New **Deploy Dioxus UI** step at `pr{N}-dx.sandbox.videocall.rs` using `helm/videocall-ui/`
- Pod quota bumped 10 → 12 to accommodate the extra pod per slot
- Success comment lists both **Yew UI** and **Dioxus UI** URLs

No `helm/videocall-ui/` changes needed here — GHCR images are public so no `imagePullSecrets` required (unlike the HCL environment).

## Test plan

- [ ] Comment `/build-and-deploy` on a test PR
- [ ] Verify build success comment lists all 4 images including `videocall-dioxus-ui`
- [ ] Verify success comment shows both Yew and Dioxus URLs
- [ ] Confirm Yew UI loads at `pr{N}.sandbox.videocall.rs`
- [ ] Confirm Dioxus UI loads at `pr{N}-dx.sandbox.videocall.rs`
- [ ] Confirm OAuth login works from both UIs (each redirects back to its own origin)
- [ ] Comment `/undeploy` — verify slot fully freed (namespace delete cascades to all pods)