### PR TITLE
revert change from PR 703, webtransport should be enabled by default

### DIFF
--- a/yew-ui/scripts/config.js
+++ b/yew-ui/scripts/config.js
@@ -4,7 +4,7 @@ window.__APP_CONFIG = Object.freeze({
   webTransportHost: "https://127.0.0.1:4433",
   oauthEnabled: "true",
   e2eeEnabled: "false",
-  webTransportEnabled: "false",
+  webTransportEnabled: "true",
   firefoxEnabled: "false",
   usersAllowedToStream: "",
   serverElectionPeriodMs: 2000,


### PR DESCRIPTION
@testradav questioned this https://github.com/security-union/videocall-rs/pull/703#discussion_r2880190357 and I was off in the weeds.  This corrects (reverts) that change.

