### PR TITLE
Display participant name and email in waiting room

### DIFF
--- a/dioxus-ui/src/components/host_controls.rs
+++ b/dioxus-ui/src/components/host_controls.rs
@@ -145,24 +145,50 @@ pub fn HostControls(
                     for participant in waiting().iter() {
                         {
                             let email = participant.email.clone();
+                            let display_name = participant.display_name.clone();
+
+                            let email_for_key = email.clone();
+                            let email_for_view = email.clone();
                             let email_admit = email.clone();
                             let email_reject = email.clone();
+
                             let meeting_id_admit = meeting_id.clone();
                             let meeting_id_reject = meeting_id.clone();
+
                             let fetch_admit = fetch_waiting_list.clone();
                             let fetch_reject = fetch_waiting_list.clone();
+
+                            let mut waiting_admit = waiting.clone();
+                            let mut waiting_reject = waiting.clone();
+
+                            let mut error_admit = error.clone();
+                            let mut error_reject = error.clone();
+
                             rsx! {
-                                div { key: "{email}", class: "waiting-participant",
-                                    span { class: "participant-email", "{email}" }
+                                div { key: "{email_for_key}", class: "waiting-participant",
+                                    div { class: "participant-info",
+                                        if let Some(name) = display_name.clone() {
+                                            if !name.trim().is_empty() {
+                                                div { class: "participant-name", "{name}" }
+                                                div { class: "participant-email", "{email_for_view}" }
+                                            } else {
+                                                div { class: "participant-name", "{email_for_view}" }
+                                            }
+                                        } else {
+                                            div { class: "participant-name", "{email_for_view}" }
+                                        }
+                                    }
                                     div { class: "participant-actions",
                                         button {
                                             class: "btn-admit",
                                             title: "Admit",
                                             onclick: move |_| {
-                                                waiting.write().retain(|p| p.email != email_admit);
+                                                waiting_admit.write().retain(|p| p.email != email_admit);
                                                 let email = email_admit.clone();
                                                 let meeting_id = meeting_id_admit.clone();
                                                 let fetch = fetch_admit.clone();
+                                                let mut error = error_admit.clone();
+
                                                 spawn(async move {
                                                     match admit_participant(&meeting_id, &email).await {
                                                         Ok(_) => fetch(),
@@ -184,10 +210,12 @@ pub fn HostControls(
                                             class: "btn-reject",
                                             title: "Reject",
                                             onclick: move |_| {
-                                                waiting.write().retain(|p| p.email != email_reject);
+                                                waiting_reject.write().retain(|p| p.email != email_reject);
                                                 let email = email_reject.clone();
                                                 let meeting_id = meeting_id_reject.clone();
                                                 let fetch = fetch_reject.clone();
+                                                let mut error = error_reject.clone();
+
                                                 spawn(async move {
                                                     match reject_participant(&meeting_id, &email).await {
                                                         Ok(_) => fetch(),

--- a/dioxus-ui/static/global.css
+++ b/dioxus-ui/static/global.css
@@ -1348,3 +1348,40 @@ body {
 .auth-dropdown-signout:hover {
     background: rgba(255, 107, 107, 0.1);
 }
+
+/* Waiting room participant layout */
+.waiting-participant {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.participant-info {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.participant-name {
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.participant-email {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.2;
+  margin-top: 2px;
+  word-break: break-all;
+}
+
+.participant-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary
Display participant display name in the waiting room instead of showing only the email. 
The host can now see both the participant name and email in the waiting list UI.

Example:
Palina Piliushyna
paliina.piliushyna@gmail.com

This improves readability in the waiting room, especially when multiple participants join.

Related issue: #654

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change
- [ ] Project / Infra

## Testing
- [ ] Tests written or updated
- [x] No tests needed

Manual test:
- Join meeting as participant
- Enter display name
- Verify host sees display name and email in waiting room

## Other
- [ ] Documentation updated
- [x] Before/After Images provided
<img width="470" height="207" alt="Screenshot 2026-03-09 165022" src="https://github.com/user-attachments/assets/7a751658-7f81-48dd-b95f-21d5b2770e38" />


