### PR TITLE
App blows up if you do not have a connected camera AND or microphone (#730)

### DIFF
--- a/dioxus-ui/src/components/attendants.rs
+++ b/dioxus-ui/src/components/attendants.rs
@@ -44,8 +44,10 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use videocall_client::utils::is_ios;
 use videocall_client::Callback as VcCallback;
+use wasm_bindgen::{closure::Closure, JsCast};
 use videocall_client::{
-    MediaDeviceAccess, ScreenShareEvent, VideoCallClient, VideoCallClientOptions,
+    MediaAccessKind, MediaDeviceAccess, MediaPermission, MediaPermissionsErrorState,
+    PermissionState, ScreenShareEvent, VideoCallClient, VideoCallClientOptions,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -53,6 +55,29 @@ pub enum ScreenShareState {
     Idle,
     Requesting,
     Active,
+}
+
+pub enum MediaErrorState {
+    NoDevice,
+    PermissionDenied,
+    Other,
+}
+
+fn render_single_device_error(device: &str, err: &MediaErrorState) -> Element {
+    match err {
+        MediaErrorState::NoDevice => rsx! {
+            p { " {device} not found on this device." }
+        },
+        MediaErrorState::Other => rsx! {
+            p { " {device} has an unexpected problem." }
+        },
+        MediaErrorState::PermissionDenied => rsx! {
+            p { " {device} is blocked in your browser." }
+            p { style: "front-size: 0.9rem; opacity: 0.8;",
+                "Please click the lock icon in your browser's address bar and allow access if you want to use it."
+            }
+        },
+    }
 }
 
 impl ScreenShareState {
@@ -379,6 +404,12 @@ pub fn AttendantsComponent(
     let mut meeting_info_open = use_signal(|| false);
     let peer_list_version = use_signal(|| 0u32);
     let media_access_granted = use_signal(|| false);
+    let mic_error = use_signal(|| None::<MediaErrorState>);
+    let video_error = use_signal(|| None::<MediaErrorState>);
+    let mut show_device_warning = use_signal(|| false);
+    let reload_devices_counter = use_signal(|| 0u32);
+    let mut device_was_denied = use_signal(|| false);
+    let session_loaded = use_signal(|| false);
     let local_speaking = use_signal(|| false);
     let mut pending_mic_enable = use_signal(|| false);
     let mut pending_video_enable = use_signal(|| false);
@@ -448,8 +479,10 @@ pub fn AttendantsComponent(
                 log::info!("DIOXUS-UI: Connection established");
                 let mut connection_error = connection_error;
                 let mut call_start_time = call_start_time;
+                let mut session_loaded = session_loaded;
                 connection_error.set(None);
                 call_start_time.set(Some(js_sys::Date::now()));
+                session_loaded.set(true);
             }),
             on_connection_lost: {
                 let id = id.clone();
@@ -632,41 +665,110 @@ pub fn AttendantsComponent(
     let mda = use_hook(|| {
         let mut mda = MediaDeviceAccess::new();
         let client_cell = RefCell::new(client.clone());
-        mda.on_granted = VcCallback::from(move |_| {
+        mda.on_result = VcCallback::from(move |permit: MediaPermission| {
+            let mut connection_error = connection_error;
             let mut media_access_granted = media_access_granted;
             let mut meeting_joined = meeting_joined;
             let mut mic_enabled = mic_enabled;
             let mut video_enabled = video_enabled;
             let mut pending_mic_enable = pending_mic_enable;
             let mut pending_video_enable = pending_video_enable;
+            let mut mic_error = mic_error;
+            let mut video_error = video_error;
+            let mut show_device_warning = show_device_warning;
+            let mut reload_devices_counter = reload_devices_counter;
+            let mut device_was_denied = device_was_denied;
+
+            connection_error.set(None);
+            mic_error.set(None);
+            video_error.set(None);
             media_access_granted.set(true);
 
             // Fulfil any pending mic/camera enables that triggered the permission request.
-            if pending_mic_enable() {
+            if matches!(permit.audio, PermissionState::Granted) && pending_mic_enable() {
                 mic_enabled.set(true);
                 pending_mic_enable.set(false);
             }
-            if pending_video_enable() {
+            if matches!(permit.video, PermissionState::Granted) && pending_video_enable() {
                 video_enabled.set(true);
                 pending_video_enable.set(false);
             }
 
-            // Connect after permissions granted
-            if let Err(e) = client_cell.borrow_mut().connect() {
-                log::error!("Connection failed: {e:?}");
+            match &permit.audio {
+                PermissionState::Denied(MediaPermissionsErrorState::NoDevice) => {
+                    mic_error.set(Some(MediaErrorState::NoDevice));
+                }
+                PermissionState::Denied(MediaPermissionsErrorState::PermissionDenied) => {
+                    mic_error.set(Some(MediaErrorState::PermissionDenied));
+                }
+                PermissionState::Denied(MediaPermissionsErrorState::Other(_)) => {
+                    mic_error.set(Some(MediaErrorState::Other));
+                }
+                _ => {}
             }
-            meeting_joined.set(true);
-        });
-        mda.on_denied = VcCallback::from(move |e| {
-            let mut connection_error = connection_error;
-            let mut meeting_joined = meeting_joined;
-            let complete_error = format!("Error requesting permissions: Please make sure to allow access to both camera and microphone. ({e:?})");
-            error!("{complete_error}");
-            connection_error.set(Some(complete_error));
-            meeting_joined.set(false);
+
+            match &permit.video {
+                PermissionState::Denied(MediaPermissionsErrorState::NoDevice) => {
+                    video_error.set(Some(MediaErrorState::NoDevice));
+                }
+                PermissionState::Denied(MediaPermissionsErrorState::PermissionDenied) => {
+                    video_error.set(Some(MediaErrorState::PermissionDenied));
+                }
+                PermissionState::Denied(MediaPermissionsErrorState::Other(_)) => {
+                    video_error.set(Some(MediaErrorState::Other));
+                }
+                _ => {}
+            }
+
+            if (mic_error.read().is_some() || video_error.read().is_some()) && !session_loaded() {
+                show_device_warning.set(true);
+                meeting_joined.set(false);
+            } else {
+                if let Err(e) = client_cell.borrow_mut().connect() {
+                    log::error!("Connection failed: {e:?}");
+                }
+                meeting_joined.set(true);
+            }
+
+            if device_was_denied() {
+                device_was_denied.set(false);
+                reload_devices_counter.set(reload_devices_counter() + 1);
+            }
         });
         Rc::new(RefCell::new(mda))
     });
+
+    // Re-check permissions when the window regains focus, mirroring Yew behavior.
+    {
+        let mda = mda.clone();
+        use_effect(move || {
+
+            let value = mda.clone();
+            let closure = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+                let mic_denied = matches!(
+                    mic_error.read().as_ref(),
+                    Some(MediaErrorState::PermissionDenied)
+                );
+                let video_denied = matches!(
+                    video_error.read().as_ref(),
+                    Some(MediaErrorState::PermissionDenied)
+                );
+
+                if mic_denied || video_denied {
+                    device_was_denied.set(true);
+                }
+                value.borrow().request();
+            }) as Box<dyn FnMut(_)>);
+
+            if let Some(win) = web_sys::window() {
+                let _ = win.add_event_listener_with_callback(
+                    "focus",
+                    closure.as_ref().unchecked_ref(),
+                );
+            }
+            closure.forget();
+        });
+    }
 
     // Provide contexts for child components
     use_context_provider(|| client.clone());
@@ -877,6 +979,36 @@ pub fn AttendantsComponent(
                         },
                         if is_owner { "Start Meeting" } else { "Join Meeting" }
                     }
+                    if show_device_warning() {
+                        div { class: "modal-overlay",
+                            div { class: "modal-window",
+                                h3 { "Device access problem" }
+                                if let Some(err) = mic_error.read().as_ref() {
+                                    { render_single_device_error("Microphone", err) }
+                                }
+                                if let Some(err) = video_error.read().as_ref() {
+                                    { render_single_device_error("Camera", err) }
+                                }
+                                {
+                                    let mut client = client.clone();
+                                    rsx! {
+                                        button {
+                                            class: "btn-apple btn-primary",
+                                            style: "margin-top: 1.5rem;",
+                                            onclick: move |_| {
+                                                show_device_warning.set(false);
+                                                if let Err(e) = client.connect() {
+                                                    error!("Connection failed: {e:?}");
+                                                }
+                                                meeting_joined.set(true);
+                                            },
+                                            "Ok"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         };
@@ -1038,9 +1170,10 @@ pub fn AttendantsComponent(
                                         rsx! {
                                             MicButton {
                                                 enabled: mic_enabled(),
+                                                available: mic_error.read().is_none(),
                                                 onclick: move |_| {
                                                     if !mic_enabled() {
-                                                        if media_access_granted() {
+                                                        if mda_mic.borrow().is_granted(MediaAccessKind::AudioCheck) {
                                                             mic_enabled.set(true);
                                                         } else {
                                                             pending_mic_enable.set(true);
@@ -1058,9 +1191,10 @@ pub fn AttendantsComponent(
                                         rsx! {
                                             CameraButton {
                                                 enabled: video_enabled(),
+                                                available: video_error.read().is_none(),
                                                 onclick: move |_| {
                                                     if !video_enabled() {
-                                                        if media_access_granted() {
+                                                        if mda_cam.borrow().is_granted(MediaAccessKind::VideoCheck) {
                                                             video_enabled.set(true);
                                                             // "Warm up" the video element in this user-gesture
                                                             // call stack.  Safari blocks play() outside user
@@ -1220,6 +1354,7 @@ pub fn AttendantsComponent(
                                             }
                                         }
                                     },
+                                    reload_devices_counter: reload_devices_counter(),
                                 }
                             }
                             {

--- a/dioxus-ui/src/components/host.rs
+++ b/dioxus-ui/src/components/host.rs
@@ -73,6 +73,7 @@ pub fn Host(
     #[props(default)] on_microphone_error: EventHandler<String>,
     #[props(default)] on_camera_error: EventHandler<String>,
     on_screen_share_state: EventHandler<ScreenShareEvent>,
+    reload_devices_counter: u32,
 ) -> Element {
     let client = use_context::<VideoCallClientCtx>();
 
@@ -185,6 +186,7 @@ pub fn Host(
             prev_mic_enabled: false,
             prev_video_enabled: false,
             initialized: false,
+            last_reload_counter: 0,
         }))
     });
 
@@ -200,6 +202,7 @@ pub fn Host(
     // Initialize devices once
     {
         let state = state.clone();
+        let value = client.clone();
         use_effect(move || {
             let state_for_loaded = state.clone();
             let mut s = state.borrow_mut();
@@ -283,7 +286,53 @@ pub fn Host(
                         .forget();
                     }
                 });
-                s.media_devices.on_devices_changed = VcCallback::noop();
+                let state_for_devices_changed = state.clone();
+                let client_for_devices_changed = value.clone();
+                s.media_devices.on_devices_changed = VcCallback::from(move |_| {
+                    let mut s = state_for_devices_changed.borrow_mut();
+
+                    let audio_device_id = s.media_devices.audio_inputs.selected();
+                    let video_device_id = s.media_devices.video_inputs.selected();
+                    let speaker_device_id = s.media_devices.audio_outputs.selected();
+
+                    let mut mic_needs_start = false;
+                    if !audio_device_id.is_empty() {
+                        s.media_devices.audio_inputs.select(&audio_device_id);
+                        mic_needs_start = s.microphone.select(audio_device_id);
+                    }
+
+                    let mut cam_needs_start = false;
+                    if !video_device_id.is_empty() {
+                        s.media_devices.video_inputs.select(&video_device_id);
+                        cam_needs_start = s.camera.select(video_device_id);
+                    }
+
+                    if !speaker_device_id.is_empty() {
+                        s.media_devices.audio_outputs.select(&speaker_device_id);
+                        if let Err(e) =
+                            client_for_devices_changed.update_speaker_device(Some(speaker_device_id))
+                        {
+                            log::error!("Failed to update speaker device: {e:?}");
+                        }
+                    }
+
+                    drop(s);
+
+                    if mic_needs_start {
+                        let sc = state_for_devices_changed.clone();
+                        Timeout::new(1000, move || {
+                            sc.borrow_mut().microphone.start();
+                        })
+                        .forget();
+                    }
+                    if cam_needs_start {
+                        let sc = state_for_devices_changed.clone();
+                        Timeout::new(1000, move || {
+                            sc.borrow_mut().camera.start();
+                        })
+                        .forget();
+                    }
+                });
                 s.media_devices.load();
                 s.initialized = true;
             }
@@ -296,6 +345,11 @@ pub fn Host(
     // function itself re-runs whenever the parent passes new prop values.
     {
         let mut s = state.borrow_mut();
+
+        if s.last_reload_counter != reload_devices_counter {
+            s.media_devices.load();
+            s.last_reload_counter = reload_devices_counter;
+        }
 
         log::info!(
             "Host render: video={video_enabled} prev={} mic={mic_enabled} prev={} screen={share_screen} prev={}",
@@ -639,4 +693,5 @@ struct HostState {
     prev_mic_enabled: bool,
     prev_video_enabled: bool,
     initialized: bool,
+    last_reload_counter: u32,
 }

--- a/dioxus-ui/src/components/video_control_buttons.rs
+++ b/dioxus-ui/src/components/video_control_buttons.rs
@@ -20,15 +20,19 @@ use dioxus::prelude::*;
 // =============================================================================
 
 #[component]
-pub fn MicButton(enabled: bool, onclick: EventHandler<MouseEvent>) -> Element {
-    let class = if enabled {
-        "video-control-button active"
-    } else {
-        "video-control-button"
+pub fn MicButton(enabled: bool, available: bool, onclick: EventHandler<MouseEvent>) -> Element {
+    let class = match (enabled, available) {
+        (true, false) => "video-control-button active error",
+        (true, true) => "video-control-button active",
+        (false, false) => "video-control-button error",
+        (false, true) => "video-control-button",
     };
 
     rsx! {
-        button { class, onclick: move |evt| onclick.call(evt),
+        button {
+            class,
+            disabled: !available,
+            onclick: move |evt| onclick.call(evt),
             if enabled {
                 svg {
                     xmlns: "http://www.w3.org/2000/svg",
@@ -59,6 +63,9 @@ pub fn MicButton(enabled: bool, onclick: EventHandler<MouseEvent>) -> Element {
                 }
                 span { class: "tooltip", "Unmute" }
             }
+            if !available {
+                span { class: "device-warning", "!" }
+            }
         }
     }
 }
@@ -68,15 +75,19 @@ pub fn MicButton(enabled: bool, onclick: EventHandler<MouseEvent>) -> Element {
 // =============================================================================
 
 #[component]
-pub fn CameraButton(enabled: bool, onclick: EventHandler<MouseEvent>) -> Element {
-    let class = if enabled {
-        "video-control-button active"
-    } else {
-        "video-control-button"
+pub fn CameraButton(enabled: bool, available: bool, onclick: EventHandler<MouseEvent>) -> Element {
+    let class = match (enabled, available) {
+        (true, false) => "video-control-button active error",
+        (true, true) => "video-control-button active",
+        (false, false) => "video-control-button error",
+        (false, true) => "video-control-button",
     };
 
     rsx! {
-        button { class, onclick: move |evt| onclick.call(evt),
+        button {
+            class,
+            disabled: !available,
+            onclick: move |evt| onclick.call(evt),
             if enabled {
                 svg {
                     xmlns: "http://www.w3.org/2000/svg",
@@ -103,6 +114,9 @@ pub fn CameraButton(enabled: bool, onclick: EventHandler<MouseEvent>) -> Element
                     line { x1: "1", y1: "1", x2: "23", y2: "23" }
                 }
                 span { class: "tooltip", "Start Video" }
+            }
+            if !available {
+                span { class: "device-warning", "!" }
             }
         }
     }
@@ -160,7 +174,7 @@ pub fn ScreenShareButton(
                     path { d: "M13 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-3" }
                     polyline { points: "8 21 12 17 16 21" }
                     polyline { points: "16 7 20 7 20 3" }
-                    line { x1: "10", y1: "14", x2: "21", y2: "3" }
+                    line { x1: "1", y1: "1", x2: "23", y2: "23" }
                 }
                 span { class: "tooltip", "Share Screen" }
             }
@@ -195,7 +209,6 @@ pub fn PeerListButton(open: bool, onclick: EventHandler<MouseEvent>) -> Element 
                     circle { cx: "9", cy: "7", r: "4" }
                     path { d: "M23 21v-2a4 4 0 0 0-3-3.87" }
                     path { d: "M16 3.13a4 4 0 0 1 0 7.75" }
-                    line { x1: "1", y1: "1", x2: "23", y2: "23" }
                 }
                 span { class: "tooltip", "Close Peers" }
             } else {
@@ -211,6 +224,7 @@ pub fn PeerListButton(open: bool, onclick: EventHandler<MouseEvent>) -> Element 
                     circle { cx: "9", cy: "7", r: "4" }
                     path { d: "M23 21v-2a4 4 0 0 0-3-3.87" }
                     path { d: "M16 3.13a4 4 0 0 1 0 7.75" }
+                    line { x1: "1", y1: "1", x2: "23", y2: "23" }
                 }
                 span { class: "tooltip", "Open Peers" }
             }

--- a/dioxus-ui/static/global.css
+++ b/dioxus-ui/static/global.css
@@ -339,6 +339,26 @@ body {
     inset 0 1px 0 var(--glass-highlight);
 }
 
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal-content {
+  background: #1C1C1E;
+  padding: 2rem;
+  border-radius: 16px;
+  text-align: center;
+  color: white;
+  max-width: 400px;
+  width: 90%;
+}
+
 @media (max-width: 768px) {
   .hero-container { padding: 1rem 0; }
   .hero-content {
@@ -573,6 +593,27 @@ body {
     0 8px 20px -3px rgba(121, 40, 202, 0.5),
     0 0 0 1px rgba(121, 40, 202, 0.5),
     inset 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.video-control-button .device-warning {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #FF453A;
+  color: #FFFFFF;
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 50%;
+  box-shadow: 
+    0 0 0 2px #1C1C1E,
+    0 0 10px rgba(255, 69, 58, 0.6);
+  z-index: 2;
+  pointer-events: none;
 }
 
 .video-control-button.danger {

--- a/dioxus-ui/tests/video_control_buttons.rs
+++ b/dioxus-ui/tests/video_control_buttons.rs
@@ -34,7 +34,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 async fn mic_button_enabled_shows_mute_tooltip() {
     let mount = create_mount_point();
     fn wrapper() -> Element {
-        rsx! { MicButton { enabled: true, onclick: move |_| {} } }
+        rsx! { MicButton { enabled: true, available: true, onclick: move |_| {} } }
     }
     render_into(&mount, wrapper);
     yield_now().await;
@@ -60,7 +60,7 @@ async fn mic_button_enabled_shows_mute_tooltip() {
 async fn mic_button_disabled_shows_unmute_tooltip() {
     let mount = create_mount_point();
     fn wrapper() -> Element {
-        rsx! { MicButton { enabled: false, onclick: move |_| {} } }
+        rsx! { MicButton { enabled: false, available: true, onclick: move |_| {} } }
     }
     render_into(&mount, wrapper);
     yield_now().await;
@@ -90,7 +90,7 @@ async fn mic_button_disabled_shows_unmute_tooltip() {
 async fn camera_button_enabled_shows_stop_video_tooltip() {
     let mount = create_mount_point();
     fn wrapper() -> Element {
-        rsx! { CameraButton { enabled: true, onclick: move |_| {} } }
+        rsx! { CameraButton { enabled: true, available: true, onclick: move |_| {} } }
     }
     render_into(&mount, wrapper);
     yield_now().await;
@@ -105,7 +105,7 @@ async fn camera_button_enabled_shows_stop_video_tooltip() {
 async fn camera_button_disabled_shows_start_video_tooltip() {
     let mount = create_mount_point();
     fn wrapper() -> Element {
-        rsx! { CameraButton { enabled: false, onclick: move |_| {} } }
+        rsx! { CameraButton { enabled: false, available: true, onclick: move |_| {} } }
     }
     render_into(&mount, wrapper);
     yield_now().await;

--- a/videocall-client/README.md
+++ b/videocall-client/README.md
@@ -41,8 +41,7 @@ screen.stop();
 
 ```rust
 let media_device_access = MediaDeviceAccess::new();
-media_device_access.on_granted = ...; // callback
-media_device_access.on_denied = ...; // callback
+media_device_access.on_result = ...; // callback with audio and video state
 media_device_access.request();
 ```
 

--- a/videocall-client/src/encode/camera_encoder.rs
+++ b/videocall-client/src/encode/camera_encoder.rs
@@ -295,18 +295,23 @@ impl CameraEncoder {
             let media_info = web_sys::MediaTrackConstraints::new();
 
             // Force exact deviceId match (avoids partial/ideal matching surprises).
-            let exact = js_sys::Object::new();
-            js_sys::Reflect::set(
-                &exact,
-                &JsValue::from_str("exact"),
-                &JsValue::from_str(&device_id),
-            )
-            .unwrap();
+            if device_id.is_empty() {
+                log::warn!("Camera device_id is empty, using default constraint");
+                constraints.set_video(&JsValue::TRUE);
+            } else {
+                let exact = js_sys::Object::new();
+                js_sys::Reflect::set(
+                    &exact,
+                    &JsValue::from_str("exact"),
+                    &JsValue::from_str(&device_id),
+                )
+                .unwrap();
 
-            log::debug!("CameraEncoder: deviceId.exact = {}", device_id);
-            media_info.set_device_id(&exact.into());
+                log::debug!("CameraEncoder: deviceId.exact = {}", device_id);
+                media_info.set_device_id(&exact.into());
+                constraints.set_video(&media_info.into());
+            }
 
-            constraints.set_video(&media_info.into());
             constraints.set_audio(&Boolean::from(false));
 
             let devices_query = match media_devices.get_user_media_with_constraints(&constraints) {

--- a/videocall-client/src/encode/microphone_encoder.rs
+++ b/videocall-client/src/encode/microphone_encoder.rs
@@ -267,18 +267,23 @@ impl MicrophoneEncoder {
             let media_info = web_sys::MediaTrackConstraints::new();
 
             // Force exact deviceId match (avoids falling back to the default mic).
-            let exact = js_sys::Object::new();
-            js_sys::Reflect::set(
-                &exact,
-                &JsValue::from_str("exact"),
-                &JsValue::from_str(&device_id),
-            )
-            .unwrap();
+            if device_id.is_empty() {
+                log::warn!("Microphone device_id is empty, using default constraint");
+                constraints.set_audio(&JsValue::TRUE);
+            } else {
+                let exact = js_sys::Object::new();
+                js_sys::Reflect::set(
+                    &exact,
+                    &JsValue::from_str("exact"),
+                    &JsValue::from_str(&device_id),
+                )
+                .unwrap();
 
-            log::info!("MicrophoneEncoder: deviceId.exact = {}", device_id);
-            media_info.set_device_id(&exact.into());
-
-            constraints.set_audio(&media_info.into());
+                log::info!("MicrophoneEncoder: deviceId.exact = {}", device_id);
+                media_info.set_device_id(&exact.into());
+                constraints.set_audio(&media_info.into());
+            }
+            
             constraints.set_video(&Boolean::from(false));
             let devices_query = match media_devices.get_user_media_with_constraints(&constraints) {
                 Ok(p) => p,

--- a/videocall-client/src/lib.rs
+++ b/videocall-client/src/lib.rs
@@ -146,11 +146,8 @@
 //! use videocall_client::Callback;
 //!
 //! let mut media_device_access = MediaDeviceAccess::new();
-//! media_device_access.on_granted = Callback::from(|_| {
-//!     web_sys::console::log_1(&"Access granted!".into());
-//! });
-//! media_device_access.on_denied = Callback::from(|error| {
-//!     web_sys::console::log_2(&"Access denied:".into(), &error);
+//! media_device_access.on_result = Callback::from(|_| {
+//!     web_sys::console::log_1(&"Status of access".into());
 //! });
 //! media_device_access.request();
 //! ```
@@ -202,5 +199,6 @@ pub use encode::{
     create_microphone_encoder, CameraEncoder, MicrophoneEncoderTrait, ScreenEncoder,
     ScreenShareEvent,
 };
-pub use media_devices::{MediaDeviceAccess, MediaDeviceList, SelectableDevices};
+pub use media_devices::{MediaDeviceAccess, MediaDeviceList, SelectableDevices, MediaAccessKind, MediaPermission, PermissionState,
+                        MediaPermissionsErrorState};
 pub use videocall_types::Callback;

--- a/videocall-client/src/media_devices/media_device_access.rs
+++ b/videocall-client/src/media_devices/media_device_access.rs
@@ -17,23 +17,42 @@
  */
 
 use gloo_utils::window;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 use videocall_types::Callback;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::MediaStreamConstraints;
 
+#[derive(Clone, Copy)]
+pub enum MediaAccessKind {
+    AudioCheck,
+    VideoCheck,
+    BothCheck,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum MediaPermissionsErrorState {
+    NoDevice,
+    PermissionDenied,
+    Other(JsValue),
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum PermissionState {
+    Unknown,
+    Granted,
+    Denied(MediaPermissionsErrorState),
+}
+
+#[derive(Debug)]
+pub struct MediaPermission {
+    pub audio: PermissionState,
+    pub video: PermissionState,
+}
 /// [MediaDeviceAccess] is a utility to request the user's permission to access the microphone and
 /// camera.
 pub struct MediaDeviceAccess {
-    granted: Arc<AtomicBool>,
-
-    // Callback that is called when the user grants access permission
-    pub on_granted: Callback<()>,
-
-    // Callback that is called when the user fails to grant access permission
-    pub on_denied: Callback<JsValue>,
+    current_permission: MediaPermission,
+    pub on_result: Callback<MediaPermission>,
 }
 
 #[allow(clippy::new_without_default)]
@@ -48,65 +67,122 @@ impl MediaDeviceAccess {
     /// # use wasm_bindgen::JsValue;
     /// # use videocall_client::Callback;
     /// let mut media_device_access = MediaDeviceAccess::new();
-    /// media_device_access.on_granted = Callback::from(|_| {
-    ///     // Handle granted permission
-    /// });
-    /// media_device_access.on_denied = Callback::from(|_err: JsValue| {
-    ///     // Handle denied permission
+    /// media_device_access.on_result = Callback::from(|permission| {
+    ///     // Handle audio and video state
     /// });
     /// media_device_access.request();
     /// ```
     pub fn new() -> Self {
         Self {
-            granted: Arc::new(AtomicBool::new(false)),
-            on_granted: Callback::noop(),
-            on_denied: Callback::noop(),
+            current_permission: MediaPermission {
+                audio: PermissionState::Unknown,
+                video: PermissionState::Unknown,
+            },
+            on_result: Callback::noop(),
         }
     }
 
     /// Returns true if permission has been granted
-    pub fn is_granted(&self) -> bool {
-        self.granted.load(Ordering::Acquire)
+    pub fn is_granted(&self, device: MediaAccessKind) -> bool {
+        match device {
+            MediaAccessKind::AudioCheck => matches!(self.current_permission.audio, PermissionState::Granted),
+            MediaAccessKind::VideoCheck => matches!(self.current_permission.video, PermissionState::Granted),
+            MediaAccessKind::BothCheck =>  true,
+        }
+
     }
 
     /// Causes the browser to request the user's permission to access the microphone and camera.
     ///
-    /// This function returns immediately.  Eventually, either the [`on_granted`](Self::on_granted)
-    /// or [`on_denied`](Self::on_denied) callback will be called.
+    /// This function returns immediately.  Eventually, either the [`on_resut`](Self::on_result)
+    /// callback will be called.
     pub fn request(&self) {
-        let future = Self::request_permissions();
-        let on_granted = self.on_granted.clone();
-        let on_denied = self.on_denied.clone();
-        let granted = Arc::clone(&self.granted);
+        let on_result = self.on_result.clone();
+        log::info!("start request of permission");
+
         wasm_bindgen_futures::spawn_local(async move {
-            match future.await {
-                Ok(_) => {
-                    granted.store(true, Ordering::Release);
-                    on_granted.emit(());
-                }
-                Err(e) => {
-                    on_denied.emit(e);
-                }
-            }
+            let perm_result = Self::request_media_permission().await;
+            on_result.emit(perm_result);
         });
     }
 
-    async fn request_permissions() -> anyhow::Result<(), JsValue> {
+    async fn request_media_permission() -> MediaPermission {
+        use futures::join;
+
+        let (audio, video) = join!(
+            Self::request_audio_permissions(),
+            Self::request_video_permissions()
+        );
+
+        MediaPermission {
+            audio: match audio {
+                Ok(_) => PermissionState::Granted,
+                Err(e) => PermissionState::Denied(e),
+            },
+            video: match video {
+                Ok(_) => PermissionState::Granted,
+                Err(e) => PermissionState::Denied(e),
+            },
+        }
+    }
+
+    async fn request_audio_permissions() -> Result<(), MediaPermissionsErrorState> {
         let navigator = window().navigator();
-        let media_devices = navigator.media_devices()?;
+        let media_devices = navigator.media_devices().map_err(MediaPermissionsErrorState::Other)?;
 
         let constraints = MediaStreamConstraints::new();
 
         // Request access to the microphone
         constraints.set_audio(&JsValue::from_bool(true));
 
+        let promise = media_devices
+            .get_user_media_with_constraints(&constraints)
+            .map_err(MediaPermissionsErrorState::Other)?;
+
+        match JsFuture::from(promise).await {
+            Ok(_) => Ok(()),
+
+            Err(err) => {
+                let name =js_sys::Reflect::get(&err, &JsValue::from_str("name"))
+                    .ok()
+                    .and_then(|v| v.as_string());
+
+                match name.as_deref() {
+                    Some("NotFoundError") => Err(MediaPermissionsErrorState::NoDevice),
+                    Some("NotAllowedError") => Err(MediaPermissionsErrorState::PermissionDenied),
+                    _ => Err(MediaPermissionsErrorState::Other(err)),
+                }
+            }
+        }
+    }
+
+    async fn request_video_permissions() -> Result<(), MediaPermissionsErrorState> {
+        let navigator = window().navigator();
+        let media_devices = navigator.media_devices().map_err(MediaPermissionsErrorState::Other)?;
+
+        let constraints = MediaStreamConstraints::new();
+
         // Request access to the camera
         constraints.set_video(&JsValue::from_bool(true));
 
-        let promise = media_devices.get_user_media_with_constraints(&constraints)?;
+        let promise = media_devices
+            .get_user_media_with_constraints(&constraints)
+            .map_err(MediaPermissionsErrorState::Other)?;
 
-        JsFuture::from(promise).await?;
+        match JsFuture::from(promise).await {
+            Ok(_) => Ok(()),
 
-        Ok(())
+            Err(err) => {
+                let name =js_sys::Reflect::get(&err, &JsValue::from_str("name"))
+                    .ok()
+                    .and_then(|v| v.as_string());
+
+                match name.as_deref() {
+                    Some("NotFoundError") => Err(MediaPermissionsErrorState::NoDevice),
+                    Some("NotAllowedError") => Err(MediaPermissionsErrorState::PermissionDenied),
+                    _ => Err(MediaPermissionsErrorState::Other(err)),
+                }
+            }
+        }
     }
 }

--- a/videocall-client/src/media_devices/mod.rs
+++ b/videocall-client/src/media_devices/mod.rs
@@ -20,4 +20,8 @@ mod media_device_access;
 mod media_device_list;
 
 pub use media_device_access::MediaDeviceAccess;
+pub use media_device_access::MediaAccessKind;
+pub use media_device_access::MediaPermission;
+pub use media_device_access::PermissionState;
+pub use media_device_access::MediaPermissionsErrorState;
 pub use media_device_list::{MediaDeviceList, SelectableDevices};

--- a/yew-ui/src/components/attendants.rs
+++ b/yew-ui/src/components/attendants.rs
@@ -36,16 +36,17 @@ use crate::constants::{
 use crate::context::{MeetingTime, MeetingTimeCtx, VideoCallClientCtx};
 use gloo_timers::callback::Timeout;
 use gloo_utils::window;
-use log::{error, warn};
 use std::collections::HashMap;
-use videocall_client::utils::is_ios;
+use log::{error, warn};
+use videocall_client::{MediaAccessKind, MediaPermission, MediaPermissionsErrorState, PermissionState, utils::is_ios};
 use videocall_client::Callback as VcCallback;
 use videocall_client::{
     MediaDeviceAccess, ScreenShareEvent, VideoCallClient, VideoCallClientOptions,
 };
 use videocall_types::protos::media_packet::media_packet::MediaType;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsValue, JsCast, prelude::*};
 use web_sys::*;
+use web_sys::Event;
 use yew::prelude::*;
 use yew::{html, Component, Context, Html};
 
@@ -57,6 +58,12 @@ pub enum ScreenShareState {
     Requesting,
     /// A screen is actively being shared and encoded.
     Active,
+}
+
+pub enum MediaErrorState {
+    NoDevice,
+    PermissionDenied,
+    Other,
 }
 
 impl ScreenShareState {
@@ -73,11 +80,13 @@ pub enum WsAction {
     Connected,
     Lost(Option<JsValue>),
     RequestMediaPermissions,
-    MediaPermissionsGranted,
-    MediaPermissionsError(String),
+    MediaPermissionsUpdated(MediaPermission),
+    WindowFocused,
+    ReloadDevices,
     Log(String),
     EncoderSettingsUpdated(String),
     MeetingInfoReceived(u64),
+    CloseDeviceWarning,
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -202,7 +211,9 @@ pub struct AttendantsComponent {
     pub media_device_access: MediaDeviceAccess,
     pub screen_share_state: ScreenShareState,
     pub mic_enabled: bool,
+    pub mic_error: Option<MediaErrorState>,
     pub video_enabled: bool,
+    pub video_error: Option<MediaErrorState>,
     pub peer_list_open: bool,
     pub diagnostics_open: bool,
     pub device_settings_open: bool,
@@ -237,6 +248,10 @@ pub struct AttendantsComponent {
     peer_toasts: Vec<(u64, String, String, bool)>,
     /// Monotonic counter for toast IDs.
     toast_counter: u64,
+    show_device_warning: bool,
+    reload_devices_counter: u32,
+    device_was_denied: bool,
+    session_loaded: bool,
 }
 
 impl AttendantsComponent {
@@ -419,17 +434,10 @@ impl AttendantsComponent {
 
     fn create_media_device_access(ctx: &Context<Self>) -> MediaDeviceAccess {
         let mut media_device_access = MediaDeviceAccess::new();
-        media_device_access.on_granted = {
-            let link = ctx.link().clone();
-            VcCallback::from(move |_| link.send_message(WsAction::MediaPermissionsGranted))
-        };
-        media_device_access.on_denied = {
-            let link = ctx.link().clone();
-            VcCallback::from(move |e| {
-                let complete_error = format!("Error requesting permissions: Please make sure to allow access to both camera and microphone. ({e:?})");
-                error!("{complete_error}");
-                link.send_message(WsAction::MediaPermissionsError(complete_error.to_string()))
-            })
+        let link = ctx.link().clone();
+        media_device_access.on_result = {
+            VcCallback::from(move |permission: MediaPermission| {
+                link.send_message(WsAction::MediaPermissionsUpdated(permission))})
         };
         media_device_access
     }
@@ -636,6 +644,39 @@ impl AttendantsComponent {
         })
         .forget();
     }
+
+    fn render_device_error(&self) -> Html {
+        let mut messages = vec![];
+
+        if let Some(err) = &self.mic_error {
+            messages.push(self.render_single_error("Microphone", err));
+        }
+
+        if let Some(err) = &self.video_error {
+            messages.push(self.render_single_error("Camera", err));
+        }
+
+        html!{ for messages}
+    }
+
+    fn render_single_error(&self, device: &str, error:&MediaErrorState) -> Html {
+        match error {
+            MediaErrorState::NoDevice => html! {
+                <p>{ format!(" {} not found on this device.",device)}</p>
+            },
+            MediaErrorState::Other => html! {
+                <p>{ format!(" {} has an unexpected problem.",device)}</p>
+            },
+            MediaErrorState::PermissionDenied => html! {
+                <>
+                   <p>{ format!(" {} is blocked in your browser.",device)}</p>
+                   <p style="front-size: 0.9rem; opacity: 0.8;">
+                      {"Please click the lock icon in your browser's address bar and allow access if you want to use it."}
+                   </p>
+                </>
+            },
+        }
+    }
 }
 
 impl Component for AttendantsComponent {
@@ -643,15 +684,29 @@ impl Component for AttendantsComponent {
     type Properties = AttendantsComponentProps;
 
     fn create(ctx: &Context<Self>) -> Self {
+        let link = ctx.link().clone();
         let client = Self::create_video_call_client(ctx);
         let media_device_access = Self::create_media_device_access(ctx);
+       
+        let window = web_sys::window().expect("no global window exist");
+        let closure = Closure::wrap(Box::new(move |_event: Event| {
+            link.send_message(WsAction::WindowFocused);
+        }) as Box<dyn FnMut(_)>);
+
+        window
+            .add_event_listener_with_callback("focus", closure.as_ref().unchecked_ref())
+            .expect("failed to add focus listener");
+
+        closure.forget();
 
         let mut self_ = Self {
             client,
             media_device_access,
             screen_share_state: ScreenShareState::Idle,
             mic_enabled: false,
+            mic_error: None,
             video_enabled: false,
+            video_error: None,
             peer_list_open: false,
             diagnostics_open: false,
             device_settings_open: false,
@@ -676,6 +731,10 @@ impl Component for AttendantsComponent {
             reconnect_attempt: 0,
             peer_toasts: Vec::new(),
             toast_counter: 0,
+            show_device_warning: false,
+            reload_devices_counter: 0,
+            device_was_denied: false,
+            session_loaded: false,
         };
         if let Err(e) = crate::constants::app_config() {
             log::error!("{e:?}");
@@ -710,7 +769,6 @@ impl Component for AttendantsComponent {
                         ctx.link()
                             .send_message(WsAction::Log(format!("Connection failed: {e:?}")));
                     }
-                    log::info!("Connected in attendants");
                     self.meeting_joined = true;
                     true
                 }
@@ -719,6 +777,7 @@ impl Component for AttendantsComponent {
                     self.error = None;
                     self.reconnect_attempt = 0;
                     self.call_start_time = Some(js_sys::Date::now());
+                    self.session_loaded = true;
                     true
                 }
 
@@ -751,25 +810,75 @@ impl Component for AttendantsComponent {
                     self.media_device_access.request();
                     false
                 }
-                WsAction::MediaPermissionsGranted => {
-                    self.error = None;
-
-                    if self.pending_mic_enable {
-                        self.mic_enabled = true;
-                        self.pending_mic_enable = false;
+                WsAction::WindowFocused => {
+                    if matches!(self.mic_error, Some(MediaErrorState::PermissionDenied)) ||
+                       matches!(self.video_error, Some(MediaErrorState::PermissionDenied)) {
+                        ctx.link().send_message(WsAction::ReloadDevices);
+                    } else {
+                        ctx.link().send_message(WsAction::RequestMediaPermissions);
                     }
-
-                    if self.pending_video_enable {
-                        self.video_enabled = true;
-                        self.pending_video_enable = false;
-                    }
-
-                    ctx.link().send_message(WsAction::Connect);
+                    false
+                }
+                WsAction::ReloadDevices => {
+                    self.device_was_denied = true;
+                    self.media_device_access.request();
                     true
                 }
-                WsAction::MediaPermissionsError(error) => {
-                    self.error = Some(error);
-                    self.meeting_joined = false;
+                WsAction::MediaPermissionsUpdated(permit) => {
+                    self.error = None;
+                    self.mic_error = None;
+                    self.video_error = None;
+
+                    if let PermissionState::Granted = &permit.audio {
+                        if self.pending_mic_enable {
+                               self.mic_enabled = true;
+                               self.pending_mic_enable = false;
+                        }
+                    };
+
+                    if let PermissionState::Granted = &permit.video {
+                        if self.pending_video_enable {
+                               self.video_enabled = true;
+                               self.pending_video_enable = false;
+                        }
+                    }
+
+                    if let PermissionState::Denied(MediaPermissionsErrorState::Other(_)) = &permit.audio {
+                        self.mic_error = Some(MediaErrorState::Other);
+                    }
+
+                    if let PermissionState::Denied(MediaPermissionsErrorState::Other(_)) = &permit.video {
+                        self.video_error = Some(MediaErrorState::Other);
+                    }
+
+                    if permit.audio == PermissionState::Denied(MediaPermissionsErrorState::NoDevice) {
+                        self.mic_error = Some(MediaErrorState::NoDevice);
+                    }
+
+                    if permit.video == PermissionState::Denied(MediaPermissionsErrorState::NoDevice) {
+                        self.video_error = Some(MediaErrorState::NoDevice);
+                    }
+
+                    if permit.audio == PermissionState::Denied(MediaPermissionsErrorState::PermissionDenied) {
+                        self.mic_error = Some(MediaErrorState::PermissionDenied);
+                    }
+
+                    if permit.video == PermissionState::Denied(MediaPermissionsErrorState::PermissionDenied) {
+                        self.video_error = Some(MediaErrorState::PermissionDenied);
+                    }
+
+                    if (self.mic_error.is_some() || self.video_error.is_some()) &&
+                        !self.session_loaded {
+                        self.show_device_warning = true;
+                    } else {
+                        ctx.link().send_message(WsAction::Connect);
+                    }
+
+                    if self.device_was_denied {
+                        self.device_was_denied = false;
+                        self.reload_devices_counter += 1;
+                    }
+
                     true
                 }
                 WsAction::EncoderSettingsUpdated(settings) => {
@@ -779,6 +888,11 @@ impl Component for AttendantsComponent {
                 WsAction::MeetingInfoReceived(start_time) => {
                     log::info!("Meeting info received, start_time: {start_time:?}");
                     self.meeting_start_time_server = Some(start_time as f64);
+                    true
+                }
+                WsAction::CloseDeviceWarning => {
+                    self.show_device_warning = false;
+                    ctx.link().send_message(WsAction::Connect);
                     true
                 }
             },
@@ -820,7 +934,7 @@ impl Component for AttendantsComponent {
                     }
                     MeetingAction::ToggleMicMute => {
                         if !self.mic_enabled {
-                            if self.media_device_access.is_granted() {
+                            if self.media_device_access.is_granted(MediaAccessKind::AudioCheck) {
                                 self.mic_enabled = true;
                             } else {
                                 self.pending_mic_enable = true;
@@ -832,7 +946,7 @@ impl Component for AttendantsComponent {
                     }
                     MeetingAction::ToggleVideoOnOff => {
                         if !self.video_enabled {
-                            if self.media_device_access.is_granted() {
+                            if self.media_device_access.is_granted(MediaAccessKind::VideoCheck) {
                                 self.video_enabled = true;
                             } else {
                                 self.pending_video_enable = true;
@@ -1077,7 +1191,7 @@ impl Component for AttendantsComponent {
         let is_allowed = users_allowed_to_stream().unwrap_or_default();
         let can_stream =
             is_allowed.is_empty() || is_allowed.iter().any(|host| host == &effective_user_id);
-        let media_access_granted = self.media_device_access.is_granted();
+        let media_access_granted = self.media_device_access.is_granted(MediaAccessKind::BothCheck);
 
         let toggle_peer_list = ctx.link().callback(|_| UserScreenToggleAction::PeerList);
         let toggle_diagnostics = ctx.link().callback(|_| UserScreenToggleAction::Diagnostics);
@@ -1154,6 +1268,29 @@ impl Component for AttendantsComponent {
                         >
                             { if ctx.props().is_owner { "Start Meeting" } else { "Join Meeting" } }
                         </button>
+                        {
+                            if self.show_device_warning {
+                                html! {
+                                   <div class="modal-overlay">
+                                      <div class="modal-content">
+                                           <h3>{"Device access problem"}</h3>
+
+                                           { self.render_device_error() }
+
+                                          <button
+                                              class="btn-apple btn-primary"
+                                              onclick={ctx.link().callback(|_| WsAction::CloseDeviceWarning)}
+                                              style="margin-top: 1.5rem;"
+                                          >
+                                              {"Ok"}
+                                          </button>
+                                      </div>
+                                    </div>
+                                }
+                            } else {
+                                html! {}
+                            }
+                        }
                     </div>
                     </div>
                 </ContextProvider<VideoCallClientCtx>>
@@ -1275,16 +1412,20 @@ impl Component for AttendantsComponent {
 
                     {
                         if can_stream {
+                            let mic_available = matches!(self.mic_error, None);
+                            let video_available = matches!(self.video_error, None);
                             html! {
                                 <nav class="host">
                                     <div class="controls">
                                         <nav class="video-controls-container">
                                             <MicButton
                                                 enabled={self.mic_enabled}
+                                                available={mic_available}
                                                 onclick={ctx.link().callback(|_| MeetingAction::ToggleMicMute)}
                                             />
                                             <CameraButton
                                                 enabled={self.video_enabled}
+                                                available={video_available}
                                                 onclick={ctx.link().callback(|_| MeetingAction::ToggleVideoOnOff)}
                                             />
                                             {
@@ -1360,6 +1501,7 @@ impl Component for AttendantsComponent {
                                                  on_microphone_error={ctx.link().callback(Msg::OnMicrophoneError)}
                                                  on_camera_error={ctx.link().callback(Msg::OnCameraError)}
                                                  on_screen_share_state={ctx.link().callback(Msg::ScreenShareStateChange)}
+                                                 reload_devices_counter = {self.reload_devices_counter}
                                              />}
                                          } else {
                                              html! {<></>}

--- a/yew-ui/src/components/host.rs
+++ b/yew-ui/src/components/host.rs
@@ -75,6 +75,7 @@ pub struct Host {
     show_change_name: bool,
     pending_name: String,
     change_name_error: Option<String>,
+    last_reload_counter: u32,
 }
 
 pub struct EncoderSettings {
@@ -134,6 +135,7 @@ pub struct MeetingProps {
     /// Called when screen share state changes (started, cancelled, stopped).
     /// This allows the parent component to react to screen share lifecycle events.
     pub on_screen_share_state: Callback<ScreenShareEvent>,
+    pub reload_devices_counter: u32,
 }
 
 impl Component for Host {
@@ -248,10 +250,15 @@ impl Component for Host {
             show_change_name: false,
             pending_name: String::new(),
             change_name_error: None,
+            last_reload_counter: 0,
         }
     }
 
     fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {
+        if ctx.props().reload_devices_counter != self.last_reload_counter {     
+            self.media_devices.load();
+            self.last_reload_counter = ctx.props().reload_devices_counter;
+        }
         if self.screen.set_enabled(ctx.props().share_screen) && ctx.props().share_screen {
             self.share_screen = ctx.props().share_screen;
             let link = ctx.link().clone();
@@ -490,6 +497,62 @@ impl Component for Host {
                 }
             }
             Msg::DevicesLoaded => {
+                let audio_id_str = self.media_devices.audio_inputs.selected();
+                let video_id_str = self.media_devices.video_inputs.selected();
+
+                let (client, _) = ctx
+                    .link()
+                    .context::<VideoCallClientCtx>(Callback::noop())
+                    .expect("VideoCallClient context missing");
+                
+                if audio_id_str == "" {
+                    let microphone_callback = VcCallback::from({
+                        let link = ctx.link().clone();
+                        move |s: String| link.send_message(Msg::MicrophoneEncoderSettingsUpdated(s))
+                    });
+                    let microphone_error_cb = VcCallback::from({
+                        let link = ctx.link().clone();
+                        move |s: String| link.send_message(Msg::MicrophoneError(s))
+                    });
+        
+                    let audio_bitrate = audio_bitrate_kbps().unwrap_or(65);
+                    self.microphone = create_microphone_encoder(
+                        client.clone(),
+                        audio_bitrate,
+                        microphone_callback,
+                        microphone_error_cb.clone(),
+                        vad_threshold().ok(),
+                    );
+
+                    let (tx, rx) = mpsc::unbounded();
+                    client.subscribe_diagnostics(tx.clone(), MediaType::AUDIO);
+                    self.microphone.set_encoder_control(rx);
+                }
+
+                if video_id_str == "" {
+                    let camera_callback = VcCallback::from({
+                        let link = ctx.link().clone();
+                        move |s: String| link.send_message(Msg::CameraEncoderSettingsUpdated(s))
+                    });
+                    let camera_error_cb = VcCallback::from({
+                        let link = ctx.link().clone();
+                        move |s: String| link.send_message(Msg::CameraError(s))
+                    });
+
+                    let video_bitrate = video_bitrate_kbps().unwrap_or(1000);
+                    self.camera = CameraEncoder::new(
+                        client.clone(),
+                        VIDEO_ELEMENT_ID,
+                        video_bitrate,
+                        camera_callback,
+                        camera_error_cb,
+                    );
+
+                    let (tx, rx) = mpsc::unbounded();
+                    client.subscribe_diagnostics(tx.clone(), MediaType::VIDEO);
+                    self.camera.set_encoder_control(rx);
+               }
+
                 let audio_device_id = self.media_devices.audio_inputs.selected();
                 let video_device_id = self.media_devices.video_inputs.selected();
                 let speaker_device_id = self.media_devices.audio_outputs.selected();

--- a/yew-ui/src/components/video_control_buttons.rs
+++ b/yew-ui/src/components/video_control_buttons.rs
@@ -22,15 +22,16 @@ use yew::prelude::*;
 #[derive(Properties, PartialEq)]
 pub struct MicButtonProps {
     pub enabled: bool,
+    pub available: bool,
     pub onclick: Callback<MouseEvent>,
 }
 
 #[function_component(MicButton)]
 pub fn mic_button(props: &MicButtonProps) -> Html {
-    let class = classes!("video-control-button", props.enabled.then_some("active"));
+    let class = classes!("video-control-button", props.enabled.then_some("active"),(!props.available).then_some("error"));
 
     html! {
-        <button {class} onclick={props.onclick.clone()}>
+        <button {class} onclick={props.onclick.clone()} disabled={!props.available}>
             {
                 if props.enabled {
                     html! {
@@ -57,6 +58,15 @@ pub fn mic_button(props: &MicButtonProps) -> Html {
                     }
                 }
             }
+            {
+                if !props.available {
+                    html!{
+                      <span class="device-warning">{"!"}</span>
+                    }
+                } else {
+                   html! {}
+                }
+            }
         </button>
     }
 }
@@ -68,15 +78,16 @@ pub fn mic_button(props: &MicButtonProps) -> Html {
 #[derive(Properties, PartialEq)]
 pub struct CameraButtonProps {
     pub enabled: bool,
+    pub available: bool,
     pub onclick: Callback<MouseEvent>,
 }
 
 #[function_component(CameraButton)]
 pub fn camera_button(props: &CameraButtonProps) -> Html {
-    let class = classes!("video-control-button", props.enabled.then_some("active"));
+    let class = classes!("video-control-button", props.enabled.then_some("active"),(!props.available).then_some("error"));
 
     html! {
-        <button {class} onclick={props.onclick.clone()}>
+        <button {class} onclick={props.onclick.clone()} disabled={!props.available}>
             {
                 if props.enabled {
                     html! {
@@ -98,6 +109,15 @@ pub fn camera_button(props: &CameraButtonProps) -> Html {
                             <span class="tooltip">{"Start Video"}</span>
                         </>
                     }
+                }
+            }
+            {
+                if !props.available {
+                    html! {
+                      <span class="device-warning">{"!"}</span>
+                    }
+                } else {
+                   html! {}
                 }
             }
         </button>

--- a/yew-ui/static/global.css
+++ b/yew-ui/static/global.css
@@ -339,6 +339,26 @@ body {
     inset 0 1px 0 var(--glass-highlight);
 }
 
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal-content {
+  background: #1C1C1E;
+  padding: 2rem;
+  border-radius: 16px;
+  text-align: center;
+  color: white;
+  max-width: 400px;
+  width: 90%;
+}
+
 @media (max-width: 768px) {
   .hero-container { padding: 1rem 0; }
   .hero-content {
@@ -573,6 +593,27 @@ body {
     0 8px 20px -3px rgba(121, 40, 202, 0.5),
     0 0 0 1px rgba(121, 40, 202, 0.5),
     inset 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.video-control-button .device-warning {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #FF453A;
+  color: #FFFFFF;
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 50%;
+  box-shadow: 
+    0 0 0 2px #1C1C1E,
+    0 0 10px rgba(255, 69, 58, 0.6);
+  z-index: 2;
+  pointer-events: none;
 }
 
 .video-control-button.danger {

--- a/yew-ui/tests/video_control_buttons.rs
+++ b/yew-ui/tests/video_control_buttons.rs
@@ -39,7 +39,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 async fn mic_button_enabled_shows_mute_tooltip() {
     #[function_component(Wrapper)]
     fn wrapper() -> Html {
-        html! { <MicButton enabled={true} onclick={Callback::noop()} /> }
+        html! { <MicButton enabled={true} available={true} onclick={Callback::noop()} /> }
     }
 
     let mount = create_mount_point();
@@ -67,7 +67,7 @@ async fn mic_button_enabled_shows_mute_tooltip() {
 async fn mic_button_disabled_shows_unmute_tooltip() {
     #[function_component(Wrapper)]
     fn wrapper() -> Html {
-        html! { <MicButton enabled={false} onclick={Callback::noop()} /> }
+        html! { <MicButton enabled={false} available={true} onclick={Callback::noop()} /> }
     }
 
     let mount = create_mount_point();
@@ -99,7 +99,7 @@ async fn mic_button_disabled_shows_unmute_tooltip() {
 async fn camera_button_enabled_shows_stop_video_tooltip() {
     #[function_component(Wrapper)]
     fn wrapper() -> Html {
-        html! { <CameraButton enabled={true} onclick={Callback::noop()} /> }
+        html! { <CameraButton enabled={true} available={true} onclick={Callback::noop()} /> }
     }
 
     let mount = create_mount_point();
@@ -116,7 +116,7 @@ async fn camera_button_enabled_shows_stop_video_tooltip() {
 async fn camera_button_disabled_shows_start_video_tooltip() {
     #[function_component(Wrapper)]
     fn wrapper() -> Html {
-        html! { <CameraButton enabled={false} onclick={Callback::noop()} /> }
+        html! { <CameraButton enabled={false} available={true} onclick={Callback::noop()} /> }
     }
 
     let mount = create_mount_point();


### PR DESCRIPTION
The correction contain the following changes:

1. If you have inaccessible camera or microphone, you still can login to meeting and listen.
2. If you have inaccessible camera or/and microphone, the problem device is marked with red exclamation mark and appropriate button can't be pressed.
3. During joing to meeting, if any of devices is inaccessible by any reason (no device, device is locked in browser, any other error), user will see warning
---------

_Please include a summary of the changes and related context._

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Project / Infra

## Testing
- [x] Tests written or updated
- [ ] No tests needed

## Other
- [x] Documentation updated
- [ ] Before/After Images provided

