### PR TITLE
feat: build version info endpoints and diagnostics display

### DIFF
--- a/.github/workflows/docker-build-check.yaml
+++ b/.github/workflows/docker-build-check.yaml
@@ -50,6 +50,10 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ github.event.pull_request.head.sha }}
+            GIT_BRANCH=${{ github.head_ref }}
+            BUILD_TIMESTAMP=${{ github.event.pull_request.updated_at }}
 
   build-meeting-api:
     name: Build Meeting API Docker image
@@ -69,6 +73,10 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ github.event.pull_request.head.sha }}
+            GIT_BRANCH=${{ github.head_ref }}
+            BUILD_TIMESTAMP=${{ github.event.pull_request.updated_at }}
 
   build-ui:
     name: Build UI Docker image
@@ -88,6 +96,10 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ github.event.pull_request.head.sha }}
+            GIT_BRANCH=${{ github.head_ref }}
+            BUILD_TIMESTAMP=${{ github.event.pull_request.updated_at }}
 
   build-website:
     name: Build Website Docker image

--- a/.github/workflows/pr-build-and-deploy.yaml
+++ b/.github/workflows/pr-build-and-deploy.yaml
@@ -167,6 +167,10 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:pr-${{ needs.check-permissions.outputs.pr_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ needs.check-permissions.outputs.pr_sha }}
+            GIT_BRANCH=${{ needs.check-permissions.outputs.pr_ref }}
+            BUILD_TIMESTAMP=${{ github.event.comment.created_at }}
 
   comment-build-complete:
     name: Comment build complete

--- a/.github/workflows/pr-build-images-command.yaml
+++ b/.github/workflows/pr-build-images-command.yaml
@@ -161,6 +161,10 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/videocall-media-server:pr-${{ needs.check-permissions.outputs.pr_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ needs.check-permissions.outputs.pr_sha }}
+            GIT_BRANCH=${{ needs.check-permissions.outputs.pr_ref }}
+            BUILD_TIMESTAMP=${{ github.event.comment.created_at }}
 
   build-meeting-api:
     name: Build Meeting API Docker image
@@ -192,6 +196,10 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/videocall-meeting-api:pr-${{ needs.check-permissions.outputs.pr_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ needs.check-permissions.outputs.pr_sha }}
+            GIT_BRANCH=${{ needs.check-permissions.outputs.pr_ref }}
+            BUILD_TIMESTAMP=${{ github.event.comment.created_at }}
 
   build-ui:
     name: Build UI Docker image
@@ -223,6 +231,10 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/videocall-web-ui:pr-${{ needs.check-permissions.outputs.pr_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ needs.check-permissions.outputs.pr_sha }}
+            GIT_BRANCH=${{ needs.check-permissions.outputs.pr_ref }}
+            BUILD_TIMESTAMP=${{ github.event.comment.created_at }}
 
   comment-success:
     name: Comment with image tags

--- a/.github/workflows/upload-api-docker-hub.yaml
+++ b/.github/workflows/upload-api-docker-hub.yaml
@@ -49,3 +49,7 @@ jobs:
           tags: |
             securityunion/videocall-media-server:${{ steps.extract_branch.outputs.branch }}-${{ steps.extract_sha.outputs.sha8 }}
             securityunion/videocall-media-server:latest
+          build-args: |
+            GIT_SHA=${{ steps.extract_sha.outputs.sha8 }}
+            GIT_BRANCH=${{ steps.extract_branch.outputs.branch }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}

--- a/.github/workflows/upload-meeting-api-docker-hub.yaml
+++ b/.github/workflows/upload-meeting-api-docker-hub.yaml
@@ -47,3 +47,7 @@ jobs:
           tags: |
             securityunion/videocall-meeting-api:${{ steps.extract_branch.outputs.branch }}-${{ steps.extract_sha.outputs.sha8 }}
             securityunion/videocall-meeting-api:latest
+          build-args: |
+            GIT_SHA=${{ steps.extract_sha.outputs.sha8 }}
+            GIT_BRANCH=${{ steps.extract_branch.outputs.branch }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}

--- a/.github/workflows/upload-ui-docker-hub.yaml
+++ b/.github/workflows/upload-ui-docker-hub.yaml
@@ -52,3 +52,7 @@ jobs:
           tags: |
             securityunion/videocall-web-ui:${{ steps.extract_branch.outputs.branch }}-${{ steps.extract_sha.outputs.sha8 }}
             securityunion/videocall-web-ui:latest
+          build-args: |
+            GIT_SHA=${{ steps.extract_sha.outputs.sha8 }}
+            GIT_BRANCH=${{ steps.extract_branch.outputs.branch }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}

--- a/Dockerfile.actix
+++ b/Dockerfile.actix
@@ -1,6 +1,12 @@
 FROM securityunion/actix-base:meeting-ownership-branch-c4b19265 as build
 
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+ARG BUILD_TIMESTAMP=unknown
 ENV CARGO_TARGET_DIR=/app/actix-api/target
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
 COPY . /app
 WORKDIR /app/actix-api
 RUN cargo build --release
@@ -12,6 +18,11 @@ RUN mkdir -p /app/binaries && \
     -exec cp {} /app/binaries/ \;
 
 FROM debian:trixie-slim as production
+
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+LABEL org.opencontainers.image.revision=${GIT_SHA}
+LABEL org.opencontainers.image.ref.name=${GIT_BRANCH}
 
 RUN apt-get --yes update && apt-get --yes install libssl-dev ca-certificates
 

--- a/Dockerfile.dioxus
+++ b/Dockerfile.dioxus
@@ -26,10 +26,11 @@ RUN nix develop .#yew-ui --command bash -c "\
     tailwindcss -i ./static/leptos-style.css -o ./static/tailwind.css --minify && \
     trunk build --release"
 
-# Generate a static version.json so nginx can serve it at /version.json
-RUN printf '{"service":"dioxus-ui","version":"%s","git_sha":"%s","git_branch":"%s","build_timestamp":"%s"}\n' \
-    "$(grep '^version' dioxus-ui/Cargo.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')" \
-    "$(echo "${GIT_SHA}" | cut -c1-8)" "${GIT_BRANCH}" "${BUILD_TIMESTAMP}" \
+# Generate a static version.json so nginx can serve it at /version.json.
+# Note: sed is not available in the nix base image, so use shell parameter expansion.
+RUN v=$(grep '^version' dioxus-ui/Cargo.toml | head -1) && v="${v#*\"}" && v="${v%\"*}" && \
+    printf '{"service":"dioxus-ui","version":"%s","git_sha":"%s","git_branch":"%s","build_timestamp":"%s"}\n' \
+    "$v" "$(echo "${GIT_SHA}" | cut -c1-8)" "${GIT_BRANCH}" "${BUILD_TIMESTAMP}" \
     > dioxus-ui/dist/version.json
 
 # ---------------------------------------------------------------------------

--- a/Dockerfile.dioxus
+++ b/Dockerfile.dioxus
@@ -1,6 +1,12 @@
 FROM nixos/nix:2.33.2 AS builder
 
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+ARG BUILD_TIMESTAMP=unknown
 ENV NIX_CONFIG="experimental-features = nix-command flakes"
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
 
 WORKDIR /app
 
@@ -20,8 +26,19 @@ RUN nix develop .#yew-ui --command bash -c "\
     tailwindcss -i ./static/leptos-style.css -o ./static/tailwind.css --minify && \
     trunk build --release"
 
+# Generate a static version.json so nginx can serve it at /version.json
+RUN printf '{"service":"dioxus-ui","version":"%s","git_sha":"%s","git_branch":"%s","build_timestamp":"%s"}\n' \
+    "$(grep '^version' dioxus-ui/Cargo.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')" \
+    "$(echo "${GIT_SHA}" | cut -c1-8)" "${GIT_BRANCH}" "${BUILD_TIMESTAMP}" \
+    > dioxus-ui/dist/version.json
+
 # ---------------------------------------------------------------------------
 FROM nginx:1.21.5-alpine
+
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+LABEL org.opencontainers.image.revision=${GIT_SHA}
+LABEL org.opencontainers.image.ref.name=${GIT_BRANCH}
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /app/dioxus-ui/dist /usr/share/nginx/html

--- a/Dockerfile.meeting-api
+++ b/Dockerfile.meeting-api
@@ -1,11 +1,22 @@
 FROM securityunion/actix-base:meeting-ownership-branch-c4b19265 as build
 
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+ARG BUILD_TIMESTAMP=unknown
 ENV CARGO_TARGET_DIR=/app/meeting-api/target
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
 COPY . /app
 WORKDIR /app/meeting-api
 RUN cargo build --release --bin meeting-api
 
 FROM debian:trixie-slim as production
+
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+LABEL org.opencontainers.image.revision=${GIT_SHA}
+LABEL org.opencontainers.image.ref.name=${GIT_BRANCH}
 
 RUN apt-get --yes update && apt-get --yes install libssl-dev ca-certificates
 

--- a/Dockerfile.yew
+++ b/Dockerfile.yew
@@ -1,6 +1,12 @@
 FROM nixos/nix:2.33.2 AS builder
 
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+ARG BUILD_TIMESTAMP=unknown
 ENV NIX_CONFIG="experimental-features = nix-command flakes"
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
 
 WORKDIR /app
 
@@ -22,6 +28,11 @@ RUN nix develop .#yew-ui --command bash -c "\
 
 # ---------------------------------------------------------------------------
 FROM nginx:1.21.5-alpine
+
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+LABEL org.opencontainers.image.revision=${GIT_SHA}
+LABEL org.opencontainers.image.ref.name=${GIT_BRANCH}
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /app/yew-ui/dist /usr/share/nginx/html

--- a/actix-api/build.rs
+++ b/actix-api/build.rs
@@ -1,0 +1,40 @@
+fn main() {
+    // Prefer env vars (set by Docker ARGs during CI builds) over git commands (local dev).
+    let sha = std::env::var("GIT_SHA")
+        .map(|s| s.chars().take(8).collect())
+        .unwrap_or_else(|_| git_short("rev-parse", &["--short", "HEAD"]));
+    let branch = std::env::var("GIT_BRANCH")
+        .unwrap_or_else(|_| git_short("rev-parse", &["--abbrev-ref", "HEAD"]));
+    let ts = std::env::var("BUILD_TIMESTAMP").unwrap_or_else(|_| now_utc());
+
+    println!("cargo:rustc-env=GIT_SHA={sha}");
+    println!("cargo:rustc-env=GIT_BRANCH={branch}");
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={ts}");
+
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+    println!("cargo:rerun-if-env-changed=GIT_BRANCH");
+    println!("cargo:rerun-if-env-changed=BUILD_TIMESTAMP");
+}
+
+fn git_short(cmd: &str, args: &[&str]) -> String {
+    std::process::Command::new("git")
+        .arg(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn now_utc() -> String {
+    // Avoid adding chrono as a build-dep; shell `date` is fine.
+    std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into())
+}

--- a/actix-api/src/bin/websocket_server.rs
+++ b/actix-api/src/bin/websocket_server.rs
@@ -37,6 +37,7 @@ use sec_api::{
     models::{AppConfig, AppState},
     server_diagnostics::ServerDiagnostics,
     session_manager::SessionManager,
+    version,
 };
 use tracing::{debug, error, info};
 use videocall_types::truthy;
@@ -327,6 +328,7 @@ async fn main() -> std::io::Result<()> {
                 .service(logout)
                 .service(ws_connect_authenticated)
                 .service(ws_connect)
+                .route("/version", web::get().to(version::websocket_version))
         } else if db_enabled {
             // OAuth requires database (r2d2 pool for legacy OAuth code)
             let pool = get_pool();
@@ -354,6 +356,7 @@ async fn main() -> std::io::Result<()> {
                 .service(logout)
                 .service(ws_connect_authenticated)
                 .service(ws_connect)
+                .route("/version", web::get().to(version::websocket_version))
         } else {
             // OAuth configured but database disabled - skip OAuth routes
             error!("OAuth is configured but DATABASE_ENABLED=false. OAuth requires database. Skipping OAuth routes.");
@@ -370,6 +373,7 @@ async fn main() -> std::io::Result<()> {
                 .service(logout)
                 .service(ws_connect_authenticated)
                 .service(ws_connect)
+                .route("/version", web::get().to(version::websocket_version))
         }
     })
     .bind((

--- a/actix-api/src/bin/webtransport_server.rs
+++ b/actix-api/src/bin/webtransport_server.rs
@@ -25,6 +25,7 @@ use tracing::{error, info};
 use sec_api::actors::chat_server::ChatServer;
 use sec_api::server_diagnostics::ServerDiagnostics;
 use sec_api::session_manager::SessionManager;
+use sec_api::version;
 use sec_api::webtransport::{self, Certs};
 
 async fn health_responder() -> impl Responder {
@@ -98,8 +99,11 @@ async fn main() {
     // Start health server
     actix_rt::spawn(async move {
         info!("Starting health/metrics HTTP server: {:?}", health_listen);
-        let server =
-            HttpServer::new(|| App::new().route("/healthz", web::get().to(health_responder)));
+        let server = HttpServer::new(|| {
+            App::new()
+                .route("/healthz", web::get().to(health_responder))
+                .route("/version", web::get().to(version::webtransport_version))
+        });
 
         match server.bind(&health_listen) {
             Ok(server) => {

--- a/actix-api/src/lib.rs
+++ b/actix-api/src/lib.rs
@@ -28,4 +28,5 @@ pub mod models;
 pub mod server_diagnostics;
 pub mod session_manager;
 pub mod token_validator;
+pub mod version;
 pub mod webtransport;

--- a/actix-api/src/version.rs
+++ b/actix-api/src/version.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ *
+ * at your option.
+ */
+
+//! Build version information exposed via HTTP endpoints.
+
+use actix_web::{HttpResponse, Responder};
+use serde::Serialize;
+
+/// Compile-time build metadata for a service binary.
+#[derive(Serialize)]
+pub struct BuildInfo {
+    pub service: &'static str,
+    pub version: &'static str,
+    pub git_sha: &'static str,
+    pub git_branch: &'static str,
+    pub build_timestamp: &'static str,
+}
+
+/// Construct a [`BuildInfo`] for the given service name using compile-time env vars.
+pub fn build_info(service: &'static str) -> BuildInfo {
+    BuildInfo {
+        service,
+        version: env!("CARGO_PKG_VERSION"),
+        git_sha: env!("GIT_SHA"),
+        git_branch: env!("GIT_BRANCH"),
+        build_timestamp: env!("BUILD_TIMESTAMP"),
+    }
+}
+
+/// Handler that returns version info for the websocket relay service.
+pub async fn websocket_version() -> impl Responder {
+    HttpResponse::Ok().json(build_info("websocket-relay"))
+}
+
+/// Handler that returns version info for the webtransport relay service.
+pub async fn webtransport_version() -> impl Responder {
+    HttpResponse::Ok().json(build_info("webtransport-relay"))
+}

--- a/cut_build_push_backend.sh
+++ b/cut_build_push_backend.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 set -e
 
-TAG=$1
-if [ -z "$1" ]
-then
-    TAG=$(git rev-parse HEAD)
-fi
+REGISTRY="${REGISTRY:-securityunion}"
 
-IMAGE_URL=securityunion/videocall-media-server:$TAG
-echo "Building image "$IMAGE_URL
+TAG="${1:-$(git rev-parse HEAD)}"
 
-if ! docker build -t $IMAGE_URL . --file Dockerfile.actix; then
+GIT_SHA=$(git rev-parse --short HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+IMAGE_URL="${REGISTRY}/videocall-media-server:${TAG}"
+echo "Building image ${IMAGE_URL}"
+
+if ! docker build -t "$IMAGE_URL" \
+    --build-arg GIT_SHA="$GIT_SHA" \
+    --build-arg GIT_BRANCH="$GIT_BRANCH" \
+    --build-arg BUILD_TIMESTAMP="$BUILD_TIMESTAMP" \
+    -f Dockerfile.actix .; then
     echo "Failed to build server_rust"
 else
-    docker push $IMAGE_URL
-    echo "New image uploaded to "$IMAGE_URL
+    docker push "$IMAGE_URL"
+    echo "New image uploaded to ${IMAGE_URL}"
 fi

--- a/cut_build_push_meeting_api.sh
+++ b/cut_build_push_meeting_api.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 set -e
 
-TAG=$1
-if [ -z "$1" ]
-then
-    TAG=$(git rev-parse HEAD)
-fi
+REGISTRY="${REGISTRY:-securityunion}"
 
-IMAGE_URL=securityunion/videocall-meeting-api:$TAG
-echo "Building image "$IMAGE_URL
+TAG="${1:-$(git rev-parse HEAD)}"
 
-if ! docker build -t $IMAGE_URL . --file Dockerfile.meeting-api; then
+GIT_SHA=$(git rev-parse --short HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+IMAGE_URL="${REGISTRY}/videocall-meeting-api:${TAG}"
+echo "Building image ${IMAGE_URL}"
+
+if ! docker build -t "$IMAGE_URL" \
+    --build-arg GIT_SHA="$GIT_SHA" \
+    --build-arg GIT_BRANCH="$GIT_BRANCH" \
+    --build-arg BUILD_TIMESTAMP="$BUILD_TIMESTAMP" \
+    -f Dockerfile.meeting-api .; then
     echo "Failed to build meeting-api"
 else
-    docker push $IMAGE_URL
-    echo "New image uploaded to "$IMAGE_URL
+    docker push "$IMAGE_URL"
+    echo "New image uploaded to ${IMAGE_URL}"
 fi

--- a/cut_build_push_ui.sh
+++ b/cut_build_push_ui.sh
@@ -1,28 +1,39 @@
 #!/bin/bash
 set -e
 
-TAG=$1
-if [ -z "$1" ]
-then
-    TAG=$(git rev-parse HEAD)
-fi
+REGISTRY="${REGISTRY:-securityunion}"
+
+TAG="${1:-$(git rev-parse HEAD)}"
+
+GIT_SHA=$(git rev-parse --short HEAD)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # --- Yew UI ---
-IMAGE_URL=securityunion/videocall-web-ui:$TAG
-echo "Building image $IMAGE_URL"
-if ! docker build -t $IMAGE_URL --build-arg USERS_ALLOWED_TO_STREAM="dario,griffin,hamdy" . --file Dockerfile.yew; then
+IMAGE_URL="${REGISTRY}/videocall-web-ui:${TAG}"
+echo "Building image ${IMAGE_URL}"
+if ! docker build -t "$IMAGE_URL" \
+    --build-arg USERS_ALLOWED_TO_STREAM="dario,griffin,hamdy" \
+    --build-arg GIT_SHA="$GIT_SHA" \
+    --build-arg GIT_BRANCH="$GIT_BRANCH" \
+    --build-arg BUILD_TIMESTAMP="$BUILD_TIMESTAMP" \
+    -f Dockerfile.yew .; then
     echo "Failed to build yew-ui"
 else
-    docker push $IMAGE_URL
-    echo "New image uploaded to $IMAGE_URL"
+    docker push "$IMAGE_URL"
+    echo "New image uploaded to ${IMAGE_URL}"
 fi
 
 # --- Dioxus UI ---
-DIOXUS_IMAGE_URL=securityunion/videocall-dioxus-ui:$TAG
-echo "Building image $DIOXUS_IMAGE_URL"
-if ! docker build -t $DIOXUS_IMAGE_URL . --file Dockerfile.dioxus; then
+DIOXUS_IMAGE_URL="${REGISTRY}/videocall-dioxus-ui:${TAG}"
+echo "Building image ${DIOXUS_IMAGE_URL}"
+if ! docker build -t "$DIOXUS_IMAGE_URL" \
+    --build-arg GIT_SHA="$GIT_SHA" \
+    --build-arg GIT_BRANCH="$GIT_BRANCH" \
+    --build-arg BUILD_TIMESTAMP="$BUILD_TIMESTAMP" \
+    -f Dockerfile.dioxus .; then
     echo "Failed to build dioxus-ui"
 else
-    docker push $DIOXUS_IMAGE_URL
-    echo "New image uploaded to $DIOXUS_IMAGE_URL"
+    docker push "$DIOXUS_IMAGE_URL"
+    echo "New image uploaded to ${DIOXUS_IMAGE_URL}"
 fi

--- a/dioxus-ui/build.rs
+++ b/dioxus-ui/build.rs
@@ -1,0 +1,39 @@
+fn main() {
+    // Prefer env vars (set by Docker ARGs during CI builds) over git commands (local dev).
+    let sha = std::env::var("GIT_SHA")
+        .map(|s| s.chars().take(8).collect())
+        .unwrap_or_else(|_| git_short("rev-parse", &["--short", "HEAD"]));
+    let branch = std::env::var("GIT_BRANCH")
+        .unwrap_or_else(|_| git_short("rev-parse", &["--abbrev-ref", "HEAD"]));
+    let ts = std::env::var("BUILD_TIMESTAMP").unwrap_or_else(|_| now_utc());
+
+    println!("cargo:rustc-env=GIT_SHA={sha}");
+    println!("cargo:rustc-env=GIT_BRANCH={branch}");
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={ts}");
+
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+    println!("cargo:rerun-if-env-changed=GIT_BRANCH");
+    println!("cargo:rerun-if-env-changed=BUILD_TIMESTAMP");
+}
+
+fn git_short(cmd: &str, args: &[&str]) -> String {
+    std::process::Command::new("git")
+        .arg(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn now_utc() -> String {
+    std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into())
+}

--- a/dioxus-ui/src/components/diagnostics.rs
+++ b/dioxus-ui/src/components/diagnostics.rs
@@ -712,9 +712,6 @@ pub fn Diagnostics(
     let screen_str = if share_screen { "Enabled" } else { "Disabled" };
     let media_status =
         format!("Video: {video_str}\nAudio: {audio_str}\nScreen Share: {screen_str}");
-    let version = env!("CARGO_PKG_VERSION");
-    let git_sha = env!("GIT_SHA");
-    let git_branch = env!("GIT_BRANCH");
     let current_peer_display = if current_peer == "All Peers" {
         "All Peers".to_string()
     } else {
@@ -738,11 +735,6 @@ pub fn Diagnostics(
                             span { class: "build-info-cell", "Component" }
                             span { class: "build-info-cell", "Commit" }
                             span { class: "build-info-cell", "Branch" }
-                        }
-                        div { class: "build-info-row",
-                            span { class: "build-info-cell build-info-service", "UI ({version})" }
-                            span { class: "build-info-cell monospace", "{git_sha}" }
-                            span { class: "build-info-cell", "{git_branch}" }
                         }
                         for comp in backend_versions() {
                             {

--- a/dioxus-ui/src/components/diagnostics.rs
+++ b/dioxus-ui/src/components/diagnostics.rs
@@ -450,6 +450,7 @@ pub fn Diagnostics(
     let mut neteq_buffer_per_peer = use_signal(HashMap::<String, Vec<u64>>::new);
     let mut neteq_jitter_per_peer = use_signal(HashMap::<String, Vec<u64>>::new);
     let mut diag_task = use_signal(|| None::<Task>);
+    let mut backend_versions = use_signal(|| Vec::<serde_json::Value>::new());
 
     // Subscribe to diagnostics events using Dioxus `spawn`.
     // `spawn` runs within the Dioxus runtime so signal mutations properly
@@ -623,6 +624,26 @@ pub fn Diagnostics(
         diag_task.set(Some(task));
     });
 
+    // Fetch aggregated version info from meeting-api when the panel opens.
+    use_effect(move || {
+        if !is_open {
+            backend_versions.set(Vec::new());
+            return;
+        }
+        spawn(async move {
+            if let Ok(base_url) = crate::constants::meeting_api_base_url() {
+                let url = format!("{base_url}/api/v1/versions");
+                if let Ok(resp) = reqwest::get(&url).await {
+                    if let Ok(body) = resp.json::<serde_json::Value>().await {
+                        if let Some(components) = body["components"].as_array() {
+                            backend_versions.set(components.clone());
+                        }
+                    }
+                }
+            }
+        });
+    });
+
     // Resolve numeric session IDs to display names via VideoCallClient context.
     let client = use_context::<VideoCallClient>();
     let peer_display_name = move |session_id: &str| -> String {
@@ -692,7 +713,8 @@ pub fn Diagnostics(
     let media_status =
         format!("Video: {video_str}\nAudio: {audio_str}\nScreen Share: {screen_str}");
     let version = env!("CARGO_PKG_VERSION");
-    let version_str = format!("VideoCall UI: {version}");
+    let git_sha = env!("GIT_SHA");
+    let git_branch = env!("GIT_BRANCH");
     let current_peer_display = if current_peer == "All Peers" {
         "All Peers".to_string()
     } else {
@@ -710,8 +732,35 @@ pub fn Diagnostics(
             }
             div { class: "sidebar-content",
                 div { class: "diagnostics-section",
-                    h3 { "Application Version" }
-                    pre { "{version_str}" }
+                    h3 { "Build Info" }
+                    div { class: "build-info-table",
+                        div { class: "build-info-header",
+                            span { class: "build-info-cell", "Component" }
+                            span { class: "build-info-cell", "Commit" }
+                            span { class: "build-info-cell", "Branch" }
+                        }
+                        div { class: "build-info-row",
+                            span { class: "build-info-cell build-info-service", "UI ({version})" }
+                            span { class: "build-info-cell monospace", "{git_sha}" }
+                            span { class: "build-info-cell", "{git_branch}" }
+                        }
+                        for comp in backend_versions() {
+                            {
+                                let svc = comp["service"].as_str().unwrap_or("?").to_string();
+                                let ver = comp["version"].as_str().unwrap_or("").to_string();
+                                let sha = comp["git_sha"].as_str().unwrap_or("?").to_string();
+                                let br = comp["git_branch"].as_str().unwrap_or("?").to_string();
+                                let label = if ver.is_empty() { svc } else { format!("{svc} ({ver})") };
+                                rsx! {
+                                    div { class: "build-info-row",
+                                        span { class: "build-info-cell build-info-service", "{label}" }
+                                        span { class: "build-info-cell monospace", "{sha}" }
+                                        span { class: "build-info-cell", "{br}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 div { class: "diagnostics-section",
                     h3 { "Connection Manager" }

--- a/dioxus-ui/static/style.css
+++ b/dioxus-ui/static/style.css
@@ -832,6 +832,41 @@ select {
   text-align: center;
 }
 
+/* Build Info Styles */
+.build-info-table {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 2px 10px;
+  font-size: 0.85em;
+}
+.build-info-header {
+  display: contents;
+}
+.build-info-header .build-info-cell {
+  color: #888;
+  font-weight: 600;
+  border-bottom: 1px solid #444;
+  padding-bottom: 4px;
+  margin-bottom: 2px;
+}
+.build-info-row {
+  display: contents;
+}
+.build-info-cell {
+  color: #fff;
+  padding: 2px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.build-info-cell.monospace {
+  font-family: monospace;
+  color: #4fc3f7;
+}
+.build-info-cell.build-info-service {
+  color: #ccc;
+}
+
 /* NetEQ Chart Styles */
 .neteq-chart {
   display: flex;

--- a/helm/global/us-east/meeting-api/values.yaml
+++ b/helm/global/us-east/meeting-api/values.yaml
@@ -61,6 +61,8 @@ meeting-api:
       value: "https://app.videocall.rs"
     - name: ALLOWED_REDIRECT_URLS
       value: "https://app.videocall.rs,https://app-dx.videocall.rs"
+    - name: SERVICE_VERSION_URLS
+      value: "http://websocket-us-east:8080/version,http://webtransport-us-east:444/version,http://videocall-ui-dx-us-east:80/version.json"
 
   resources:
     limits:

--- a/helm/meeting-api/values.yaml
+++ b/helm/meeting-api/values.yaml
@@ -78,6 +78,10 @@ env:
     value: "https://app.videocall.rs"
   - name: ALLOWED_REDIRECT_URLS
     value: "https://app.videocall.rs,https://app-dx.videocall.rs"
+  # Comma-separated internal URLs for the aggregated /api/v1/versions endpoint.
+  # Adjust service names per region/deployment.
+  - name: SERVICE_VERSION_URLS
+    value: ""
 resources:
   limits:
     cpu: "200m"

--- a/meeting-api/build.rs
+++ b/meeting-api/build.rs
@@ -1,0 +1,40 @@
+fn main() {
+    // Prefer env vars (set by Docker ARGs during CI builds) over git commands (local dev).
+    let sha = std::env::var("GIT_SHA")
+        .map(|s| s.chars().take(8).collect())
+        .unwrap_or_else(|_| git_short("rev-parse", &["--short", "HEAD"]));
+    let branch = std::env::var("GIT_BRANCH")
+        .unwrap_or_else(|_| git_short("rev-parse", &["--abbrev-ref", "HEAD"]));
+    let ts = std::env::var("BUILD_TIMESTAMP").unwrap_or_else(|_| now_utc());
+
+    println!("cargo:rustc-env=GIT_SHA={sha}");
+    println!("cargo:rustc-env=GIT_BRANCH={branch}");
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={ts}");
+
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+    println!("cargo:rerun-if-env-changed=GIT_BRANCH");
+    println!("cargo:rerun-if-env-changed=BUILD_TIMESTAMP");
+}
+
+fn git_short(cmd: &str, args: &[&str]) -> String {
+    std::process::Command::new("git")
+        .arg(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn now_utc() -> String {
+    // Avoid adding chrono as a build-dep; shell `date` is fine.
+    std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".into())
+}

--- a/meeting-api/src/auth.rs
+++ b/meeting-api/src/auth.rs
@@ -134,6 +134,8 @@ mod tests {
             cookie_name: name.to_string(),
             cookie_secure: false,
             nats: None,
+            service_version_urls: Vec::new(),
+            http_client: reqwest::Client::new(),
         }
     }
 

--- a/meeting-api/src/config.rs
+++ b/meeting-api/src/config.rs
@@ -47,6 +47,9 @@ pub struct Config {
     /// NATS server URL (e.g. "nats://localhost:4222"). `None` if `NATS_URL` is unset.
     /// When not configured, NATS event publishing is silently skipped (graceful degradation).
     pub nats_url: Option<String>,
+    /// Internal URLs for fetching version info from peer services.
+    /// Used by the aggregated `/api/v1/versions` endpoint.
+    pub service_version_urls: Vec<String>,
 }
 
 /// OAuth/OIDC configuration — provider-agnostic.
@@ -123,6 +126,14 @@ impl Config {
             .map(|s| s.split(',').map(|o| o.trim().to_string()).collect())
             .unwrap_or_default();
         let nats_url = env::var("NATS_URL").ok().filter(|s| !s.is_empty());
+
+        // Internal URLs for the aggregated /api/v1/versions endpoint.
+        // Comma-separated list, e.g. "http://rustlemania-websocket:8080/version,http://rustlemania-webtransport:444/version"
+        let service_version_urls = env::var("SERVICE_VERSION_URLS")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.split(',').map(|u| u.trim().to_string()).collect())
+            .unwrap_or_default();
 
         let oauth = env::var("OAUTH_CLIENT_ID")
             .ok()
@@ -207,6 +218,7 @@ impl Config {
             cookie_secure,
             cors_allowed_origin,
             nats_url,
+            service_version_urls,
         })
     }
 

--- a/meeting-api/src/routes/mod.rs
+++ b/meeting-api/src/routes/mod.rs
@@ -19,15 +19,78 @@ pub mod participants;
 pub mod waiting_room;
 
 use axum::{
+    extract::State,
     routing::{delete, get, patch, post},
     Router,
 };
 
+use serde::{Deserialize, Serialize};
+
 use crate::state::AppState;
+
+/// Build version metadata returned by all service `/version` endpoints.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct BuildInfo {
+    pub service: String,
+    pub version: String,
+    pub git_sha: String,
+    pub git_branch: String,
+    pub build_timestamp: String,
+}
+
+fn own_build_info() -> BuildInfo {
+    BuildInfo {
+        service: "meeting-api".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        git_sha: env!("GIT_SHA").into(),
+        git_branch: env!("GIT_BRANCH").into(),
+        build_timestamp: env!("BUILD_TIMESTAMP").into(),
+    }
+}
+
+/// Handler that returns build version info for the meeting-api service.
+pub async fn version() -> axum::Json<BuildInfo> {
+    axum::Json(own_build_info())
+}
+
+/// Aggregated version info from meeting-api and all configured peer services.
+///
+/// Fetches `/version` from each URL in `SERVICE_VERSION_URLS` (with a short
+/// timeout) and returns them alongside this service's own build info.
+/// Peer responses are deserialized into [`BuildInfo`]; unexpected payloads
+/// are silently dropped.
+pub async fn versions(State(state): State<AppState>) -> axum::Json<serde_json::Value> {
+    let mut components = vec![own_build_info()];
+
+    let fetches: Vec<_> = state
+        .service_version_urls
+        .iter()
+        .map(|url| {
+            let client = state.http_client.clone();
+            let url = url.clone();
+            async move {
+                match client.get(&url).send().await {
+                    Ok(resp) => resp.json::<BuildInfo>().await.ok(),
+                    Err(_) => None,
+                }
+            }
+        })
+        .collect();
+
+    let results = futures::future::join_all(fetches).await;
+    for result in results.into_iter().flatten() {
+        components.push(result);
+    }
+
+    axum::Json(serde_json::json!({ "components": components }))
+}
 
 /// Build the full application router with all meeting API routes.
 pub fn router() -> Router<AppState> {
     Router::new()
+        // Version info
+        .route("/version", get(version))
+        .route("/api/v1/versions", get(versions))
         // OAuth / session
         .route("/login", get(oauth::login))
         .route("/login/callback", get(oauth::callback))

--- a/meeting-api/src/state.rs
+++ b/meeting-api/src/state.rs
@@ -45,6 +45,10 @@ pub struct AppState {
     pub cookie_secure: bool,
     /// NATS client for publishing meeting events. `None` when `NATS_URL` is not configured.
     pub nats: Option<async_nats::Client>,
+    /// Internal URLs for fetching version info from peer services.
+    pub service_version_urls: Vec<String>,
+    /// Shared HTTP client for outbound requests (e.g. version fan-out).
+    pub http_client: reqwest::Client,
 }
 
 impl AppState {
@@ -66,6 +70,11 @@ impl AppState {
             cookie_name: config.cookie_name.clone(),
             cookie_secure: config.cookie_secure,
             nats,
+            service_version_urls: config.service_version_urls.clone(),
+            http_client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(3))
+                .build()
+                .expect("failed to build reqwest client"),
         }
     }
 }

--- a/meeting-api/tests/test_helpers.rs
+++ b/meeting-api/tests/test_helpers.rs
@@ -64,6 +64,8 @@ pub fn build_app(pool: PgPool) -> Router {
         cookie_name: "session".to_string(),
         cookie_secure: false,
         nats: None,
+        service_version_urls: Vec::new(),
+        http_client: reqwest::Client::new(),
     };
     routes::router().with_state(state)
 }


### PR DESCRIPTION
### We need a mechanism to understand exactly what specific build is deployed

## Summary

- Embeds git SHA (8-char), branch name, and build timestamp in all service binaries at compile time via `build.rs`
- Adds unauthenticated `/version` JSON endpoints on websocket relay, webtransport relay, and meeting-api
- Adds aggregated `/api/v1/versions` endpoint on meeting-api that fans out to peer services with 3s timeout
- Updates Dioxus diagnostics panel to show all component versions in a Build Info table
- Updates all 4 Dockerfiles, 6 GitHub Actions workflows, and 3 build scripts to pass build metadata

## Details

**Backend**: New `BuildInfo` typed struct ensures only expected fields are forwarded from peer services. Shared `reqwest::Client` stored in `AppState` for connection reuse. `SERVICE_VERSION_URLS` env var (comma-separated) configures which internal services to query.

**Frontend**: Diagnostics panel replaces static "Application Version" text with a 3-column table (Component, Commit, Branch) showing the UI's own build info plus all backend versions fetched from the aggregated endpoint.

**Build pipeline**: All Dockerfiles declare `ARG GIT_SHA/GIT_BRANCH/BUILD_TIMESTAMP` with "unknown" defaults. Build scripts support `REGISTRY` env var override. SHA standardized to 8 chars via `build.rs` truncation.

## Test plan

- [x] `cargo clippy -p videocall-api -p meeting-api` passes clean
- [x] Verify `/version` returns JSON on websocket relay (port 8080)
- [x] Verify `/version` returns JSON on webtransport health server (port 444)
- [x] Verify `/api/v1/versions` aggregates all configured services
- [x] Verify Dioxus diagnostics panel shows Build Info table with all components
- [x] Verify `docker build` with `--build-arg GIT_SHA=abc123` embeds the value
- [x] Verify local `cargo build` works without env vars set (falls back to git commands)

