### PR TITLE
ci: add Dioxus UI Docker Hub publish workflow

### DIFF
--- a/.github/workflows/docker-build-check.yaml
+++ b/.github/workflows/docker-build-check.yaml
@@ -12,10 +12,12 @@ on:
       - 'Cargo.toml'
       # UI image dependencies
       - 'yew-ui/**'
+      - 'dioxus-ui/**'
       - 'videocall-client/**'
       - 'videocall-codecs/**'
       - 'neteq/**'
       - 'Dockerfile.yew'
+      - 'Dockerfile.dioxus'
       - 'nginx.conf'
       - 'flake.nix'
       - 'flake.lock'
@@ -85,6 +87,25 @@ jobs:
         with:
           context: .
           file: Dockerfile.yew
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-dioxus-ui:
+    name: Build Dioxus UI Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Dioxus UI Docker image (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.dioxus
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/upload-dioxus-ui-docker-hub.yaml
+++ b/.github/workflows/upload-dioxus-ui-docker-hub.yaml
@@ -1,0 +1,51 @@
+name: Publish Dioxus UI to Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'dioxus-ui/**'
+      - 'videocall-types/**'
+      - 'protobuf/**'
+      - 'videocall-client/**'
+      - 'videocall-codecs/**'
+      - 'neteq/**'
+      - Dockerfile.dioxus
+      - nginx.conf
+      - flake.nix
+      - flake.lock
+
+jobs:
+  push_to_registry:
+    name: Push Dioxus UI Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        id: checkout
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract SHA
+        id: extract_sha
+        run: echo "sha8=$(echo ${GITHUB_SHA::8})" >> "$GITHUB_OUTPUT"
+
+      - name: Extract branch name
+        id: extract_branch
+        run: echo "branch=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | sed 's/\//-/g')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Dioxus UI Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: Dockerfile.dioxus
+          push: true
+          tags: |
+            securityunion/videocall-dioxus-ui:${{ steps.extract_branch.outputs.branch }}-${{ steps.extract_sha.outputs.sha8 }}
+            securityunion/videocall-dioxus-ui:latest


### PR DESCRIPTION
## Summary
- Adds `upload-dioxus-ui-docker-hub.yaml` to build and push `securityunion/videocall-dioxus-ui` to Docker Hub on pushes to `main` (mirrors the existing Yew UI workflow)
- Adds Dioxus UI build validation to `docker-build-check.yaml` so PRs that break the Dioxus Docker build get caught
- Triggered by changes to `dioxus-ui/`, shared crates, `Dockerfile.dioxus`, `nginx.conf`, or flake files
- Includes `workflow_dispatch` for manual trigger

## Test plan
- [ ] Merge and trigger via `workflow_dispatch` to verify the image builds and pushes to Docker Hub
- [ ] Verify `securityunion/videocall-dioxus-ui:latest` appears on Docker Hub after run
- [ ] Verify PR build check runs the new `build-dioxus-ui` job