### PR TITLE
feat: add SERVICE_VERSION_URLS to PR preview deploy workflow

### DIFF
--- a/.github/workflows/pr-deploy-reusable.yaml
+++ b/.github/workflows/pr-deploy-reusable.yaml
@@ -515,6 +515,8 @@ jobs:
             --set "env[12].value=pr${SLOT}-session" \
             --set "env[13].name=ALLOWED_REDIRECT_URLS" \
             --set "env[13].value=https://pr${SLOT}.sandbox.videocall.rs\,https://pr${SLOT}-dx.sandbox.videocall.rs" \
+            --set "env[14].name=SERVICE_VERSION_URLS" \
+            --set "env[14].value=http://websocket-pr-${PR_NUM}:8080/version\,http://dx-pr-${PR_NUM}:80/version.json\,http://ui-pr-${PR_NUM}:80/version.json" \
             --set "ingress.hosts[0].host=pr${SLOT}-api.sandbox.videocall.rs" \
             --set "ingress.hosts[0].paths[0].path=/" \
             --set "ingress.hosts[0].paths[0].pathType=Prefix" \


### PR DESCRIPTION
should have been done as part of https://github.com/security-union/videocall-rs/pull/751   This change sets the version urls so the UI diagnostics panel can show the version of each component.

## Summary
- Add `SERVICE_VERSION_URLS` env var to meeting-api in the PR preview deploy workflow
- Uses per-PR service names: `websocket-pr-N`, `dx-pr-N`, `ui-pr-N`
- No webtransport URL since it's disabled in preview environments
- Production already has this configured via global helm values

## Test plan
- [ ] Deploy a PR preview and verify `/api/v1/versions` endpoint returns service versions