### PR TITLE
When joining a meeting, exit message is shown to current attendees as the user transitions from wait room to meeting page

### DIFF
--- a/actix-api/src/actors/chat_server.rs
+++ b/actix-api/src/actors/chat_server.rs
@@ -376,7 +376,6 @@ impl Handler<ActivateConnection> for ChatServer {
                                     session: session_for_cleanup,
                                     room: room.clone(),
                                 });
-                                return;
                             }
                         }
                     });
@@ -457,7 +456,7 @@ impl Handler<JoinRoom> for ChatServer {
             display_name,
             observer,
         }: JoinRoom,
-        ctx: &mut Self::Context,
+        _ctx: &mut Self::Context,
     ) -> Self::Result {
         // Validate user_id synchronously BEFORE spawning async task.
         // This ensures we return an error to the client if validation fails,


### PR DESCRIPTION
- Fixed: When a user joins a meeting, the "participant left" (exit) message is no longer shown to current attendees during the transition.
- Moved "meeting started" and "participant joined" event logic to the `ActivateConnection` handler. This should resolve the issue where a user could appear duplicated to others when their session was not yet selected during an election.


## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Project / Infra

## Testing
- [ ] Tests written or updated
- [X] No tests needed

## Other
- [ ] Documentation updated
- [ ] Before/After Images provided

