### PR TITLE
When joining a meeting, exit message is shown to current attendees as the user transitions from wait room to meeting page

### DIFF
--- a/actix-api/src/actors/chat_server.rs
+++ b/actix-api/src/actors/chat_server.rs
@@ -1550,6 +1550,14 @@ mod tests {
             .expect("Message delivery should succeed");
         assert!(result.is_ok(), "Non-observer JoinRoom should succeed");
 
+        // Activate the connection so the state is Active before disconnect
+        chat_server
+            .send(ActivateConnection {
+                session: session_id,
+            })
+            .await
+            .expect("ActivateConnection should succeed");
+
         // Wait for session setup
         sleep(Duration::from_millis(300)).await;
 


### PR DESCRIPTION
Fixed: When a user joins a meeting, the "participant left" (exit) message is no longer shown to current attendees during the transition #738

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Project / Infra

## Testing
- [X] Tests written or updated
- [ ] No tests needed

## Other
- [ ] Documentation updated
- [ ] Before/After Images provided

