### PR TITLE
Fix: workflow broken; Remove deprecated Yew UI Docker Hub workflow

### DIFF
--- a/.github/workflows/upload-ui-docker-hub.yaml
+++ b/.github/workflows/upload-ui-docker-hub.yaml
@@ -1,8 +1,0 @@
-# Deprecated: Yew UI has been removed.
-# Dioxus UI is now published via upload-dioxus-ui-docker-hub.yaml
-name: "[DEPRECATED] Publish Yew UI to Docker image"
-
-on:
-  workflow_dispatch:
-
-jobs: {}


### PR DESCRIPTION
follow up to #788 #789 
Fix workflow.  
Remove deprecated Yew UI Docker Hub workflow; Dioxus replacement already exists

_Please include a summary of the changes and related context._

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Project / Infra

## Testing
- [ ] Tests written or updated
- [x] No tests needed

## Other
- [ ] Documentation updated
- [x] Before/After Images provided

https://github.com/security-union/videocall-rs/actions/runs/23774351524/workflow

<img width="1070" height="563" alt="image" src="https://github.com/user-attachments/assets/be2830d8-c3aa-4c29-8111-bdb41318cbb0" />

