### PR TITLE
Feature:  select protocol

### DIFF
--- a/dioxus-ui/src/components/attendants.rs
+++ b/dioxus-ui/src/components/attendants.rs
@@ -34,7 +34,10 @@ use crate::constants::actix_websocket_base;
 use crate::constants::{
     server_election_period_ms, users_allowed_to_stream, webtransport_host_base, CANVAS_LIMIT,
 };
-use crate::context::{LocalAudioLevelCtx, MeetingTime, PeerMediaState, PeerStatusMap};
+use crate::context::{
+    resolve_transport_config, LocalAudioLevelCtx, MeetingTime, PeerMediaState, PeerStatusMap,
+    TransportPreference, TransportPreferenceCtx,
+};
 use dioxus::prelude::Element as DioxusElement;
 use dioxus::prelude::*;
 use gloo_timers::callback::Timeout;
@@ -198,6 +201,7 @@ fn schedule_reconnect(
     current_display_name: Signal<String>,
     mut connection_error: Signal<Option<String>>,
     mut meeting_ended_message: Signal<Option<String>>,
+    transport_pref_signal: Signal<TransportPreference>,
     attempt: u32,
 ) {
     let delay_ms = match reconnect_delay_ms(attempt) {
@@ -224,6 +228,15 @@ fn schedule_reconnect(
                     log::info!("Room token refreshed, reconnecting with new token");
                     let latest_display_name = current_display_name();
                     let (ws, wt) = build_lobby_urls(&new_token, &latest_display_name, &meeting_id);
+
+                    // Apply the user's transport preference so the reconnection
+                    // honours the same protocol selection as the initial connection.
+                    let pref = transport_pref_signal();
+                    let server_wt_enabled =
+                        crate::constants::webtransport_enabled().unwrap_or(false);
+                    let (_enable_wt, ws, wt) =
+                        resolve_transport_config(pref, server_wt_enabled, ws, wt);
+
                     if let Some(client) = client_cell.borrow_mut().as_mut() {
                         client.update_server_urls(ws, wt);
                         if let Err(e) = client.connect() {
@@ -243,6 +256,7 @@ fn schedule_reconnect(
                         current_display_name,
                         connection_error,
                         meeting_ended_message,
+                        transport_pref_signal,
                         attempt + 1,
                     );
                 }
@@ -376,7 +390,6 @@ pub fn AttendantsComponent(
     #[props(default)] id: String,
     #[props(default)] display_name: String,
     e2ee_enabled: bool,
-    webtransport_enabled: bool,
     #[props(default)] user_name: Option<String>,
     #[props(default)] user_id: Option<String>,
     #[props(default)] on_logout: Option<EventHandler<()>>,
@@ -448,6 +461,11 @@ pub fn AttendantsComponent(
     // on_peer_removed callback inside use_hook below.
     let mut peer_status_map: PeerStatusMap = use_signal(HashMap::new);
 
+    // Read transport preference from context BEFORE use_hook (hooks must not
+    // be called inside the hook closure).
+    let transport_pref_ctx = use_context::<TransportPreferenceCtx>();
+    let transport_pref = (transport_pref_ctx.0)();
+
     // Create VideoCallClient and MediaDeviceAccess once.
     // We use an Rc<RefCell<Option<VideoCallClient>>> so the on_connection_lost
     // callback can access the client for reconnection. The cell is populated
@@ -469,6 +487,15 @@ pub fn AttendantsComponent(
         let (websocket_urls, webtransport_urls) =
             build_lobby_urls(&token, &initial_display_name, &id);
 
+        // Apply user's transport preference
+        let server_wt_enabled = crate::constants::webtransport_enabled().unwrap_or(false);
+        let (effective_wt_enabled, websocket_urls, webtransport_urls) = resolve_transport_config(
+            transport_pref,
+            server_wt_enabled,
+            websocket_urls,
+            webtransport_urls,
+        );
+
         log::info!(
             "DIOXUS-UI: Creating VideoCallClient for {} in meeting {}",
             initial_display_name,
@@ -486,7 +513,7 @@ pub fn AttendantsComponent(
             websocket_urls,
             webtransport_urls,
             enable_e2ee: e2ee_enabled,
-            enable_webtransport: webtransport_enabled,
+            enable_webtransport: effective_wt_enabled,
             on_connected: VcCallback::from(move |_| {
                 log::info!("DIOXUS-UI: Connection established");
                 let mut connection_error = connection_error;
@@ -517,6 +544,7 @@ pub fn AttendantsComponent(
                             current_display_name,
                             connection_error,
                             meeting_ended_message,
+                            transport_pref_ctx.0,
                             0,
                         );
                     }

--- a/dioxus-ui/src/components/device_settings_modal.rs
+++ b/dioxus-ui/src/components/device_settings_modal.rs
@@ -2,6 +2,7 @@
  * Copyright 2025 Security Union LLC
  * Licensed under MIT OR Apache-2.0
  */
+use crate::context::TransportPreference;
 use crate::types::DeviceInfo;
 use dioxus::prelude::*;
 use videocall_client::utils::is_ios;
@@ -11,6 +12,7 @@ use web_sys::MediaDeviceInfo;
 enum SettingsSection {
     Audio,
     Video,
+    Network,
 }
 
 impl SettingsSection {
@@ -18,6 +20,7 @@ impl SettingsSection {
         match self {
             SettingsSection::Audio => "Audio",
             SettingsSection::Video => "Video",
+            SettingsSection::Network => "Network",
         }
     }
 
@@ -25,6 +28,7 @@ impl SettingsSection {
         match self {
             SettingsSection::Audio => "settings-tab-audio",
             SettingsSection::Video => "settings-tab-video",
+            SettingsSection::Network => "settings-tab-network",
         }
     }
 
@@ -32,6 +36,7 @@ impl SettingsSection {
         match self {
             SettingsSection::Audio => "settings-panel-audio",
             SettingsSection::Video => "settings-panel-video",
+            SettingsSection::Network => "settings-panel-network",
         }
     }
 
@@ -39,24 +44,31 @@ impl SettingsSection {
         match self {
             SettingsSection::Audio => "settings-nav-audio",
             SettingsSection::Video => "settings-nav-video",
+            SettingsSection::Network => "settings-nav-network",
         }
     }
 
-    fn all() -> [SettingsSection; 2] {
-        [SettingsSection::Audio, SettingsSection::Video]
+    fn all() -> [SettingsSection; 3] {
+        [
+            SettingsSection::Audio,
+            SettingsSection::Video,
+            SettingsSection::Network,
+        ]
     }
 
     fn next(self) -> Self {
         match self {
             SettingsSection::Audio => SettingsSection::Video,
-            SettingsSection::Video => SettingsSection::Audio,
+            SettingsSection::Video => SettingsSection::Network,
+            SettingsSection::Network => SettingsSection::Audio,
         }
     }
 
     fn prev(self) -> Self {
         match self {
-            SettingsSection::Audio => SettingsSection::Video,
+            SettingsSection::Audio => SettingsSection::Network,
             SettingsSection::Video => SettingsSection::Audio,
+            SettingsSection::Network => SettingsSection::Video,
         }
     }
 }
@@ -74,6 +86,8 @@ pub fn DeviceSettingsModal(
     on_speaker_select: EventHandler<DeviceInfo>,
     visible: bool,
     on_close: EventHandler<()>,
+    #[props(default = TransportPreference::Auto)] transport_preference: TransportPreference,
+    #[props(default)] on_transport_preference_change: Option<EventHandler<TransportPreference>>,
 ) -> Element {
     let is_ios_safari = is_ios();
     let mut active_section = use_signal(|| SettingsSection::Audio);
@@ -261,6 +275,53 @@ pub fn DeviceSettingsModal(
                                                 }
                                             }
                                         }
+                                    }
+                                }
+                            },
+                            SettingsSection::Network => rsx! {
+                                div {
+                                    id: SettingsSection::Network.panel_id(),
+                                    class: "settings-section",
+                                    role: "tabpanel",
+                                    "aria-labelledby": SettingsSection::Network.tab_id(),
+
+                                    h3 { class: "settings-section-title", "Network" }
+                                    p { class: "settings-section-description",
+                                        "Choose the transport protocol for media connections."
+                                    }
+
+                                    div { class: "device-setting-group",
+                                        label { r#for: "modal-transport-select", "Protocol" }
+                                        select {
+                                            id: "modal-transport-select",
+                                            class: "device-selector-modal",
+                                            onchange: move |evt: Event<FormData>| {
+                                                let val = evt.value();
+                                                let pref = val.parse::<TransportPreference>().unwrap_or_default();
+                                                if let Some(handler) = &on_transport_preference_change {
+                                                    handler.call(pref);
+                                                }
+                                            },
+                                            option {
+                                                value: "auto",
+                                                selected: transport_preference == TransportPreference::Auto,
+                                                "Auto"
+                                            }
+                                            option {
+                                                value: "webtransport",
+                                                selected: transport_preference == TransportPreference::WebTransportOnly,
+                                                "WebTransport"
+                                            }
+                                            option {
+                                                value: "websocket",
+                                                selected: transport_preference == TransportPreference::WebSocketOnly,
+                                                "WebSocket"
+                                            }
+                                        }
+                                    }
+
+                                    p { class: "transport-preference-note",
+                                        "Takes effect on next connection."
                                     }
                                 }
                             },

--- a/dioxus-ui/src/components/device_settings_modal.rs
+++ b/dioxus-ui/src/components/device_settings_modal.rs
@@ -2,7 +2,7 @@
  * Copyright 2025 Security Union LLC
  * Licensed under MIT OR Apache-2.0
  */
-use crate::context::TransportPreference;
+use crate::context::{confirm_transport_change, TransportPreference};
 use crate::types::DeviceInfo;
 use dioxus::prelude::*;
 use videocall_client::utils::is_ios;
@@ -86,8 +86,7 @@ pub fn DeviceSettingsModal(
     on_speaker_select: EventHandler<DeviceInfo>,
     visible: bool,
     on_close: EventHandler<()>,
-    #[props(default = TransportPreference::Auto)] transport_preference: TransportPreference,
-    #[props(default)] on_transport_preference_change: Option<EventHandler<TransportPreference>>,
+    #[props(default)] transport_preference: TransportPreference,
 ) -> Element {
     let is_ios_safari = is_ios();
     let mut active_section = use_signal(|| SettingsSection::Audio);
@@ -296,11 +295,11 @@ pub fn DeviceSettingsModal(
                                             id: "modal-transport-select",
                                             class: "device-selector-modal",
                                             onchange: move |evt: Event<FormData>| {
-                                                let val = evt.value();
-                                                let pref = val.parse::<TransportPreference>().unwrap_or_default();
-                                                if let Some(handler) = &on_transport_preference_change {
-                                                    handler.call(pref);
-                                                }
+                                                confirm_transport_change(
+                                                    &evt.value(),
+                                                    transport_preference,
+                                                    "modal-transport-select",
+                                                );
                                             },
                                             option {
                                                 value: "auto",

--- a/dioxus-ui/src/components/device_settings_modal.rs
+++ b/dioxus-ui/src/components/device_settings_modal.rs
@@ -321,7 +321,7 @@ pub fn DeviceSettingsModal(
                                     }
 
                                     p { class: "transport-preference-note",
-                                        "Takes effect on next connection."
+                                        "Changing protocol will reload the page."
                                     }
                                 }
                             },

--- a/dioxus-ui/src/components/diagnostics.rs
+++ b/dioxus-ui/src/components/diagnostics.rs
@@ -19,14 +19,13 @@
 use crate::components::neteq_chart::{
     AdvancedChartType, ChartType, NetEqAdvancedChart, NetEqChart, NetEqStats, NetEqStatusDisplay,
 };
-use crate::context::{save_transport_preference, TransportPreference, TransportPreferenceCtx};
+use crate::context::{confirm_transport_change, TransportPreference, TransportPreferenceCtx};
 use dioxus::prelude::*;
 use dioxus_core::Task;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use videocall_client::VideoCallClient;
 use videocall_diagnostics::{subscribe, MetricValue};
-use web_sys;
 
 // Serializable versions of DiagEvent structures
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -770,23 +769,14 @@ pub fn Diagnostics(
                     h3 { "Transport Preference" }
                     div { class: "device-setting-group",
                         select {
+                            id: "diagnostics-transport-select",
                             class: "peer-selector",
                             onchange: move |evt: Event<FormData>| {
-                                let pref = evt.value().parse::<TransportPreference>().unwrap_or_default();
-                                if pref == (transport_pref_ctx.0)() {
-                                    return;
-                                }
-                                let confirmed = web_sys::window()
-                                    .and_then(|w| w.confirm_with_message(
-                                        "Changing the transport protocol will reload the page and disconnect the current call. Continue?"
-                                    ).ok())
-                                    .unwrap_or(false);
-                                if confirmed {
-                                    save_transport_preference(pref);
-                                    if let Some(w) = web_sys::window() {
-                                        let _ = w.location().reload();
-                                    }
-                                }
+                                confirm_transport_change(
+                                    &evt.value(),
+                                    (transport_pref_ctx.0)(),
+                                    "diagnostics-transport-select",
+                                );
                             },
                             option {
                                 value: "auto",

--- a/dioxus-ui/src/components/diagnostics.rs
+++ b/dioxus-ui/src/components/diagnostics.rs
@@ -19,6 +19,7 @@
 use crate::components::neteq_chart::{
     AdvancedChartType, ChartType, NetEqAdvancedChart, NetEqChart, NetEqStats, NetEqStatusDisplay,
 };
+use crate::context::{save_transport_preference, TransportPreference, TransportPreferenceCtx};
 use dioxus::prelude::*;
 use dioxus_core::Task;
 use serde::{Deserialize, Serialize};
@@ -442,6 +443,7 @@ pub fn Diagnostics(
     share_screen: bool,
     encoder_settings: Option<String>,
 ) -> Element {
+    let mut transport_pref_ctx = use_context::<TransportPreferenceCtx>();
     let mut selected_peer = use_signal(|| "All Peers".to_string());
     let mut diagnostics_data = use_signal(|| None::<String>);
     let mut sender_stats = use_signal(|| None::<String>);
@@ -762,6 +764,37 @@ pub fn Diagnostics(
                 div { class: "diagnostics-section",
                     h3 { "Connection Manager" }
                     ConnectionManagerDisplay { connection_manager_state: conn_state }
+                }
+                div { class: "diagnostics-section",
+                    h3 { "Transport Preference" }
+                    div { class: "device-setting-group",
+                        select {
+                            class: "peer-selector",
+                            onchange: move |evt: Event<FormData>| {
+                                let pref = evt.value().parse::<TransportPreference>().unwrap_or_default();
+                                save_transport_preference(pref);
+                                (transport_pref_ctx.0).set(pref);
+                            },
+                            option {
+                                value: "auto",
+                                selected: (transport_pref_ctx.0)() == TransportPreference::Auto,
+                                "Auto"
+                            }
+                            option {
+                                value: "webtransport",
+                                selected: (transport_pref_ctx.0)() == TransportPreference::WebTransportOnly,
+                                "WebTransport"
+                            }
+                            option {
+                                value: "websocket",
+                                selected: (transport_pref_ctx.0)() == TransportPreference::WebSocketOnly,
+                                "WebSocket"
+                            }
+                        }
+                    }
+                    p { class: "transport-preference-note",
+                        "Takes effect on next connection."
+                    }
                 }
                 if available_peers.len() > 1 {
                     div { class: "diagnostics-section",

--- a/dioxus-ui/src/components/diagnostics.rs
+++ b/dioxus-ui/src/components/diagnostics.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use videocall_client::VideoCallClient;
 use videocall_diagnostics::{subscribe, MetricValue};
+use web_sys;
 
 // Serializable versions of DiagEvent structures
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -443,7 +444,7 @@ pub fn Diagnostics(
     share_screen: bool,
     encoder_settings: Option<String>,
 ) -> Element {
-    let mut transport_pref_ctx = use_context::<TransportPreferenceCtx>();
+    let transport_pref_ctx = use_context::<TransportPreferenceCtx>();
     let mut selected_peer = use_signal(|| "All Peers".to_string());
     let mut diagnostics_data = use_signal(|| None::<String>);
     let mut sender_stats = use_signal(|| None::<String>);
@@ -772,8 +773,20 @@ pub fn Diagnostics(
                             class: "peer-selector",
                             onchange: move |evt: Event<FormData>| {
                                 let pref = evt.value().parse::<TransportPreference>().unwrap_or_default();
-                                save_transport_preference(pref);
-                                (transport_pref_ctx.0).set(pref);
+                                if pref == (transport_pref_ctx.0)() {
+                                    return;
+                                }
+                                let confirmed = web_sys::window()
+                                    .and_then(|w| w.confirm_with_message(
+                                        "Changing the transport protocol will reload the page and disconnect the current call. Continue?"
+                                    ).ok())
+                                    .unwrap_or(false);
+                                if confirmed {
+                                    save_transport_preference(pref);
+                                    if let Some(w) = web_sys::window() {
+                                        let _ = w.location().reload();
+                                    }
+                                }
                             },
                             option {
                                 value: "auto",
@@ -793,7 +806,7 @@ pub fn Diagnostics(
                         }
                     }
                     p { class: "transport-preference-note",
-                        "Takes effect on next connection."
+                        "Changing protocol will reload the page."
                     }
                 }
                 if available_peers.len() > 1 {

--- a/dioxus-ui/src/components/host.rs
+++ b/dioxus-ui/src/components/host.rs
@@ -21,9 +21,8 @@ use crate::components::{
 };
 use crate::constants::*;
 use crate::context::{
-    load_display_name_from_storage, save_display_name_to_storage, save_transport_preference,
-    validate_display_name, LocalAudioLevelCtx, TransportPreference, TransportPreferenceCtx,
-    VideoCallClientCtx,
+    load_display_name_from_storage, save_display_name_to_storage, validate_display_name,
+    LocalAudioLevelCtx, TransportPreferenceCtx, VideoCallClientCtx,
 };
 use crate::types::DeviceInfo;
 use dioxus::prelude::*;
@@ -649,22 +648,6 @@ pub fn Host(
                     visible: device_settings_open,
                     on_close: move |_| on_device_settings_toggle.call(()),
                     transport_preference: (transport_pref_ctx.0)(),
-                    on_transport_preference_change: Some(EventHandler::new(move |pref: TransportPreference| {
-                        if pref == (transport_pref_ctx.0)() {
-                            return;
-                        }
-                        let confirmed = web_sys::window()
-                            .and_then(|w| w.confirm_with_message(
-                                "Changing the transport protocol will reload the page and disconnect the current call. Continue?"
-                            ).ok())
-                            .unwrap_or(false);
-                        if confirmed {
-                            save_transport_preference(pref);
-                            if let Some(w) = web_sys::window() {
-                                let _ = w.location().reload();
-                            }
-                        }
-                    })),
                 }
             }
         }

--- a/dioxus-ui/src/components/host.rs
+++ b/dioxus-ui/src/components/host.rs
@@ -21,8 +21,9 @@ use crate::components::{
 };
 use crate::constants::*;
 use crate::context::{
-    load_display_name_from_storage, save_display_name_to_storage, validate_display_name,
-    LocalAudioLevelCtx, VideoCallClientCtx,
+    load_display_name_from_storage, save_display_name_to_storage, save_transport_preference,
+    validate_display_name, LocalAudioLevelCtx, TransportPreference, TransportPreferenceCtx,
+    VideoCallClientCtx,
 };
 use crate::types::DeviceInfo;
 use dioxus::prelude::*;
@@ -79,6 +80,7 @@ pub fn Host(
 ) -> Element {
     let client = use_context::<VideoCallClientCtx>();
     let audio_level = use_context::<LocalAudioLevelCtx>().0;
+    let mut transport_pref_ctx = use_context::<TransportPreferenceCtx>();
     let mut glow_el = use_signal(|| None::<web_sys::Element>);
 
     // Indirection cells for callbacks: updated each render, closed over by encoder callbacks
@@ -645,7 +647,12 @@ pub fn Host(
                     on_camera_select: move |d: DeviceInfo| on_cam(d),
                     on_speaker_select: move |d: DeviceInfo| on_spk(d),
                     visible: device_settings_open,
-                    on_close: move |_| on_device_settings_toggle.call(())
+                    on_close: move |_| on_device_settings_toggle.call(()),
+                    transport_preference: (transport_pref_ctx.0)(),
+                    on_transport_preference_change: Some(EventHandler::new(move |pref: TransportPreference| {
+                        save_transport_preference(pref);
+                        (transport_pref_ctx.0).set(pref);
+                    })),
                 }
             }
         }

--- a/dioxus-ui/src/components/host.rs
+++ b/dioxus-ui/src/components/host.rs
@@ -80,7 +80,7 @@ pub fn Host(
 ) -> Element {
     let client = use_context::<VideoCallClientCtx>();
     let audio_level = use_context::<LocalAudioLevelCtx>().0;
-    let mut transport_pref_ctx = use_context::<TransportPreferenceCtx>();
+    let transport_pref_ctx = use_context::<TransportPreferenceCtx>();
     let mut glow_el = use_signal(|| None::<web_sys::Element>);
 
     // Indirection cells for callbacks: updated each render, closed over by encoder callbacks
@@ -650,8 +650,20 @@ pub fn Host(
                     on_close: move |_| on_device_settings_toggle.call(()),
                     transport_preference: (transport_pref_ctx.0)(),
                     on_transport_preference_change: Some(EventHandler::new(move |pref: TransportPreference| {
-                        save_transport_preference(pref);
-                        (transport_pref_ctx.0).set(pref);
+                        if pref == (transport_pref_ctx.0)() {
+                            return;
+                        }
+                        let confirmed = web_sys::window()
+                            .and_then(|w| w.confirm_with_message(
+                                "Changing the transport protocol will reload the page and disconnect the current call. Continue?"
+                            ).ok())
+                            .unwrap_or(false);
+                        if confirmed {
+                            save_transport_preference(pref);
+                            if let Some(w) = web_sys::window() {
+                                let _ = w.location().reload();
+                            }
+                        }
                     })),
                 }
             }

--- a/dioxus-ui/src/components/waiting_room.rs
+++ b/dioxus-ui/src/components/waiting_room.rs
@@ -14,6 +14,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::constants::{actix_websocket_base, webtransport_enabled, webtransport_host_base};
+use crate::context::{resolve_transport_config, TransportPreferenceCtx};
 use crate::meeting_api::{check_status, JoinMeetingResponse};
 use dioxus::prelude::*;
 use videocall_client::Callback as VcCallback;
@@ -35,6 +36,7 @@ pub fn WaitingRoom(
     on_rejected: EventHandler<()>,
     on_cancel: EventHandler<()>,
 ) -> Element {
+    let transport_pref_ctx = use_context::<TransportPreferenceCtx>();
     let mut error = use_signal(|| None::<String>);
 
     // Track whether the observer WebSocket is currently connected.
@@ -71,6 +73,16 @@ pub fn WaitingRoom(
                 .map(&lobby_url)
                 .collect();
 
+            // Apply user's transport preference
+            let server_wt_enabled = webtransport_enabled().unwrap_or(false);
+            let (effective_wt_enabled, websocket_urls, webtransport_urls) =
+                resolve_transport_config(
+                    (transport_pref_ctx.0)(),
+                    server_wt_enabled,
+                    websocket_urls,
+                    webtransport_urls,
+                );
+
             let meeting_id_for_fetch = meeting_id.clone();
             let meeting_id_for_post_connect = meeting_id.clone();
             let obs_conn_on_connect = observer_connected.clone();
@@ -82,7 +94,7 @@ pub fn WaitingRoom(
                 websocket_urls,
                 webtransport_urls,
                 enable_e2ee: false,
-                enable_webtransport: webtransport_enabled().unwrap_or(false),
+                enable_webtransport: effective_wt_enabled,
                 on_connected: VcCallback::from(move |_| {
                     log::info!("Observer connection established (waiting room)");
                     obs_conn_on_connect.set(true);

--- a/dioxus-ui/src/context.rs
+++ b/dioxus-ui/src/context.rs
@@ -234,6 +234,41 @@ pub fn resolve_transport_config(
     }
 }
 
+/// Handle a transport preference change from a `<select>` element.
+///
+/// Shows a confirmation dialog. If the user confirms, saves the preference and
+/// reloads the page. If cancelled, resets the `<select>` element back to the
+/// current value so the dropdown doesn't show a stale selection.
+pub fn confirm_transport_change(new_value: &str, current: TransportPreference, select_id: &str) {
+    use wasm_bindgen::JsCast;
+
+    let pref = new_value.parse::<TransportPreference>().unwrap_or_default();
+    if pref == current {
+        return;
+    }
+    let confirmed = web_sys::window()
+        .and_then(|w| {
+            w.confirm_with_message(
+                "Changing the transport protocol will reload the page \
+                 and disconnect the current call. Continue?",
+            )
+            .ok()
+        })
+        .unwrap_or(false);
+    if confirmed {
+        save_transport_preference(pref);
+        if let Some(w) = web_sys::window() {
+            let _ = w.location().reload();
+        }
+    } else if let Some(select) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id(select_id))
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+    {
+        select.set_value(&current.to_string());
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Validation helpers (re-exported from shared crate)
 // ---------------------------------------------------------------------------

--- a/dioxus-ui/src/context.rs
+++ b/dioxus-ui/src/context.rs
@@ -153,6 +153,88 @@ pub fn migrate_legacy_storage() {
 }
 
 // ---------------------------------------------------------------------------
+// Transport preference
+// ---------------------------------------------------------------------------
+
+/// User-facing transport protocol preference.
+///
+/// Stored in `localStorage` under `vc_transport_preference` and read at
+/// connection time to override the server-provided WebTransport flag.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum TransportPreference {
+    /// Honour the server-side `webTransportEnabled` flag (default behaviour).
+    #[default]
+    Auto,
+    /// Force WebTransport — WebSocket URLs are cleared.
+    WebTransportOnly,
+    /// Force WebSocket — WebTransport is disabled.
+    WebSocketOnly,
+}
+
+impl std::fmt::Display for TransportPreference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            TransportPreference::Auto => "auto",
+            TransportPreference::WebTransportOnly => "webtransport",
+            TransportPreference::WebSocketOnly => "websocket",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for TransportPreference {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(TransportPreference::Auto),
+            "webtransport" => Ok(TransportPreference::WebTransportOnly),
+            "websocket" => Ok(TransportPreference::WebSocketOnly),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Context wrapper for the transport preference signal.
+#[derive(Clone, Copy)]
+pub struct TransportPreferenceCtx(pub Signal<TransportPreference>);
+
+const TRANSPORT_PREF_KEY: &str = "vc_transport_preference";
+
+/// Load the persisted transport preference from `localStorage`.
+pub fn load_transport_preference() -> TransportPreference {
+    web_sys::window()
+        .and_then(|w| w.local_storage().ok().flatten())
+        .and_then(|storage| storage.get_item(TRANSPORT_PREF_KEY).ok().flatten())
+        .and_then(|val| val.parse::<TransportPreference>().ok())
+        .unwrap_or_default()
+}
+
+/// Persist the transport preference to `localStorage`.
+pub fn save_transport_preference(pref: TransportPreference) {
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item(TRANSPORT_PREF_KEY, &pref.to_string());
+    }
+}
+
+/// Resolve effective transport configuration from the user's preference and
+/// the server-provided WebTransport flag.
+///
+/// Returns `(enable_webtransport, websocket_urls, webtransport_urls)`.
+pub fn resolve_transport_config(
+    pref: TransportPreference,
+    server_wt_enabled: bool,
+    ws_urls: Vec<String>,
+    wt_urls: Vec<String>,
+) -> (bool, Vec<String>, Vec<String>) {
+    match pref {
+        TransportPreference::Auto => (server_wt_enabled, ws_urls, wt_urls),
+        TransportPreference::WebTransportOnly => (true, vec![], wt_urls),
+        TransportPreference::WebSocketOnly => (false, ws_urls, vec![]),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Validation helpers (re-exported from shared crate)
 // ---------------------------------------------------------------------------
 

--- a/dioxus-ui/src/main.rs
+++ b/dioxus-ui/src/main.rs
@@ -11,7 +11,10 @@ mod routing;
 mod types;
 
 use crate::routing::Route;
-use context::{load_display_name_from_storage, migrate_legacy_storage, DisplayNameCtx};
+use context::{
+    load_display_name_from_storage, load_transport_preference, migrate_legacy_storage,
+    DisplayNameCtx, TransportPreferenceCtx,
+};
 use dioxus::prelude::*;
 use matomo_logger::{MatomoConfig, MatomoLogger};
 
@@ -37,6 +40,9 @@ fn main() {
 fn App() -> Element {
     let display_name = use_signal(load_display_name_from_storage);
     use_context_provider(|| DisplayNameCtx(display_name));
+
+    let transport_pref = use_signal(load_transport_preference);
+    use_context_provider(|| TransportPreferenceCtx(transport_pref));
 
     rsx! {
         Router::<Route> {}

--- a/dioxus-ui/src/pages/meeting.rs
+++ b/dioxus-ui/src/pages/meeting.rs
@@ -17,8 +17,8 @@ use crate::constants::{
     actix_websocket_base, e2ee_enabled, oauth_enabled, webtransport_enabled, webtransport_host_base,
 };
 use crate::context::{
-    get_or_create_local_user_id, load_display_name_from_storage, save_display_name_to_storage,
-    validate_display_name, DisplayNameCtx,
+    get_or_create_local_user_id, load_display_name_from_storage, resolve_transport_config,
+    save_display_name_to_storage, validate_display_name, DisplayNameCtx, TransportPreferenceCtx,
 };
 use crate::meeting_api::{join_meeting, JoinError, JoinMeetingResponse};
 use dioxus::prelude::*;
@@ -53,6 +53,7 @@ pub enum MeetingStatus {
 
 #[component]
 pub fn MeetingPage(id: String) -> Element {
+    let transport_pref_ctx = use_context::<TransportPreferenceCtx>();
     let mut display_name_ctx = use_context::<DisplayNameCtx>();
     let mut auth_checked = use_signal(|| false);
     let navigator = use_navigator();
@@ -167,6 +168,15 @@ pub fn MeetingPage(id: String) -> Element {
                 .map(&lobby_url)
                 .collect();
 
+            // Apply user's transport preference
+            let (effective_wt_enabled, websocket_urls, webtransport_urls) =
+                resolve_transport_config(
+                    (transport_pref_ctx.0)(),
+                    webtransport_enabled().unwrap_or(false),
+                    websocket_urls,
+                    webtransport_urls,
+                );
+
             // Use the user's ID so the server can match
             // push-notification `target_user_id` to this observer client.
             let user_id_for_client = current_user_id().unwrap_or_else(|| display_name.clone());
@@ -177,7 +187,7 @@ pub fn MeetingPage(id: String) -> Element {
                 websocket_urls,
                 webtransport_urls,
                 enable_e2ee: false,
-                enable_webtransport: webtransport_enabled().unwrap_or(false),
+                enable_webtransport: effective_wt_enabled,
                 on_connected: VcCallback::from(move |_| {
                     log::info!("Observer connection established (waiting for meeting)");
                 }),
@@ -470,7 +480,6 @@ pub fn MeetingPage(id: String) -> Element {
                 AttendantsComponent {
                     display_name: username.clone(),
                     id: id.clone(),
-                    webtransport_enabled: webtransport_enabled().unwrap_or(false),
                     e2ee_enabled: e2ee_enabled().unwrap_or(false),
                     user_name: user_profile().as_ref().map(|p| p.name.clone()),
                     user_id: current_user_id()

--- a/dioxus-ui/static/style.css
+++ b/dioxus-ui/static/style.css
@@ -2680,6 +2680,13 @@ select {
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.transport-preference-note {
+  margin: 8px 0 0;
+  font-size: 0.75rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.5));
+  font-style: italic;
+}
+
 .settings-modal {
   width: min(920px, 92vw);
   max-width: min(920px, 92vw);

--- a/dioxus-ui/tests/context_unit.rs
+++ b/dioxus-ui/tests/context_unit.rs
@@ -12,7 +12,8 @@ use wasm_bindgen_test::*;
 
 use dioxus_ui::context::{
     clear_display_name_from_storage, email_to_display_name, load_display_name_from_storage,
-    save_display_name_to_storage, validate_display_name, DISPLAY_NAME_MAX_LEN,
+    load_transport_preference, resolve_transport_config, save_display_name_to_storage,
+    save_transport_preference, validate_display_name, TransportPreference, DISPLAY_NAME_MAX_LEN,
 };
 use videocall_types::validation::normalize_spaces;
 
@@ -242,4 +243,328 @@ fn profile_name_preserves_casing_when_not_email() {
     let profile_name = "McDowell";
     let validated = validate_display_name(profile_name).unwrap();
     assert_eq!(validated, "McDowell");
+}
+
+// ---------------------------------------------------------------------------
+// TransportPreference — Display trait
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn transport_preference_display_auto() {
+    assert_eq!(TransportPreference::Auto.to_string(), "auto");
+}
+
+#[wasm_bindgen_test]
+fn transport_preference_display_webtransport_only() {
+    assert_eq!(
+        TransportPreference::WebTransportOnly.to_string(),
+        "webtransport"
+    );
+}
+
+#[wasm_bindgen_test]
+fn transport_preference_display_websocket_only() {
+    assert_eq!(TransportPreference::WebSocketOnly.to_string(), "websocket");
+}
+
+// ---------------------------------------------------------------------------
+// TransportPreference — FromStr trait
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn transport_preference_parse_auto() {
+    assert_eq!(
+        "auto".parse::<TransportPreference>().unwrap(),
+        TransportPreference::Auto
+    );
+}
+
+#[wasm_bindgen_test]
+fn transport_preference_parse_webtransport() {
+    assert_eq!(
+        "webtransport".parse::<TransportPreference>().unwrap(),
+        TransportPreference::WebTransportOnly
+    );
+}
+
+#[wasm_bindgen_test]
+fn transport_preference_parse_websocket() {
+    assert_eq!(
+        "websocket".parse::<TransportPreference>().unwrap(),
+        TransportPreference::WebSocketOnly
+    );
+}
+
+#[wasm_bindgen_test]
+fn transport_preference_parse_invalid_returns_err() {
+    assert!("".parse::<TransportPreference>().is_err());
+    assert!("Auto".parse::<TransportPreference>().is_err());
+    assert!("WEBTRANSPORT".parse::<TransportPreference>().is_err());
+    assert!("WebSocket".parse::<TransportPreference>().is_err());
+    assert!("quic".parse::<TransportPreference>().is_err());
+    assert!("tcp".parse::<TransportPreference>().is_err());
+    assert!("something_random".parse::<TransportPreference>().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// TransportPreference — Default trait
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn transport_preference_default_is_auto() {
+    assert_eq!(TransportPreference::default(), TransportPreference::Auto);
+}
+
+// ---------------------------------------------------------------------------
+// TransportPreference — Display/FromStr round-trip
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn transport_preference_display_fromstr_roundtrip() {
+    // Every variant should survive a Display -> FromStr round-trip.
+    let variants = [
+        TransportPreference::Auto,
+        TransportPreference::WebTransportOnly,
+        TransportPreference::WebSocketOnly,
+    ];
+    for variant in &variants {
+        let s = variant.to_string();
+        let parsed: TransportPreference = s.parse().unwrap_or_else(|_| {
+            panic!(
+                "TransportPreference::from_str({:?}) should succeed for variant {:?}",
+                s, variant
+            )
+        });
+        assert_eq!(
+            *variant, parsed,
+            "Round-trip failed for variant {:?} (serialized as {:?})",
+            variant, s
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// resolve_transport_config — Auto mode
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn resolve_auto_with_server_wt_enabled_passes_through() {
+    let ws = vec!["ws://a:8080".to_string(), "ws://b:8080".to_string()];
+    let wt = vec!["https://a:4433".to_string(), "https://b:4433".to_string()];
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::Auto, true, ws.clone(), wt.clone());
+    assert!(
+        enable_wt,
+        "Auto + server WT enabled => enable_webtransport = true"
+    );
+    assert_eq!(ws_out, ws, "Auto should pass WS URLs through unchanged");
+    assert_eq!(wt_out, wt, "Auto should pass WT URLs through unchanged");
+}
+
+#[wasm_bindgen_test]
+fn resolve_auto_with_server_wt_disabled_passes_through() {
+    let ws = vec!["ws://a:8080".to_string()];
+    let wt = vec!["https://a:4433".to_string()];
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::Auto, false, ws.clone(), wt.clone());
+    assert!(
+        !enable_wt,
+        "Auto + server WT disabled => enable_webtransport = false"
+    );
+    assert_eq!(ws_out, ws, "Auto should pass WS URLs through unchanged");
+    assert_eq!(wt_out, wt, "Auto should pass WT URLs through unchanged");
+}
+
+#[wasm_bindgen_test]
+fn resolve_auto_with_empty_urls_passes_through_empties() {
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::Auto, true, vec![], vec![]);
+    assert!(enable_wt);
+    assert!(ws_out.is_empty(), "Auto should pass empty WS list through");
+    assert!(wt_out.is_empty(), "Auto should pass empty WT list through");
+}
+
+// ---------------------------------------------------------------------------
+// resolve_transport_config — WebTransportOnly mode
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn resolve_webtransport_only_clears_ws_urls_and_enables_wt() {
+    let ws = vec!["ws://a:8080".to_string(), "ws://b:8080".to_string()];
+    let wt = vec!["https://a:4433".to_string()];
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::WebTransportOnly, true, ws, wt.clone());
+    assert!(
+        enable_wt,
+        "WebTransportOnly should force enable_webtransport = true"
+    );
+    assert!(
+        ws_out.is_empty(),
+        "WebTransportOnly should clear all WS URLs"
+    );
+    assert_eq!(wt_out, wt, "WebTransportOnly should keep WT URLs unchanged");
+}
+
+#[wasm_bindgen_test]
+fn resolve_webtransport_only_overrides_server_wt_disabled() {
+    // Even when the server says WT is disabled, WebTransportOnly forces it on.
+    let ws = vec!["ws://a:8080".to_string()];
+    let wt = vec!["https://a:4433".to_string()];
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::WebTransportOnly, false, ws, wt.clone());
+    assert!(
+        enable_wt,
+        "WebTransportOnly should override server_wt_enabled=false and force true"
+    );
+    assert!(
+        ws_out.is_empty(),
+        "WebTransportOnly should clear WS URLs even when server says WT disabled"
+    );
+    assert_eq!(wt_out, wt);
+}
+
+#[wasm_bindgen_test]
+fn resolve_webtransport_only_with_empty_urls() {
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::WebTransportOnly, false, vec![], vec![]);
+    assert!(
+        enable_wt,
+        "WebTransportOnly should enable WT even with empty URL lists"
+    );
+    assert!(ws_out.is_empty());
+    assert!(wt_out.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// resolve_transport_config — WebSocketOnly mode
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn resolve_websocket_only_clears_wt_urls_and_disables_wt() {
+    let ws = vec!["ws://a:8080".to_string()];
+    let wt = vec!["https://a:4433".to_string(), "https://b:4433".to_string()];
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::WebSocketOnly, false, ws.clone(), wt);
+    assert!(
+        !enable_wt,
+        "WebSocketOnly should force enable_webtransport = false"
+    );
+    assert_eq!(ws_out, ws, "WebSocketOnly should keep WS URLs unchanged");
+    assert!(wt_out.is_empty(), "WebSocketOnly should clear all WT URLs");
+}
+
+#[wasm_bindgen_test]
+fn resolve_websocket_only_overrides_server_wt_enabled() {
+    // Even when the server says WT is enabled, WebSocketOnly forces it off.
+    let ws = vec!["ws://a:8080".to_string()];
+    let wt = vec!["https://a:4433".to_string()];
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::WebSocketOnly, true, ws.clone(), wt);
+    assert!(
+        !enable_wt,
+        "WebSocketOnly should override server_wt_enabled=true and force false"
+    );
+    assert_eq!(
+        ws_out, ws,
+        "WebSocketOnly should keep WS URLs even when server says WT enabled"
+    );
+    assert!(
+        wt_out.is_empty(),
+        "WebSocketOnly should clear WT URLs even when server says WT enabled"
+    );
+}
+
+#[wasm_bindgen_test]
+fn resolve_websocket_only_with_empty_urls() {
+    let (enable_wt, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::WebSocketOnly, true, vec![], vec![]);
+    assert!(
+        !enable_wt,
+        "WebSocketOnly should disable WT even with empty URL lists"
+    );
+    assert!(ws_out.is_empty());
+    assert!(wt_out.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// resolve_transport_config — multiple URLs preserved correctly
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn resolve_auto_preserves_order_of_multiple_urls() {
+    let ws = vec![
+        "ws://first:8080".to_string(),
+        "ws://second:8080".to_string(),
+        "ws://third:8080".to_string(),
+    ];
+    let wt = vec![
+        "https://first:4433".to_string(),
+        "https://second:4433".to_string(),
+    ];
+    let (_, ws_out, wt_out) =
+        resolve_transport_config(TransportPreference::Auto, true, ws.clone(), wt.clone());
+    assert_eq!(ws_out, ws, "URL order must be preserved");
+    assert_eq!(wt_out, wt, "URL order must be preserved");
+}
+
+// ---------------------------------------------------------------------------
+// Transport preference localStorage round-trip
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen_test]
+fn transport_preference_storage_round_trip() {
+    // Clear any previous value
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.remove_item("vc_transport_preference");
+    }
+
+    // Default (nothing stored) should return Auto
+    assert_eq!(
+        load_transport_preference(),
+        TransportPreference::Auto,
+        "With nothing stored, load_transport_preference should return Auto"
+    );
+
+    // Save WebTransportOnly and reload
+    save_transport_preference(TransportPreference::WebTransportOnly);
+    assert_eq!(
+        load_transport_preference(),
+        TransportPreference::WebTransportOnly,
+    );
+
+    // Save WebSocketOnly and reload
+    save_transport_preference(TransportPreference::WebSocketOnly);
+    assert_eq!(
+        load_transport_preference(),
+        TransportPreference::WebSocketOnly,
+    );
+
+    // Save Auto explicitly and reload
+    save_transport_preference(TransportPreference::Auto);
+    assert_eq!(load_transport_preference(), TransportPreference::Auto);
+
+    // Cleanup
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.remove_item("vc_transport_preference");
+    }
+}
+
+#[wasm_bindgen_test]
+fn transport_preference_storage_invalid_value_returns_auto() {
+    // If localStorage contains an invalid string, load_transport_preference
+    // should fall back to Auto (the default).
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item("vc_transport_preference", "invalid_value");
+    }
+
+    assert_eq!(
+        load_transport_preference(),
+        TransportPreference::Auto,
+        "Invalid stored value should fall back to Auto"
+    );
+
+    // Cleanup
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.remove_item("vc_transport_preference");
+    }
 }

--- a/dioxus-ui/tests/device_selector.rs
+++ b/dioxus-ui/tests/device_selector.rs
@@ -562,7 +562,7 @@ async fn device_settings_modal_updates_active_nav_highlighting() {
 }
 
 #[wasm_bindgen_test]
-async fn device_settings_modal_renders_only_audio_and_video_navigation() {
+async fn device_settings_modal_renders_expected_navigation_tabs() {
     let mount = create_mount_point();
 
     fn wrapper() -> Element {
@@ -589,13 +589,14 @@ async fn device_settings_modal_renders_only_audio_and_video_navigation() {
     let nav_buttons = mount.query_selector_all(".settings-nav-button").unwrap();
     assert_eq!(
         nav_buttons.length(),
-        2,
-        "should render exactly two nav buttons"
+        3,
+        "should render exactly three nav buttons (Audio, Video, Network)"
     );
 
     let text = mount.text_content().unwrap_or_default();
     assert!(text.contains("Audio"), "should render Audio nav");
     assert!(text.contains("Video"), "should render Video nav");
+    assert!(text.contains("Network"), "should render Network nav");
     assert!(!text.contains("Devices"), "should not render Devices nav");
     assert!(!text.contains("Profile"), "should not render Profile nav");
     assert!(!text.contains("Advanced"), "should not render Advanced nav");

--- a/e2e/tests/protocol-selection.spec.ts
+++ b/e2e/tests/protocol-selection.spec.ts
@@ -1,0 +1,293 @@
+import { test, expect, Page } from "@playwright/test";
+import { injectSessionCookie } from "../helpers/auth";
+import { waitForServices } from "../helpers/wait-for-services";
+
+/**
+ * Navigate to a meeting room and join as a single user.
+ *
+ * Follows the same pattern used by settings-modal.spec.ts: fill meeting-id,
+ * fill username, press Enter, wait for the meeting page, click the
+ * "Start Meeting" / "Join Meeting" button, and wait for the grid container.
+ */
+async function joinMeeting(page: Page, meetingId: string, username: string): Promise<void> {
+  await page.goto("/");
+  await page.waitForTimeout(1500);
+
+  await page.locator("#meeting-id").click();
+  await page.locator("#meeting-id").pressSequentially(meetingId, { delay: 80 });
+
+  await page.locator("#username").click();
+  await page.locator("#username").fill("");
+  await page.locator("#username").pressSequentially(username, { delay: 80 });
+  await page.waitForTimeout(500);
+  await page.locator("#username").press("Enter");
+
+  await expect(page).toHaveURL(new RegExp(`/meeting/${meetingId}`), { timeout: 10_000 });
+
+  const joinButton = page.getByText(/Start Meeting|Join Meeting/);
+  await expect(joinButton).toBeVisible({ timeout: 20_000 });
+  await joinButton.click();
+
+  await expect(page.locator("#grid-container")).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Open the settings modal via the gear icon in the bottom toolbar.
+ */
+async function openSettingsModal(page: Page): Promise<void> {
+  await page.locator('[data-testid="open-settings"]').click();
+  await expect(page.locator(".device-settings-modal")).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Switch to the Network tab inside the settings modal.
+ */
+async function switchToNetworkTab(page: Page): Promise<void> {
+  await page.locator('[data-testid="settings-nav-network"]').click();
+  await expect(page.locator(".settings-nav-button.active")).toContainText("Network");
+}
+
+/**
+ * Open the diagnostics panel via the button with the "Open Diagnostics" tooltip.
+ */
+async function openDiagnosticsPanel(page: Page): Promise<void> {
+  // The diagnostics button does not have a data-testid. Locate it via the
+  // tooltip span text inside the button.
+  const diagButton = page.locator("button", {
+    has: page.locator("span.tooltip", { hasText: "Open Diagnostics" }),
+  });
+  await diagButton.click();
+  // Wait for the diagnostics panel to render -- it contains a section with
+  // heading "Transport Preference".
+  await expect(page.locator("h3", { hasText: "Transport Preference" })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+/**
+ * Locate the transport preference dropdown inside the diagnostics panel.
+ * The dropdown is a `.peer-selector` inside the section whose h3 says
+ * "Transport Preference".
+ */
+function diagnosticsTransportSelect(page: Page) {
+  const section = page.locator(".diagnostics-section", {
+    has: page.locator("h3", { hasText: "Transport Preference" }),
+  });
+  return section.locator(".peer-selector");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Protocol selection (transport preference)", () => {
+  test.beforeAll(async () => {
+    await waitForServices();
+  });
+
+  test.beforeEach(async ({ context, baseURL }) => {
+    await injectSessionCookie(context, { baseURL });
+  });
+
+  // 1. Settings modal shows Network tab and transport dropdown defaults to Auto
+  test("settings modal Network tab shows transport dropdown defaulting to Auto", async ({
+    page,
+  }) => {
+    const meetingId = `e2e_proto_net_${Date.now()}`;
+    await joinMeeting(page, meetingId, "proto-user-1");
+
+    await openSettingsModal(page);
+    await switchToNetworkTab(page);
+
+    // The transport select should be visible
+    const transportSelect = page.locator("#modal-transport-select");
+    await expect(transportSelect).toBeVisible();
+
+    // Default value is "Auto" (value = "auto")
+    await expect(transportSelect).toHaveValue("auto");
+  });
+
+  // 2. Selecting a different protocol in settings shows confirm dialog
+  test("changing protocol in settings shows confirm dialog", async ({ page }) => {
+    const meetingId = `e2e_proto_confirm_${Date.now()}`;
+    await joinMeeting(page, meetingId, "proto-user-2");
+
+    await openSettingsModal(page);
+    await switchToNetworkTab(page);
+
+    // Set up a dialog listener to capture the confirm dialog
+    let dialogMessage = "";
+    page.on("dialog", async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.dismiss(); // cancel to avoid reload
+    });
+
+    // Change the transport dropdown to WebSocket
+    await page.locator("#modal-transport-select").selectOption("websocket");
+
+    // Wait a moment for the dialog event to propagate
+    await page.waitForTimeout(500);
+
+    expect(dialogMessage).toContain(
+      "Changing the transport protocol will reload the page and disconnect the current call. Continue?",
+    );
+  });
+
+  // 3. Cancelling the confirm dialog keeps the original value
+  test("cancelling confirm dialog keeps the original Auto value", async ({ page }) => {
+    const meetingId = `e2e_proto_cancel_${Date.now()}`;
+    await joinMeeting(page, meetingId, "proto-user-3");
+
+    await openSettingsModal(page);
+    await switchToNetworkTab(page);
+
+    // Dismiss (cancel) the confirm dialog
+    page.on("dialog", async (dialog) => {
+      await dialog.dismiss();
+    });
+
+    const transportSelect = page.locator("#modal-transport-select");
+    await expect(transportSelect).toHaveValue("auto");
+
+    // Try to change to WebTransport
+    await transportSelect.selectOption("webtransport");
+    await page.waitForTimeout(500);
+
+    // The dropdown should still show "auto" because the user cancelled
+    // Note: In Dioxus, after the dialog is dismissed and the change is
+    // rejected, the component re-renders with the original value.
+    // The select element's value is controlled by the `selected` attribute.
+    await expect(transportSelect).toHaveValue("auto");
+  });
+
+  // 4. Confirming the dialog saves to localStorage and reloads
+  test("confirming dialog saves preference to localStorage and reloads", async ({ page }) => {
+    const meetingId = `e2e_proto_save_${Date.now()}`;
+    await joinMeeting(page, meetingId, "proto-user-4");
+
+    await openSettingsModal(page);
+    await switchToNetworkTab(page);
+
+    // Accept the confirm dialog to trigger save + reload
+    page.on("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+
+    // Change to WebSocket -- this will save and reload
+    await page.locator("#modal-transport-select").selectOption("websocket");
+
+    // The page should reload. Wait for navigation to settle.
+    // After reload, the app will load the meeting page again.
+    // The localStorage value should be set before the reload happens.
+    // We wait for the page to finish loading after reload.
+    await page.waitForLoadState("domcontentloaded", { timeout: 15_000 });
+    await page.waitForTimeout(2000);
+
+    // Verify localStorage was set
+    const storedPref = await page.evaluate(() => {
+      return localStorage.getItem("vc_transport_preference");
+    });
+    expect(storedPref).toBe("websocket");
+  });
+
+  // 5. After reload, the saved preference persists in the dropdown
+  test("saved preference persists in settings dropdown after reload", async ({ page }) => {
+    const meetingId = `e2e_proto_persist_${Date.now()}`;
+
+    // Pre-set localStorage with a transport preference before joining
+    await page.goto("/");
+    await page.waitForTimeout(1500);
+    await page.evaluate(() => {
+      localStorage.setItem("vc_transport_preference", "websocket");
+    });
+
+    await joinMeeting(page, meetingId, "proto-user-5");
+
+    await openSettingsModal(page);
+    await switchToNetworkTab(page);
+
+    // The dropdown should reflect the persisted value
+    const transportSelect = page.locator("#modal-transport-select");
+    await expect(transportSelect).toHaveValue("websocket");
+
+    // Clean up: remove the localStorage entry
+    await page.evaluate(() => {
+      localStorage.removeItem("vc_transport_preference");
+    });
+  });
+
+  // 6. Diagnostics panel shows transport preference dropdown
+  test("diagnostics panel shows transport preference dropdown", async ({ page }) => {
+    const meetingId = `e2e_proto_diag_${Date.now()}`;
+    await joinMeeting(page, meetingId, "proto-user-6");
+
+    await openDiagnosticsPanel(page);
+
+    // The transport preference select should be visible
+    const diagSelect = diagnosticsTransportSelect(page);
+    await expect(diagSelect).toBeVisible();
+
+    // Default value should be "auto" (Auto)
+    await expect(diagSelect).toHaveValue("auto");
+  });
+
+  // 7. Diagnostics panel protocol change also shows confirm dialog
+  test("changing protocol in diagnostics panel shows confirm dialog", async ({ page }) => {
+    const meetingId = `e2e_proto_diag_confirm_${Date.now()}`;
+    await joinMeeting(page, meetingId, "proto-user-7");
+
+    await openDiagnosticsPanel(page);
+
+    let dialogMessage = "";
+    page.on("dialog", async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.dismiss();
+    });
+
+    const diagSelect = diagnosticsTransportSelect(page);
+    await diagSelect.selectOption("webtransport");
+    await page.waitForTimeout(500);
+
+    expect(dialogMessage).toContain(
+      "Changing the transport protocol will reload the page and disconnect the current call. Continue?",
+    );
+  });
+
+  // 8. Both dropdowns reflect the same stored preference
+  test("settings modal and diagnostics panel reflect the same stored preference", async ({
+    page,
+  }) => {
+    const meetingId = `e2e_proto_sync_${Date.now()}`;
+
+    // Pre-set localStorage with a specific preference
+    await page.goto("/");
+    await page.waitForTimeout(1500);
+    await page.evaluate(() => {
+      localStorage.setItem("vc_transport_preference", "webtransport");
+    });
+
+    await joinMeeting(page, meetingId, "proto-user-8");
+
+    // Check settings modal dropdown
+    await openSettingsModal(page);
+    await switchToNetworkTab(page);
+
+    const settingsSelect = page.locator("#modal-transport-select");
+    await expect(settingsSelect).toHaveValue("webtransport");
+
+    // Close settings modal by clicking outside or pressing Escape
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    // Check diagnostics panel dropdown
+    await openDiagnosticsPanel(page);
+
+    const diagSelect = diagnosticsTransportSelect(page);
+    await expect(diagSelect).toHaveValue("webtransport");
+
+    // Clean up
+    await page.evaluate(() => {
+      localStorage.removeItem("vc_transport_preference");
+    });
+  });
+});


### PR DESCRIPTION
Ability to select webtransport or websocket manually
We needed this feature to debug errors while using the different protocols

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Project / Infra

## Testing
- [x] Tests written or updated
- [ ] No tests needed

## Other
- [ ] Documentation updated
- [ ] Before/After Images provided

<img width="512" height="242" alt="image" src="https://github.com/user-attachments/assets/406c6fec-07a6-4c7b-974f-d20a30044d45" />

<img width="512" height="249" alt="image" src="https://github.com/user-attachments/assets/59cba285-c6ba-4ff6-b155-cdbf95a2c9b6" />

<img width="512" height="196" alt="image" src="https://github.com/user-attachments/assets/4abc7dfa-9645-4275-8b48-f82bfc7c8e10" />
