### PR TITLE
helm: fix webtransport version URL to use LB service

### DIFF
--- a/helm/global/us-east/meeting-api/values.yaml
+++ b/helm/global/us-east/meeting-api/values.yaml
@@ -62,7 +62,7 @@ meeting-api:
     - name: ALLOWED_REDIRECT_URLS
       value: "https://app.videocall.rs"
     - name: SERVICE_VERSION_URLS
-      value: "http://websocket-us-east:8080/version,http://webtransport-us-east:444/version,http://videocall-ui-us-east:80/version.json"
+      value: "http://websocket-us-east:8080/version,http://webtransport-us-east-lb:444/version,http://videocall-ui-us-east:80/version.json"
 
   resources:
     limits:


### PR DESCRIPTION
## Summary
- Fix `SERVICE_VERSION_URLS` in meeting-api us-east values to use `webtransport-us-east-lb:444` instead of `webtransport-us-east:444`
- The ClusterIP service only exposes 443/UDP (QUIC); the `/version` HTTP endpoint on port 444/TCP is only on the LoadBalancer service

## Test plan
- [x] Already deployed to production and verified at `https://api.videocall.rs/api/v1/versions`
```
{
  "components": [
    {
      "build_timestamp": "2026-04-03T00:48:26-07:00",
      "git_branch": "main",
      "git_sha": "0a6d9dc5",
      "service": "meeting-api",
      "version": "0.1.0"
    },
    {
      "build_timestamp": "2026-03-30T20:18:13-04:00",
      "git_branch": "main",
      "git_sha": "5bafad69",
      "service": "websocket-relay",
      "version": "1.0.1"
    },
    {
      "build_timestamp": "2026-03-30T20:18:13-04:00",
      "git_branch": "main",
      "git_sha": "5bafad69",
      "service": "webtransport-relay",
      "version": "1.0.1"
    },
    {
      "build_timestamp": "2026-04-03T14:51:37-04:00",
      "git_branch": "main",
      "git_sha": "63c54552",
      "service": "dioxus-ui",
      "version": "1.1.42"
    }
  ]
}
```