### PR TITLE
fix: stabilize flaky home_integration test in CI

### DIFF
--- a/dioxus-ui/tests/home_integration.rs
+++ b/dioxus-ui/tests/home_integration.rs
@@ -14,7 +14,7 @@ mod support;
 
 use support::{
     cleanup, create_mount_point, inject_app_config, mock_fetch_401, mock_fetch_meetings_empty,
-    remove_app_config, render_into, restore_fetch, yield_now,
+    remove_app_config, render_into, restore_fetch, wait_for_selector, wait_for_text, yield_now,
 };
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
@@ -77,10 +77,13 @@ fn home_wrapper_direct() -> Element {
 async fn home_page_renders_with_oauth_disabled() {
     ensure_root_url();
     inject_app_config();
+    mock_fetch_meetings_empty();
 
     let mount = create_mount_point();
     render_into(&mount, home_wrapper_direct);
-    yield_now().await;
+
+    // Poll until the Home component has rendered its heading (async fetch must resolve first).
+    wait_for_text(&mount, "Start or Join a Meeting", 5000).await;
 
     // No error banner — config loaded and browser checks passed.
     assert!(
@@ -116,6 +119,7 @@ async fn home_page_renders_with_oauth_disabled() {
     );
 
     cleanup(&mount);
+    restore_fetch();
     remove_app_config();
 }
 
@@ -128,25 +132,8 @@ async fn home_shows_login_when_unauthenticated() {
     let mount = create_mount_point();
     render_into(&mount, home_wrapper_direct);
 
-    // Allow the mock fetch to resolve and Dioxus to re-render.
-    yield_now().await;
-    // Extra yield for async fetch resolution
-    let promise = js_sys::Promise::new(&mut |resolve, _| {
-        gloo_utils::window()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 100)
-            .unwrap();
-    });
-    wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
-    yield_now().await;
-
-    // The meetings section should show the sign-in prompt instead of an error.
-    assert!(
-        mount
-            .query_selector(".meetings-auth-prompt")
-            .unwrap()
-            .is_some(),
-        "Sign-in prompt should be visible when API returns 401"
-    );
+    // Poll until the 401 response triggers the sign-in prompt.
+    wait_for_selector(&mount, ".meetings-auth-prompt", 5000).await;
 
     let text = mount.text_content().unwrap_or_default();
     assert!(
@@ -177,15 +164,8 @@ async fn home_hides_login_when_authenticated() {
     let mount = create_mount_point();
     render_into(&mount, home_wrapper_direct);
 
-    // Allow the mock fetch to resolve and Dioxus to re-render.
-    yield_now().await;
-    let promise = js_sys::Promise::new(&mut |resolve, _| {
-        gloo_utils::window()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 100)
-            .unwrap();
-    });
-    wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
-    yield_now().await;
+    // Poll until the empty-meetings text appears (async fetch must resolve first).
+    wait_for_text(&mount, "No meetings yet", 5000).await;
 
     // The sign-in prompt should NOT be visible.
     assert!(
@@ -194,13 +174,6 @@ async fn home_hides_login_when_authenticated() {
             .unwrap()
             .is_none(),
         "Sign-in prompt should NOT be visible when API returns 200"
-    );
-
-    // Should show the empty meetings state instead.
-    let text = mount.text_content().unwrap_or_default();
-    assert!(
-        text.contains("No meetings yet"),
-        "Empty meetings message should be shown when authenticated"
     );
 
     cleanup(&mount);

--- a/dioxus-ui/tests/support/mod.rs
+++ b/dioxus-ui/tests/support/mod.rs
@@ -221,6 +221,85 @@ pub fn restore_fetch() {
 }
 
 // ---------------------------------------------------------------------------
+// Polling helpers (for async-dependent DOM assertions)
+// ---------------------------------------------------------------------------
+
+/// Poll for a CSS selector to appear in the mount element, with a timeout.
+/// Returns the element if found, or panics with a descriptive message.
+pub async fn wait_for_selector(
+    mount: &web_sys::Element,
+    selector: &str,
+    timeout_ms: u32,
+) -> web_sys::Element {
+    let start = js_sys::Date::now();
+    loop {
+        if let Some(el) = mount.query_selector(selector).unwrap() {
+            return el;
+        }
+        let elapsed = js_sys::Date::now() - start;
+        if elapsed > timeout_ms as f64 {
+            let html = mount.inner_html();
+            panic!(
+                "Timed out after {timeout_ms}ms waiting for selector '{selector}'. Mount HTML:\n{html}"
+            );
+        }
+        let promise = js_sys::Promise::new(&mut |resolve, _| {
+            gloo_utils::window()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 50)
+                .unwrap();
+        });
+        JsFuture::from(promise).await.unwrap();
+    }
+}
+
+/// Poll for a CSS selector to NOT be present, with a timeout.
+/// Returns if absent, panics if still present after timeout.
+pub async fn wait_for_no_selector(mount: &web_sys::Element, selector: &str, timeout_ms: u32) {
+    let start = js_sys::Date::now();
+    loop {
+        if mount.query_selector(selector).unwrap().is_none() {
+            return;
+        }
+        let elapsed = js_sys::Date::now() - start;
+        if elapsed > timeout_ms as f64 {
+            let html = mount.inner_html();
+            panic!(
+                "Timed out after {timeout_ms}ms waiting for selector '{selector}' to disappear. Mount HTML:\n{html}"
+            );
+        }
+        let promise = js_sys::Promise::new(&mut |resolve, _| {
+            gloo_utils::window()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 50)
+                .unwrap();
+        });
+        JsFuture::from(promise).await.unwrap();
+    }
+}
+
+/// Poll until the mount's text_content contains a substring, with a timeout.
+pub async fn wait_for_text(mount: &web_sys::Element, substring: &str, timeout_ms: u32) {
+    let start = js_sys::Date::now();
+    loop {
+        let text = mount.text_content().unwrap_or_default();
+        if text.contains(substring) {
+            return;
+        }
+        let elapsed = js_sys::Date::now() - start;
+        if elapsed > timeout_ms as f64 {
+            panic!(
+                "Timed out after {timeout_ms}ms waiting for text containing '{substring}'. Got:\n{text}"
+            );
+        }
+        let promise = js_sys::Promise::new(&mut |resolve, _| {
+            gloo_utils::window()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 50)
+                .unwrap();
+        });
+        JsFuture::from(promise).await.unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Real Chrome fake-device enumeration
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add fetch mock to `home_page_renders_with_oauth_disabled` — it was the only integration test not mocking `window.fetch`, causing real requests to hang against a nonexistent backend
- Replace hardcoded 100ms `setTimeout` sleeps with polling helpers that wait for DOM conditions (50ms poll interval, 5s timeout)
- Add `wait_for_selector`, `wait_for_text`, and `wait_for_no_selector` helpers to the test support module

## Context

The `home_integration` test timed out intermittently in CI headless Chrome with "Timed out receiving message from renderer: 299.983". The `fix/session-instances` branch hit the same failure 4 times before passing on retry. The `vcprobe-rebase` branch (#829) also hit it repeatedly.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p videocall-ui` passes
- [x] `cargo fmt -p videocall-ui -- --check` clean
- [ ] Dioxus UI Component Tests CI job passes without retry