### PR TITLE
fix: camera + screen share bandwidth coordination

### DIFF
--- a/dioxus-ui/src/components/host.rs
+++ b/dioxus-ui/src/components/host.rs
@@ -177,6 +177,11 @@ pub fn Host(
         camera.set_force_keyframe_flag(client.force_camera_keyframe_flag());
         screen.set_force_keyframe_flag(client.force_screen_keyframe_flag());
 
+        // Wire up cross-stream bandwidth coordination: the screen encoder sets
+        // this flag when capture starts/stops; the camera encoder reads it to
+        // drop quality and set a ceiling, preventing bandwidth contention.
+        screen.set_screen_sharing_flag(camera.screen_sharing_flag());
+
         // Wire up encoder controls. The microphone encoder no longer needs
         // its own diagnostics channel — it reads audio tier settings from
         // the camera encoder's shared atomics.

--- a/videocall-client/src/adaptive_quality_constants.rs
+++ b/videocall-client/src/adaptive_quality_constants.rs
@@ -128,6 +128,16 @@ pub const VIDEO_QUALITY_TIERS: &[VideoQualityTier] = &[
 /// resolution drop.
 pub const DEFAULT_VIDEO_TIER_INDEX: usize = 3; // "minimal"
 
+/// Camera tier ceiling (maximum quality) when screen share is active.
+///
+/// Index 2 = "low" (640x360, 15fps, 300kbps ideal). When screen share starts,
+/// the camera is forced to this tier and capped here to avoid bandwidth
+/// contention on the shared TCP connection. The screen encoder ramps up
+/// independently via its own PID controller; this ceiling ensures the camera
+/// doesn't compete for headroom. Camera can still step DOWN further if
+/// conditions worsen, but cannot step UP past this ceiling.
+pub const SCREEN_SHARE_CAMERA_CEILING_INDEX: usize = 2; // "low"
+
 /// Index into `SCREEN_QUALITY_TIERS` for the default starting tier.
 ///
 /// Screen share starts at the lowest tier ("low", 480p/5fps/250kbps) to
@@ -585,6 +595,16 @@ mod tests {
             DEFAULT_VIDEO_TIER_INDEX < VIDEO_QUALITY_TIERS.len(),
             "DEFAULT_VIDEO_TIER_INDEX ({}) out of bounds (len={})",
             DEFAULT_VIDEO_TIER_INDEX,
+            VIDEO_QUALITY_TIERS.len(),
+        );
+    }
+
+    #[test]
+    fn test_screen_share_camera_ceiling_index_in_bounds() {
+        assert!(
+            SCREEN_SHARE_CAMERA_CEILING_INDEX < VIDEO_QUALITY_TIERS.len(),
+            "SCREEN_SHARE_CAMERA_CEILING_INDEX ({}) out of bounds (len={})",
+            SCREEN_SHARE_CAMERA_CEILING_INDEX,
             VIDEO_QUALITY_TIERS.len(),
         );
     }

--- a/videocall-client/src/diagnostics/adaptive_quality_manager.rs
+++ b/videocall-client/src/diagnostics/adaptive_quality_manager.rs
@@ -73,6 +73,12 @@ pub struct AdaptiveQualityManager {
     /// grace period during which no tier transitions occur, preventing
     /// false step-downs from zero-FPS readings at encoder startup.
     created_at_ms: f64,
+
+    /// Quality ceiling: step-up cannot go below (better quality than) this index.
+    /// Used for cross-stream coordination — when screen share is active, the
+    /// camera's quality manager is capped to prevent bandwidth contention.
+    /// `None` means no ceiling (default).
+    quality_ceiling_index: Option<usize>,
 }
 
 impl AdaptiveQualityManager {
@@ -96,6 +102,7 @@ impl AdaptiveQualityManager {
             audio_degrade_start_ms: None,
             audio_recover_start_ms: None,
             created_at_ms: now,
+            quality_ceiling_index: None,
         }
     }
 
@@ -117,6 +124,7 @@ impl AdaptiveQualityManager {
             audio_degrade_start_ms: None,
             audio_recover_start_ms: None,
             created_at_ms: now,
+            quality_ceiling_index: None,
         }
     }
 
@@ -211,7 +219,10 @@ impl AdaptiveQualityManager {
         let should_recover = fps_ratio > VIDEO_TIER_RECOVER_FPS_RATIO
             && bitrate_ratio > VIDEO_TIER_RECOVER_BITRATE_RATIO;
 
-        if should_recover && self.video_tier_index > 0 {
+        // Respect the quality ceiling set by cross-stream coordination.
+        let min_allowed_index = self.quality_ceiling_index.unwrap_or(0);
+
+        if should_recover && self.video_tier_index > min_allowed_index {
             let recover_start = *self.recover_start_ms.get_or_insert(now_ms);
             let recover_duration = now_ms - recover_start;
 
@@ -353,6 +364,60 @@ impl AdaptiveQualityManager {
         self.recover_start_ms = None;
         log::warn!(
             "AdaptiveQuality: CONGESTION forced video step-down to tier '{}' (index {})",
+            self.video_tiers[self.video_tier_index].label,
+            self.video_tier_index,
+        );
+        true
+    }
+
+    /// Set a quality ceiling that prevents step-up from going below (better
+    /// quality than) the given index.
+    ///
+    /// Used for cross-stream bandwidth coordination: when screen share is
+    /// active, the camera's quality manager is capped so the combined
+    /// bandwidth stays within safe limits.
+    ///
+    /// Pass `None` to remove the ceiling (e.g., when screen share stops).
+    pub fn set_quality_ceiling(&mut self, ceiling: Option<usize>) {
+        self.quality_ceiling_index = ceiling;
+        // Reset recovery timer so the ceiling takes effect immediately
+        // rather than allowing a pending step-up to fire.
+        self.recover_start_ms = None;
+    }
+
+    /// Force the video tier to a specific index, bypassing the one-step-at-a-time
+    /// limit and the minimum transition interval.
+    ///
+    /// This is a coordination signal (e.g., screen share started/stopped), not a
+    /// congestion reaction. It allows jumping multiple tiers in a single call and
+    /// intentionally bypasses the warmup guard — coordination must take effect
+    /// immediately regardless of encoder startup state.
+    ///
+    /// Note: if the current tier is already *below* the target (worse quality),
+    /// this will step UP to the target. This is intentional for screen share
+    /// coordination — it normalizes the camera to the ceiling tier.
+    ///
+    /// Returns `true` if the tier actually changed.
+    pub fn force_video_step_to(&mut self, target: usize, now_ms: f64) -> bool {
+        let max_index = self.video_tiers.len().saturating_sub(1);
+        let clamped = target.min(max_index);
+
+        if clamped == self.video_tier_index {
+            return false;
+        }
+
+        let direction = if clamped > self.video_tier_index {
+            "DOWN"
+        } else {
+            "UP"
+        };
+        self.video_tier_index = clamped;
+        self.last_transition_time_ms = now_ms;
+        self.degrade_start_ms = None;
+        self.recover_start_ms = None;
+        log::info!(
+            "AdaptiveQuality: forced video step {} to tier '{}' (index {}) for cross-stream coordination",
+            direction,
             self.video_tiers[self.video_tier_index].label,
             self.video_tier_index,
         );
@@ -627,5 +692,111 @@ mod tests {
         let mut mgr = new_test_manager(VIDEO_QUALITY_TIERS);
         let changed = mgr.update(0.0, 0.0, 0.0, 0.0, 10000.0);
         assert!(!changed);
+    }
+
+    // =====================================================================
+    // Quality ceiling tests (cross-stream coordination)
+    // =====================================================================
+
+    #[wasm_bindgen_test]
+    fn test_quality_ceiling_blocks_step_up() {
+        let mut mgr = new_test_manager(VIDEO_QUALITY_TIERS);
+        // Start at index 2 ("low")
+        mgr.video_tier_index = 2;
+        // Set ceiling at index 2 — can't go above "low"
+        mgr.set_quality_ceiling(Some(2));
+
+        // Good conditions that would normally trigger step-up
+        let base = 10000.0;
+        // Sustain recovery for STEP_UP_STABILIZATION_WINDOW_MS
+        for i in 0..=6 {
+            let t = base + (i as f64 * 1000.0);
+            mgr.update(29.0, 30.0, 1400.0, 1500.0, t);
+        }
+        assert_eq!(
+            mgr.video_tier_index(),
+            2,
+            "Step-up should be blocked by quality ceiling"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_quality_ceiling_allows_step_down() {
+        let mut mgr = new_test_manager(VIDEO_QUALITY_TIERS);
+        // Start at index 1 ("medium")
+        mgr.video_tier_index = 1;
+        // Set ceiling at index 1 — ceiling only blocks step-up, not step-down
+        mgr.set_quality_ceiling(Some(1));
+
+        // Bad conditions to trigger step-down
+        let base = 10000.0;
+        // Sustain degradation for STEP_DOWN_REACTION_TIME_MS
+        for i in 0..=3 {
+            let t = base + (i as f64 * 1000.0);
+            mgr.update(5.0, 30.0, 100.0, 600.0, t);
+        }
+        assert!(
+            mgr.video_tier_index() > 1,
+            "Step-down should not be blocked by quality ceiling"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_quality_ceiling_removal_allows_step_up() {
+        let mut mgr = new_test_manager(VIDEO_QUALITY_TIERS);
+        mgr.video_tier_index = 2;
+        mgr.set_quality_ceiling(Some(2));
+
+        // Good conditions — blocked by ceiling
+        let base = 10000.0;
+        for i in 0..=6 {
+            let t = base + (i as f64 * 1000.0);
+            mgr.update(29.0, 30.0, 1400.0, 1500.0, t);
+        }
+        assert_eq!(mgr.video_tier_index(), 2, "Should be blocked by ceiling");
+
+        // Remove ceiling
+        mgr.set_quality_ceiling(None);
+        mgr.last_transition_time_ms = 0.0; // Reset min-interval guard
+
+        // Now step-up should work
+        let base2 = 30000.0;
+        for i in 0..=6 {
+            let t = base2 + (i as f64 * 1000.0);
+            mgr.update(29.0, 30.0, 1400.0, 1500.0, t);
+        }
+        assert!(
+            mgr.video_tier_index() < 2,
+            "Step-up should work after ceiling removal"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_force_video_step_to() {
+        let mut mgr = new_test_manager(VIDEO_QUALITY_TIERS);
+        mgr.video_tier_index = 0;
+
+        // Force to index 2
+        let changed = mgr.force_video_step_to(2, 10000.0);
+        assert!(changed);
+        assert_eq!(mgr.video_tier_index(), 2);
+
+        // Force to same index — no change
+        let changed = mgr.force_video_step_to(2, 10001.0);
+        assert!(!changed);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_force_video_step_to_clamps() {
+        let mut mgr = new_test_manager(VIDEO_QUALITY_TIERS);
+        // Force to index far beyond array bounds
+        let changed = mgr.force_video_step_to(999, 10000.0);
+        assert!(changed);
+        let max_index = VIDEO_QUALITY_TIERS.len() - 1;
+        assert_eq!(
+            mgr.video_tier_index(),
+            max_index,
+            "Should clamp to last valid index"
+        );
     }
 }

--- a/videocall-client/src/diagnostics/encoder_bitrate_controller.rs
+++ b/videocall-client/src/diagnostics/encoder_bitrate_controller.rs
@@ -25,7 +25,7 @@ use js_sys::Date;
 use crate::adaptive_quality_constants::{
     AudioQualityTier, VideoQualityTier, PID_CORRECTION_THROTTLE_MS, PID_DEADBAND_FPS,
     PID_FPS_HISTORY_SIZE, PID_KD, PID_KI, PID_KP, PID_MAX_JITTER_PENALTY, PID_OUTPUT_MAX,
-    PID_OUTPUT_MIN, VIDEO_QUALITY_TIERS,
+    PID_OUTPUT_MIN, SCREEN_SHARE_CAMERA_CEILING_INDEX, VIDEO_QUALITY_TIERS,
 };
 use crate::diagnostics::adaptive_quality_manager::AdaptiveQualityManager;
 use videocall_types::protos::diagnostics_packet::DiagnosticsPacket;
@@ -524,6 +524,29 @@ impl EncoderBitrateController {
             self.ideal_bitrate_kbps = new_tier.ideal_bitrate_kbps;
         }
         changed
+    }
+
+    /// Notify this controller that screen sharing state changed.
+    ///
+    /// When screen share becomes active, the camera is forced to a conservative
+    /// tier and capped there to prevent bandwidth contention. When screen share
+    /// stops, the cap is removed and the camera recovers naturally.
+    pub fn notify_screen_sharing(&mut self, active: bool) {
+        if active {
+            let now = Date::now();
+            let changed = self
+                .quality_manager
+                .force_video_step_to(SCREEN_SHARE_CAMERA_CEILING_INDEX, now);
+            self.quality_manager
+                .set_quality_ceiling(Some(SCREEN_SHARE_CAMERA_CEILING_INDEX));
+            if changed {
+                let new_tier = self.quality_manager.current_video_tier();
+                self.ideal_bitrate_kbps = new_tier.ideal_bitrate_kbps;
+                self.tier_changed = true;
+            }
+        } else {
+            self.quality_manager.set_quality_ceiling(None);
+        }
     }
 }
 

--- a/videocall-client/src/encode/camera_encoder.rs
+++ b/videocall-client/src/encode/camera_encoder.rs
@@ -105,6 +105,10 @@ pub struct CameraEncoder {
     /// Shared audio tier FEC flag. Written by the camera encoder's quality
     /// manager alongside `shared_audio_tier_bitrate`.
     shared_audio_tier_fec: Rc<AtomicBool>,
+    /// Shared flag indicating whether screen share is active. Written by the
+    /// `ScreenEncoder`, read by this camera encoder's diagnostics loop to
+    /// coordinate bandwidth (drop camera tier and set ceiling when active).
+    screen_sharing_active: Rc<AtomicBool>,
 }
 
 impl CameraEncoder {
@@ -146,6 +150,7 @@ impl CameraEncoder {
                 default_audio_tier.bitrate_kbps * 1000,
             )),
             shared_audio_tier_fec: Rc::new(AtomicBool::new(default_audio_tier.enable_fec)),
+            screen_sharing_active: Rc::new(AtomicBool::new(false)),
         }
     }
 
@@ -163,12 +168,26 @@ impl CameraEncoder {
         let congestion_flag = self.congestion_step_down.clone();
         let shared_audio_bitrate = self.shared_audio_tier_bitrate.clone();
         let shared_audio_fec = self.shared_audio_tier_fec.clone();
+        let screen_sharing_active = self.screen_sharing_active.clone();
         wasm_bindgen_futures::spawn_local(async move {
             let mut encoder_control = EncoderBitrateController::new(
                 current_bitrate.load(Ordering::Relaxed),
                 current_fps.clone(),
             );
+            let mut prev_screen_active = false;
             while let Some(event) = diagnostics_receiver.next().await {
+                // Check for screen sharing state transitions and coordinate
+                // camera quality to avoid bandwidth contention.
+                let screen_active = screen_sharing_active.load(Ordering::Acquire);
+                if screen_active != prev_screen_active {
+                    prev_screen_active = screen_active;
+                    encoder_control.notify_screen_sharing(screen_active);
+                    log::info!(
+                        "CameraEncoder: screen sharing {} — camera tier coordination applied",
+                        if screen_active { "ACTIVE" } else { "INACTIVE" },
+                    );
+                }
+
                 // Check for server congestion step-down request before
                 // processing the diagnostics packet so the forced step-down
                 // takes effect immediately.
@@ -250,6 +269,14 @@ impl CameraEncoder {
     /// RED-style redundancy in audio packets.
     pub fn shared_audio_tier_fec(&self) -> Rc<AtomicBool> {
         self.shared_audio_tier_fec.clone()
+    }
+
+    /// Returns the shared screen-sharing-active flag.
+    ///
+    /// The `ScreenEncoder` writes this flag when screen capture starts/stops.
+    /// The camera encoder's diagnostics loop reads it to coordinate bandwidth.
+    pub fn screen_sharing_flag(&self) -> Rc<AtomicBool> {
+        self.screen_sharing_active.clone()
     }
 
     /// Returns a shared reference to the force-keyframe flag.

--- a/videocall-client/src/encode/screen_encoder.rs
+++ b/videocall-client/src/encode/screen_encoder.rs
@@ -150,11 +150,8 @@ impl ScreenEncoder {
         let tier_max_height = self.tier_max_height.clone();
         let tier_keyframe_interval = self.tier_keyframe_interval.clone();
         wasm_bindgen_futures::spawn_local(async move {
-            let mut encoder_control = EncoderBitrateController::new_with_tiers(
-                current_bitrate.load(Ordering::Relaxed),
-                current_fps.clone(),
-                SCREEN_QUALITY_TIERS,
-            );
+            let mut encoder_control =
+                EncoderBitrateController::new_for_screen(current_fps.clone(), SCREEN_QUALITY_TIERS);
             while let Some(event) = diagnostics_receiver.next().await {
                 let output_wasted = encoder_control.process_diagnostics_packet(event);
                 if let Some(bitrate) = output_wasted {

--- a/videocall-client/src/encode/screen_encoder.rs
+++ b/videocall-client/src/encode/screen_encoder.rs
@@ -104,6 +104,10 @@ pub struct ScreenEncoder {
     /// original capture track is stopped; stopping a cloned track (e.g. from
     /// `MediaStream::clone()`) does **not** affect the indicator.
     active_video_track: Rc<RefCell<Option<MediaStreamTrack>>>,
+    /// Shared flag for cross-stream bandwidth coordination. Set to `true` when
+    /// screen capture starts, `false` when it stops. The `CameraEncoder` reads
+    /// this to drop its quality tier and prevent bandwidth contention.
+    screen_sharing_active: Option<Rc<AtomicBool>>,
 }
 
 impl ScreenEncoder {
@@ -135,7 +139,16 @@ impl ScreenEncoder {
             tier_keyframe_interval: Rc::new(AtomicU32::new(default_tier.keyframe_interval_frames)),
             force_keyframe: Arc::new(AtomicBool::new(false)),
             active_video_track: Rc::new(RefCell::new(None)),
+            screen_sharing_active: None,
         }
+    }
+
+    /// Set the shared screen-sharing-active flag for cross-stream coordination.
+    ///
+    /// This flag is read by the `CameraEncoder` to drop its quality tier when
+    /// screen share is active, preventing bandwidth contention.
+    pub fn set_screen_sharing_flag(&mut self, flag: Rc<AtomicBool>) {
+        self.screen_sharing_active = Some(flag);
     }
 
     pub fn set_encoder_control(
@@ -247,6 +260,11 @@ impl ScreenEncoder {
     /// It sets the encoder flags, notifies the client at the protocol level,
     /// and synchronously stops all media tracks.
     pub fn stop(&mut self) {
+        // Clear screen-sharing flag so the camera encoder removes its quality ceiling.
+        if let Some(ref flag) = self.screen_sharing_active {
+            flag.store(false, Ordering::Release);
+        }
+
         // Signal the encoding loop to exit
         self.state.stop();
 
@@ -319,6 +337,7 @@ impl ScreenEncoder {
         let tier_keyframe_interval = self.tier_keyframe_interval.clone();
         let force_keyframe = self.force_keyframe.clone();
         let active_video_track = self.active_video_track.clone();
+        let screen_sharing_active = self.screen_sharing_active.clone();
 
         wasm_bindgen_futures::spawn_local(async move {
             let navigator = window().navigator();
@@ -477,9 +496,15 @@ impl ScreenEncoder {
             let _onended_handler = {
                 let enabled_clone = enabled.clone();
                 let on_state_change_clone = on_state_change.clone();
+                let screen_sharing_flag_clone = screen_sharing_active.clone();
                 let handler = Closure::wrap(Box::new(move || {
                     log::info!("Screen share track ended (user stopped sharing)");
                     enabled_clone.store(false, Ordering::Release);
+                    // Clear the flag immediately so the camera encoder can begin recovery
+                    // without waiting for the async encoding loop to wind down.
+                    if let Some(ref flag) = screen_sharing_flag_clone {
+                        flag.store(false, Ordering::Release);
+                    }
                     client_for_onended.set_screen_enabled(false);
                     if let Some(ref callback) = on_state_change_clone {
                         callback.emit(ScreenShareEvent::Stopped);
@@ -522,6 +547,10 @@ impl ScreenEncoder {
             client_for_state.set_screen_enabled(true);
             if let Some(ref callback) = on_state_change {
                 callback.emit(ScreenShareEvent::Started(screen_to_share.clone()));
+            }
+            // Signal the camera encoder to drop quality and set a ceiling.
+            if let Some(ref flag) = screen_sharing_active {
+                flag.store(true, Ordering::Release);
             }
 
             let screen_reader = screen_processor
@@ -709,6 +738,11 @@ impl ScreenEncoder {
                         track.stop();
                     }
                 }
+            }
+
+            // Clear screen-sharing flag so the camera encoder removes its quality ceiling.
+            if let Some(ref flag) = screen_sharing_active {
+                flag.store(false, Ordering::Release);
             }
 
             // Emit Stopped event if we haven't already (onended handler might have already fired)


### PR DESCRIPTION
## Summary

Fixes #848 — **bandwidth death spiral when camera + screen share are active simultaneously**.

When screen share activates alongside camera, both streams share a single WebSocket/TCP connection but have **independent** `EncoderBitrateController` / `AdaptiveQualityManager` instances. Neither knows the other exists. The combined peak bitrate (~2,500 kbps) overwhelms the connection, TCP congestion stalls both encoders to `fps_ratio=0.00`, and they race to the quality floor and never recover. The meeting becomes unusable for 2+ minutes.

### Root cause

```
Camera encoder: "I have bandwidth headroom → step UP to medium (800kbps)"
Screen encoder: "I have bandwidth headroom → step UP to high (1500kbps)"
TCP connection:  combined 2,300kbps > available bandwidth → congestion
Both encoders:   fps_ratio=0.00 → step DOWN → brief relief → step UP again → repeat
```

### Fix: preemptive camera step-down + quality ceiling

When screen share starts, the camera encoder is immediately forced to the "low" tier (640×360, 15fps, 300kbps) and **capped there** via a quality ceiling. The screen encoder gets bandwidth priority since users care about content legibility — camera is just a thumbnail during screen share.

When screen share stops, the ceiling is removed and camera recovers naturally through the existing step-up mechanism (5s stabilization window).

### Design decisions

| Decision | Rationale |
|----------|-----------|
| Ceiling only blocks step-UP, not step-DOWN | Server CONGESTION signals must still degrade camera further if needed |
| Camera at "low" (index 2) keeps audio at "high" | Audio only degrades when camera reaches "minimal" (index 3) |
| `force_video_step_to()` bypasses warmup + min-interval guards | Coordination signal, not congestion reaction — must take effect immediately |
| `onended` handler clears flag immediately | Instant recovery when user clicks browser's "Stop sharing" button, don't wait for async loop to wind down |
| Uses `Rc<AtomicBool>` shared-atomic pattern | Same pattern as existing `congestion_step_down` and `shared_audio_tier_fec` cross-encoder coordination |
| Camera may step UP to ceiling if already below | Normalizes to "low" tier — intentional, 300kbps is still modest |

### Architecture

```
                    ┌─────────────────┐
                    │    host.rs      │
                    │  (wiring)       │
                    └────┬───────┬────┘
                         │       │
        screen.set_screen_sharing_flag(camera.screen_sharing_flag())
                         │       │
              ┌──────────▼──┐ ┌──▼──────────┐
              │ScreenEncoder│ │CameraEncoder│
              │             │ │             │
              │ sets flag   │ │ reads flag  │
              │ true/false  │ │ on each     │
              │ in start()/ │ │ diagnostics │
              │ stop()/     │ │ packet      │
              │ onended     │ │ (~1s)       │
              └──────┬──────┘ └──────┬──────┘
                     │               │
              Rc<AtomicBool>   notify_screen_sharing()
              (shared flag)          │
                              ┌──────▼──────────────────┐
                              │EncoderBitrateController │
                              │                         │
                              │ active=true:            │
                              │   force_video_step_to() │
                              │   set_quality_ceiling() │
                              │                         │
                              │ active=false:           │
                              │   set_quality_ceiling(  │
                              │     None) → natural     │
                              │     recovery            │
                              └──────┬──────────────────┘
                                     │
                              ┌──────▼──────────────────┐
                              │AdaptiveQualityManager   │
                              │                         │
                              │ quality_ceiling_index:  │
                              │   Some(2) blocks step-UP│
                              │   None allows recovery  │
                              │                         │
                              │ force_video_step_to():  │
                              │   immediate tier jump   │
                              └─────────────────────────┘
```

### Files changed (6)

| File | Change |
|------|--------|
| `adaptive_quality_constants.rs` | Added `SCREEN_SHARE_CAMERA_CEILING_INDEX = 2` ("low") + bounds-check test |
| `adaptive_quality_manager.rs` | Added `quality_ceiling_index` field, `set_quality_ceiling()`, `force_video_step_to()`, modified step-up to respect ceiling. 5 new unit tests |
| `encoder_bitrate_controller.rs` | Added `notify_screen_sharing(active: bool)` coordination method |
| `camera_encoder.rs` | Added `screen_sharing_active: Rc<AtomicBool>` field + accessor. Edge-triggered transition detection in diagnostics loop |
| `screen_encoder.rs` | Added `screen_sharing_active: Option<Rc<AtomicBool>>` field + setter. Flag set/clear in `start()`, `stop()`, `onended`, and end-of-loop cleanup. Also fixed pre-existing bug: `new_with_tiers()` → `new_for_screen()` (separate commit) |
| `host.rs` | Wired shared flag: `screen.set_screen_sharing_flag(camera.screen_sharing_flag())` |

### Bonus bug fix (separate commit)

The screen encoder was using `EncoderBitrateController::new_with_tiers()` which starts at `DEFAULT_VIDEO_TIER_INDEX=3`, but `SCREEN_QUALITY_TIERS` only has 3 entries (indices 0-2) — the starting index was out of bounds. Fixed by switching to `new_for_screen()` which uses `DEFAULT_SCREEN_TIER_INDEX=2`.

### Interaction with existing systems

- **Server CONGESTION signals**: Still work — they step down further from current position. Ceiling only blocks step-UP
- **Audio tier**: Unaffected. Audio only degrades when camera is at "minimal" (index 3). Camera at "low" (index 2) keeps audio at "high"
- **PLI/keyframe requests**: Unaffected. Quality ceiling is independent of keyframe logic
- **Rapid toggle**: Safe. Each start forces camera to "low" and sets `last_transition_time_ms`, triggering the 3s min-interval guard. Camera stays at "low" during rapid toggling

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p videocall-client` — passes
- [x] `cargo check --target wasm32-unknown-unknown -p videocall-ui` — passes
- [x] `cargo clippy --target wasm32-unknown-unknown -p videocall-client -p videocall-ui -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — passes
- [x] `cargo test -p videocall-client` — 64 unit tests + 7 doc-tests pass
- [ ] Manual test: start meeting with camera → start screen share → verify camera drops to low tier in logs → stop screen share → verify camera recovers
- [ ] Manual test: start screen share → click browser "Stop sharing" button → verify camera recovers immediately (not delayed)
- [ ] Manual test: verify screen share content remains legible (text readability) while camera is at low tier