### PR TITLE
docs(videocall-cli): add Rust prerequisite and macOS deps to README

### DIFF
--- a/videocall-cli/README.md
+++ b/videocall-cli/README.md
@@ -19,11 +19,29 @@ This is the official command-line client for [videocall.rs](https://github.com/s
 ### System Requirements
 We recommend using a **Linux machine running Ubuntu 24** for the best experience.
 
-### Install Dependencies (Linux)
+### 1. Install Rust 🦀
+Every install path below (`cargo install`, `cargo run`, `cargo deb`) needs the Rust toolchain, so do this **first**. The easiest way is via [rustup](https://rustup.rs):
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Then restart your shell (or run `source "$HOME/.cargo/env"`) so `cargo` is on your `PATH`. See the [official install guide](https://www.rust-lang.org/tools/install) for alternatives.
+
+### 2. Install Dependencies
+
+#### Linux
 Make sure you have the required libraries installed:
 
 ```sh
 sudo apt install build-essential pkg-config libclang-dev libvpx-dev libasound2-dev libv4l-dev cmake libssl-dev
+```
+
+#### macOS (experimental ⚠️)
+On macOS the native build pulls audio/video from CoreAudio and AVFoundation, so the Linux-only ALSA (`libasound2`) and V4L (`libv4l`) packages aren't needed. Install the rest with [Homebrew](https://brew.sh):
+
+```sh
+brew install pkg-config llvm libvpx cmake openssl
 ```
 
 ---

--- a/videocall-cli/README.md
+++ b/videocall-cli/README.md
@@ -38,6 +38,12 @@ sudo apt install build-essential pkg-config libclang-dev libvpx-dev libasound2-d
 ```
 
 #### macOS (experimental ⚠️)
+First make sure the Xcode Command Line Tools are installed — they provide the C compiler and SDK headers needed to build native dependencies. (Homebrew's installer also pulls these in automatically if you don't have them yet.)
+
+```sh
+xcode-select --install
+```
+
 On macOS the native build pulls audio/video from CoreAudio and AVFoundation, so the Linux-only ALSA (`libasound2`) and V4L (`libv4l`) packages aren't needed. Install the rest with [Homebrew](https://brew.sh):
 
 ```sh


### PR DESCRIPTION
## Summary

Fixes #867 — the `videocall-cli` install docs (mirrored to https://crates.io/crates/videocall-cli) sent new users straight to `cargo install videocall-cli` without ever listing the **Rust toolchain itself as a prerequisite**. The reporter hit exactly this gap.

While fixing it, also addressed a secondary gap: macOS is listed as supported in the Platforms table, but only Linux system-library deps were documented.

## Changes (`videocall-cli/README.md`)

- **Add "1. Install Rust 🦀"** as the first Setup step — the official rustup one-liner, a shell-reload reminder, and links to rustup.rs and the official install guide. Calls out that every install path (`cargo install`, `cargo run`, `cargo deb`) needs it.
- **Restructure "Install Dependencies"** into labeled **Linux** (unchanged `apt` command) and **macOS (experimental ⚠️)** subsections. macOS drops the Linux-only packages (`build-essential`, ALSA `libasound2`, V4L `libv4l`) since macOS uses CoreAudio/AVFoundation, and adds the Homebrew equivalent.
- **Number the steps** so ordering is unambiguous.

Docs-only change — no code or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)