### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "bot"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "neteq"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "axum 0.7.9",
  "clap",
@@ -8008,7 +8008,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-cli"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -8029,7 +8029,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-client"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "aes",
  "anyhow",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-codecs"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "approx",
@@ -8123,7 +8123,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "flume",
  "image 0.25.9",
@@ -8157,7 +8157,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-bindings-macos"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "flume",
  "videocall-nokhwa-core",
@@ -8174,7 +8174,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-nokhwa-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-sdk"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8213,7 +8213,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-transport"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -8230,7 +8230,7 @@ dependencies = [
 
 [[package]]
 name = "videocall-types"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "anyhow",
  "protobuf",

--- a/actix-api/Cargo.toml
+++ b/actix-api/Cargo.toml
@@ -58,7 +58,7 @@ tokio = { version = "1.28.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
-videocall-types = { path= "../videocall-types", version = "6.0.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.1" }
 urlencoding = "2.1.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 web-transport-quinn = { workspace = true }
@@ -68,7 +68,7 @@ chrono = "0.4"
 url = "2"
 serial_test = "3"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
-videocall-types = { path = "../videocall-types", version = "6.0.0", features = ["testing"] }
+videocall-types = { path = "../videocall-types", version = "6.0.1", features = ["testing"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
 meeting-api = { path = "../meeting-api" }

--- a/bot/CHANGELOG.md
+++ b/bot/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/security-union/videocall-rs/compare/bot-v1.2.0...bot-v1.3.0) - 2026-08-13
+
+### Added
+
+- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))
+
+### Other
+
+- Classic Nix everywhere: no flakes, no Dockerfiles, and a native dev stack ([#897](https://github.com/security-union/videocall-rs/pull/897))
+
 ## [1.2.0](https://github.com/security-union/videocall-rs/compare/bot-v1.1.3...bot-v1.2.0) - 2026-06-30
 
 ### Added

--- a/bot/Cargo.toml
+++ b/bot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bot"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "A bot for the videocall project"
@@ -17,7 +17,7 @@ tokio = { version = "1.28.1", features = ["full"] }
 # Remove WebSocket, add WebTransport
 web-transport-quinn = { workspace = true }
 futures = "0.3.16"
-videocall-types = { path= "../videocall-types", version = "6.0.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.1" }
 protobuf = "3.3.0"
 chrono = "0.4.25"
 dotenv = "0.15.0"
@@ -32,7 +32,7 @@ image = "0.25.5"  # JPEG processing
 # Pure-Rust VP9 encoding (replaces C libvpx/env-libvpx-sys). Default features pull
 # in zero C dependencies; the legacy libvpx backend is opt-in via the `libvpx`
 # feature below.
-videocall-codecs = { path = "../videocall-codecs", version = "0.1.14" }
+videocall-codecs = { path = "../videocall-codecs", version = "0.1.15" }
 
 # Configuration
 serde = { version = "1.0", features = ["derive"] }

--- a/dioxus-ui/Cargo.toml
+++ b/dioxus-ui/Cargo.toml
@@ -22,17 +22,17 @@ path = "src/main.rs"
 [dependencies]
 dioxus = { version = "0.7.3", default-features = false, features = ["web", "router", "launch", "logger", "lib"] }
 wasm-bindgen = { workspace = true }
-videocall-client = { path = "../videocall-client", version = "4.0.6", default-features = false }
+videocall-client = { path = "../videocall-client", version = "4.0.7", default-features = false }
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.4" }
 videocall-meeting-client = { path = "../videocall-meeting-client", version = "0.1.2" }
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
-videocall-types = { path = "../videocall-types", version = "6.0.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.1" }
 console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 log = "0.4.19"
 gloo-timers = { version = "0.2.6", features = ["futures"] }
 gloo-utils = "0.1"
-neteq = { path = "../neteq", version = "0.9.0", features = ["web"], default-features = false }
+neteq = { path = "../neteq", version = "0.9.1", features = ["web"], default-features = false }
 wasm-bindgen-futures = { workspace = true }
 futures = "0.3.31"
 web-time = "1.1.0"

--- a/meeting-api/Cargo.toml
+++ b/meeting-api/Cargo.toml
@@ -24,7 +24,7 @@ sqlite = ["sqlx/sqlite"]
 
 [dependencies]
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
-videocall-types = { path = "../videocall-types", version = "6.0.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.1" }
 
 async-nats = "0.50.0"
 protobuf = "3.3.0"

--- a/neteq/CHANGELOG.md
+++ b/neteq/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.9.0...neteq-v0.9.1) - 2026-08-13
+
+### Added
+
+- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))
+
 ## [0.9.0](https://github.com/security-union/videocall-rs/compare/neteq-v0.8.3...neteq-v0.9.0) - 2026-06-30
 
 ### Added

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neteq"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "NetEQ-inspired adaptive jitter buffer for audio decoding"
 license = "MIT OR Apache-2.0"

--- a/videocall-cli/CHANGELOG.md
+++ b/videocall-cli/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v4.0.0...videocall-cli-v4.1.0) - 2026-08-13
+
+### Added
+
+- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))
+
+### Other
+
+- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))
+
+### Security
+
+- patch all open high-severity Dependabot alerts in one sweep ([#906](https://github.com/security-union/videocall-rs/pull/906))
+
 ## [4.0.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v3.0.9...videocall-cli-v4.0.0) - 2026-06-30
 
 ### Added

--- a/videocall-cli/Cargo.toml
+++ b/videocall-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-cli"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -37,13 +37,13 @@ ropus = "0.12"  # Pure-Rust Opus encoding
 image = "0.25.5"
 # Pure-Rust VP9 encoding. Default features pull in zero C dependencies; the
 # libvpx backend is opt-in via the `libvpx` feature below.
-videocall-codecs = { path = "../videocall-codecs", version = "0.1.14" }
-videocall-nokhwa = { path = "nokhwa", version = "0.10.9", features = ["input-native", "output-threaded"] }
+videocall-codecs = { path = "../videocall-codecs", version = "0.1.15" }
+videocall-nokhwa = { path = "nokhwa", version = "0.10.10", features = ["input-native", "output-threaded"] }
 
 
 [dependencies.videocall-types]
 path = "../videocall-types"
-version = "6.0.0"
+version = "6.0.1"
 
 [features]
 # Default: pure-Rust VP9 encoder (no C dependencies).

--- a/videocall-cli/nokhwa/CHANGELOG.md
+++ b/videocall-cli/nokhwa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.10](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-v0.10.9...videocall-nokhwa-v0.10.10) - 2026-08-13
+
+### Other
+
+- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))
+
 ## [0.10.9](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-v0.10.8...videocall-nokhwa-v0.10.9) - 2025-06-23
 
 ### Other

--- a/videocall-cli/nokhwa/Cargo.toml
+++ b/videocall-cli/nokhwa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa"
-version = "0.10.9"
+version = "0.10.10"
 authors = ["l1npengtul <l1npengtul@protonmail.com>", "Dario Lencina <dario@securityunion.dev>"]
 edition = "2021"
 description = "A Simple-to-use, cross-platform Rust Webcam Capture Library"

--- a/videocall-cli/nokhwa/nokhwa-bindings-macos/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-bindings-macos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-macos-v0.2.4...videocall-nokhwa-bindings-macos-v0.2.5) - 2026-08-13
+
+### Other
+
+- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))
+
 ### Changed
 
 - Rewrote the Apple camera backend: the ~2,400-line raw `objc` `msg_send!` AVFoundation binding is replaced by a Swift static library (`VideocallCapture`, in `swift/`) bridged over a hand-written 8-function `vcc_`-prefixed C ABI, with safe RAII wrappers in `src/apple.rs`. `build.rs` cross-builds the Swift package per Cargo target (macOS arm64/x86_64, iOS device, iOS simulator incl. Intel, Mac Catalyst) and is a no-op on non-Apple targets. The public API is unchanged.

--- a/videocall-cli/nokhwa/nokhwa-bindings-macos/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-bindings-macos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-bindings-macos"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["l1npengtul", "Dario Lencina <dario@securityunion.dev>"]
 license = "Apache-2.0"

--- a/videocall-cli/nokhwa/nokhwa-core/CHANGELOG.md
+++ b/videocall-cli/nokhwa/nokhwa-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.8...videocall-nokhwa-core-v0.1.9) - 2026-08-13
+
+### Other
+
+- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))
+
 ## [0.1.8](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.7...videocall-nokhwa-core-v0.1.8) - 2025-11-30
 
 ### Other

--- a/videocall-cli/nokhwa/nokhwa-core/Cargo.toml
+++ b/videocall-cli/nokhwa/nokhwa-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-nokhwa-core"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["l1npengtul <l1npengtul@protonmail.com>", "Dario Lencina <dario@securityunion.dev>"]
 edition = "2021"
 description = "Core type definitions for nokhwa"

--- a/videocall-client/CHANGELOG.md
+++ b/videocall-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.7](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.6...videocall-client-v4.0.7) - 2026-08-13
+
+### Other
+
+- updated the following local packages: videocall-types, videocall-codecs, neteq, videocall-transport
+
 ## [4.0.6](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.5...videocall-client-v4.0.6) - 2026-06-30
 
 ### Added

--- a/videocall-client/Cargo.toml
+++ b/videocall-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-client"
-version = "4.0.6"
+version = "4.0.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "High-performance WebAssembly video conferencing client for videocall.rs, supporting WebTransport and WebSocket."
@@ -28,15 +28,15 @@ log = "0.4.19"
 protobuf = "3.3.0"
 rand = { version = "0.8.5", features = ["std_rng", "small_rng"] }
 rsa = "0.9.2"
-videocall-types = { path= "../videocall-types", version = "6.0.0" }
+videocall-types = { path= "../videocall-types", version = "6.0.1" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 web-time = "1.1.0"
 serde = { version = "1", features = ["derive"] }
-videocall-transport = { path = "../videocall-transport", version = "0.2.0" }
+videocall-transport = { path = "../videocall-transport", version = "0.2.1" }
 prost = "0.11"
-videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.14" }
-neteq = { path = "../neteq", features = ["web"], version = "0.9.0", optional = true,  default-features = false }
+videocall-codecs = { path = "../videocall-codecs", features = ["wasm"], version = "0.1.15" }
+neteq = { path = "../neteq", features = ["web"], version = "0.9.1", optional = true,  default-features = false }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 videocall-diagnostics = { path = "../videocall-diagnostics", version = "0.1.4" }

--- a/videocall-codecs/CHANGELOG.md
+++ b/videocall-codecs/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.14...videocall-codecs-v0.1.15) - 2026-08-13
+
+### Added
+
+- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))
+
+### Other
+
+- ship fat (arm64+x86_64) macOS & Mac Catalyst xcframework slices ([#888](https://github.com/security-union/videocall-rs/pull/888))
+
 ## [0.1.14](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.13...videocall-codecs-v0.1.14) - 2026-06-30
 
 ### Other

--- a/videocall-codecs/Cargo.toml
+++ b/videocall-codecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-codecs"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/videocall-sdk/CHANGELOG.md
+++ b/videocall-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.20...videocall-sdk-v0.1.21) - 2026-08-13
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.20](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.19...videocall-sdk-v0.1.20) - 2026-06-30
 
 ### Other

--- a/videocall-sdk/Cargo.toml
+++ b/videocall-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-sdk"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Cross-platform FFI bindings for videocall"
@@ -35,7 +35,7 @@ ring = { version = "0.17", default-features = false }
 futures = "0.3.31"
 
 # Types
-videocall-types = { path = "../videocall-types", version = "6.0.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.1" }
 
 [build-dependencies]
 uniffi_build = { version = "0.29", features = ["builtin-bindgen"] }

--- a/videocall-transport/CHANGELOG.md
+++ b/videocall-transport/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.2.0...videocall-transport-v0.2.1) - 2026-08-13
+
+### Other
+
+- updated the following local packages: videocall-types
+
 ## [0.2.0](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.1.2...videocall-transport-v0.2.0) - 2026-06-30
 
 ### Other

--- a/videocall-transport/Cargo.toml
+++ b/videocall-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-transport"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ gloo-console = "0.3"
 js-sys = "0.3"
 log = "0.4"
 thiserror = "1.0"
-videocall-types = { path = "../videocall-types", version = "6.0.0" }
+videocall-types = { path = "../videocall-types", version = "6.0.1" }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/videocall-types/CHANGELOG.md
+++ b/videocall-types/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v6.0.0...videocall-types-v6.0.1) - 2026-08-13
+
+### Other
+
+- Classic Nix everywhere: no flakes, no Dockerfiles, and a native dev stack ([#897](https://github.com/security-union/videocall-rs/pull/897))
+
+### Security
+
+- patch remaining open Dependabot alerts (medium/low) ([#907](https://github.com/security-union/videocall-rs/pull/907))
+
 ## [6.0.0](https://github.com/security-union/videocall-rs/compare/videocall-types-v5.0.0...videocall-types-v6.0.0) - 2026-06-30
 
 ### Fixed

--- a/videocall-types/Cargo.toml
+++ b/videocall-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "videocall-types"
-version = "6.0.0"
+version = "6.0.1"
 edition = "2021"
 homepage = "https://github.com/security-union/videocall-rs"
 repository = "https://github.com/security-union/videocall-rs"


### PR DESCRIPTION



## 🤖 New release

* `videocall-types`: 6.0.0 -> 6.0.1 (✓ API compatible changes)
* `videocall-codecs`: 0.1.14 -> 0.1.15
* `bot`: 1.2.0 -> 1.3.0
* `neteq`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `videocall-nokhwa-core`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `videocall-nokhwa-bindings-macos`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `videocall-nokhwa`: 0.10.9 -> 0.10.10
* `videocall-cli`: 4.0.0 -> 4.1.0 (✓ API compatible changes)
* `videocall-sdk`: 0.1.20 -> 0.1.21
* `videocall-transport`: 0.2.0 -> 0.2.1
* `videocall-client`: 4.0.6 -> 4.0.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `videocall-types`

<blockquote>

## [6.0.1](https://github.com/security-union/videocall-rs/compare/videocall-types-v6.0.0...videocall-types-v6.0.1) - 2026-08-13

### Other

- Classic Nix everywhere: no flakes, no Dockerfiles, and a native dev stack ([#897](https://github.com/security-union/videocall-rs/pull/897))

### Security

- patch remaining open Dependabot alerts (medium/low) ([#907](https://github.com/security-union/videocall-rs/pull/907))
</blockquote>

## `videocall-codecs`

<blockquote>

## [0.1.15](https://github.com/security-union/videocall-rs/compare/videocall-codecs-v0.1.14...videocall-codecs-v0.1.15) - 2026-08-13

### Added

- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))

### Other

- ship fat (arm64+x86_64) macOS & Mac Catalyst xcframework slices ([#888](https://github.com/security-union/videocall-rs/pull/888))
</blockquote>

## `bot`

<blockquote>

## [1.3.0](https://github.com/security-union/videocall-rs/compare/bot-v1.2.0...bot-v1.3.0) - 2026-08-13

### Added

- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))

### Other

- Classic Nix everywhere: no flakes, no Dockerfiles, and a native dev stack ([#897](https://github.com/security-union/videocall-rs/pull/897))
</blockquote>

## `neteq`

<blockquote>

## [0.9.1](https://github.com/security-union/videocall-rs/compare/neteq-v0.9.0...neteq-v0.9.1) - 2026-08-13

### Added

- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))
</blockquote>

## `videocall-nokhwa-core`

<blockquote>

## [0.1.9](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-core-v0.1.8...videocall-nokhwa-core-v0.1.9) - 2026-08-13

### Other

- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))
</blockquote>

## `videocall-nokhwa-bindings-macos`

<blockquote>

## [0.2.5](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-bindings-macos-v0.2.4...videocall-nokhwa-bindings-macos-v0.2.5) - 2026-08-13

### Other

- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))

### Changed

- Rewrote the Apple camera backend: the ~2,400-line raw `objc` `msg_send!` AVFoundation binding is replaced by a Swift static library (`VideocallCapture`, in `swift/`) bridged over a hand-written 8-function `vcc_`-prefixed C ABI, with safe RAII wrappers in `src/apple.rs`. `build.rs` cross-builds the Swift package per Cargo target (macOS arm64/x86_64, iOS device, iOS simulator incl. Intel, Mac Catalyst) and is a no-op on non-Apple targets. The public API is unchanged.
- Reduced native dependencies from seven crates (`objc`, `cocoa-foundation`, `block`, `core-media-sys`, `core-video-sys`, `core-foundation`, `once_cell`) to `videocall-nokhwa-core` and `flume`.

### Fixed

- NV12 is now requested as 8-bit `'420v'`/`'420f'` instead of the 10-bit type the old bindings used by mistake.
- Frames now carry the real per-frame format read from the delivered buffer, instead of being tagged `GRAY` unconditionally; 420-biplanar fourccs are no longer misclassified as YUYV.
- `videoDataOutput.videoSettings` now pins the delivered width/height as well as the pixel format, so AVFoundation delivers the negotiated geometry rather than session-preset geometry (which corrupted frames).
- The frame channel is bounded (drop-on-full) rather than unbounded, capping memory under a stalled consumer.

### Added

- Builds now require the Xcode command-line tools (Swift toolchain) on macOS. The Swift package targets macOS 12+ and iOS 15+.
</blockquote>

## `videocall-nokhwa`

<blockquote>

## [0.10.10](https://github.com/security-union/videocall-rs/compare/videocall-nokhwa-v0.10.9...videocall-nokhwa-v0.10.10) - 2026-08-13

### Other

- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))
</blockquote>

## `videocall-cli`

<blockquote>

## [4.1.0](https://github.com/security-union/videocall-rs/compare/videocall-cli-v4.0.0...videocall-cli-v4.1.0) - 2026-08-13

### Added

- pure-Rust VP9 codec (encoder + decoder) — remove C libvpx from videocall-cli & bot ([#884](https://github.com/security-union/videocall-rs/pull/884))

### Other

- macOS camera integration rewrite: Swift AVFoundation capture layer replacing objc nokhwa bindings ([#890](https://github.com/security-union/videocall-rs/pull/890))

### Security

- patch all open high-severity Dependabot alerts in one sweep ([#906](https://github.com/security-union/videocall-rs/pull/906))
</blockquote>

## `videocall-sdk`

<blockquote>

## [0.1.21](https://github.com/security-union/videocall-rs/compare/videocall-sdk-v0.1.20...videocall-sdk-v0.1.21) - 2026-08-13

### Other

- update Cargo.lock dependencies
</blockquote>

## `videocall-transport`

<blockquote>

## [0.2.1](https://github.com/security-union/videocall-rs/compare/videocall-transport-v0.2.0...videocall-transport-v0.2.1) - 2026-08-13

### Other

- updated the following local packages: videocall-types
</blockquote>

## `videocall-client`

<blockquote>

## [4.0.7](https://github.com/security-union/videocall-rs/compare/videocall-client-v4.0.6...videocall-client-v4.0.7) - 2026-08-13

### Other

- updated the following local packages: videocall-types, videocall-codecs, neteq, videocall-transport
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).