### PR TITLE
Neteq opus toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,6 +4750,7 @@ dependencies = [
  "log",
  "matomo-logger",
  "once_cell",
+ "opus",
  "rand 0.9.2",
  "ringbuf",
  "ropus",
@@ -5092,6 +5104,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,7 @@
           pkgs.nasm
         ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
           pkgs.libvpx
+          pkgs.libopus
           pkgs.alsa-lib
           pkgs.libclang
         ];

--- a/neteq/Cargo.toml
+++ b/neteq/Cargo.toml
@@ -49,9 +49,9 @@ ringbuf = "0.3"
 hound = { version = "3.5", optional = true }
 rand = { version = "0.9.1", optional = true, default-features = false, features = ["thread_rng"] }
 cpal = { version = "0.15", optional = true }
-# Pure-Rust Opus (xiph/opus port, bit-exact, BSD-3). Replaces the C `opus`
-# crate (libopus/audiopus-sys) as the native Opus codec — no C toolchain,
-# wasm-clean core, single `wide` dependency.
+# Native Opus backends. Xiph libopus is the default; ropus can be selected for
+# a Rust implementation without linking libopus.
+opus = { version = "0.3", default-features = false, optional = true }
 ropus = { version = "0.12", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
 env_logger = { version = "0.10", optional = true }
@@ -64,7 +64,7 @@ once_cell = { version = "1.19", optional = true }
 matomo-logger = { path = "../matomo-logger", optional = true, version = "0.1.0" }
 
 [features]
-default = ["native", "audio_files"]
+default = ["native-libopus", "audio_files"]
 audio_files = ["hound"]
 web = [
     "wasm-bindgen",
@@ -78,7 +78,9 @@ web = [
     "once_cell",
     "matomo-logger/worker",
 ]
-native = ["cpal", "clap", "ropus", "rand", "axum", "tokio", "tower", "tower-http", "env_logger"]
+native = ["cpal", "clap", "rand", "axum", "tokio", "tower", "tower-http", "env_logger"]
+native-libopus = ["native", "dep:opus"]
+native-ropus = ["native", "dep:ropus"]
 
 [dev-dependencies]
 env_logger = "0.10"
@@ -95,5 +97,4 @@ required-features = ["native", "audio_files"]
 [[bin]]
 name = "dashboard_server"
 required-features = ["native"]
-
 

--- a/neteq/README.md
+++ b/neteq/README.md
@@ -20,16 +20,28 @@ Rust NetEQ is a pure-Rust, libWebRTC-inspired jitter buffer designed for profess
 
 ```toml
 [dependencies]
-neteq = "0.1"
+neteq = "0.9"
 ```
 
 Insert RTP payloads as they arrive, call `get_audio()` every 10 ms, and let the buffer handle the rest.  Full runnable snippets live in the [examples](examples) directory — open `basic_usage.rs` first.
+
+Native builds use the Xiph libopus implementation by default. To use the
+Rust ropus implementation instead, disable default features and select the
+`native-ropus` backend explicitly:
+
+```toml
+[dependencies]
+neteq = { version = "0.9", default-features = false, features = ["native-ropus"] }
+```
+
+Add `audio_files` to that feature list when using the WAV-based examples. The
+`native-libopus` and `native-ropus` features are mutually exclusive.
 
 ### Web Applications (WASM + WebWorker)
 
 ```toml
 [dependencies]
-neteq = { version = "0.1", features = ["web"], default-features = false }
+neteq = { version = "0.9", features = ["web"], default-features = false }
 ```
 
 For browser environments, NetEq ships with:
@@ -184,4 +196,3 @@ This NetEQ implementation is algorithmically inspired by and compatible with the
 - Available at: https://webrtc.googlesource.com/src/
 
 This Rust implementation is an independent rewrite and is not a derivative work of the WebRTC source code.
-

--- a/neteq/examples/neteq_player.rs
+++ b/neteq/examples/neteq_player.rs
@@ -29,7 +29,10 @@ use cpal::BufferSize;
 
 use neteq::codec::OpusDecoder;
 use neteq::{AudioPacket, NetEq, NetEqConfig, RtpHeader};
+#[cfg(feature = "native-libopus")]
+use opus::{Application as OpusApp, Channels as OpusChannels, Encoder as OpusEncoder};
 use rand::Rng;
+#[cfg(feature = "native-ropus")]
 use ropus::{Application as OpusApp, Channels as OpusChannels, Encoder as OpusEncoder};
 
 // This example does the following:
@@ -216,6 +219,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         OpusChannels::Stereo
     };
+    #[cfg(feature = "native-libopus")]
+    let mut opus_encoder = OpusEncoder::new(sample_rate, ch_enum, OpusApp::Audio)?;
+    #[cfg(feature = "native-ropus")]
     let mut opus_encoder = OpusEncoder::builder(sample_rate, ch_enum, OpusApp::Audio).build()?;
 
     let mut chunk_index_iter = wav_samples.chunks(packet_samples).enumerate();

--- a/neteq/examples/neteq_player.rs
+++ b/neteq/examples/neteq_player.rs
@@ -188,12 +188,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         n.register_decoder(111, Box::new(OpusDecoder::new(sample_rate, channels)?));
     }
 
-    // ── Warm-start NetEq with a few packets before audio begins ─────────────
-    let warmup_packets = 25; // 25 × 20 ms = 500 ms - increased for better stability
-
     // Packet parameters
     let samples_per_channel_20ms = (sample_rate as f32 * 0.02) as usize;
     let packet_samples = samples_per_channel_20ms * channels as usize;
+    let packet_duration_ms = 20_u32;
+
+    // ── Warm-start NetEq to its initial target before audio begins ──────────
+    //
+    // NetEq starts with an 80 ms target delay unless a larger minimum delay is
+    // requested. Prebuffering much more than that makes the first playout
+    // decisions immediately time-compress a large queue, which is audible as a
+    // short startup bounce.
+    let warmup_delay_ms = args.min_delay_ms.max(80);
+    let warmup_packets = warmup_delay_ms.div_ceil(packet_duration_ms) as usize;
+    log::info!(
+        "Warm-starting NetEq with {warmup_packets} packets ({} ms)",
+        warmup_packets as u32 * packet_duration_ms
+    );
 
     let mut seq_no: u16 = 0;
     let mut timestamp: u32 = 0;
@@ -217,7 +228,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             encoded.truncate(bytes_written as usize);
             let payload = encoded;
             let hdr = RtpHeader::new(seq_no, timestamp, ssrc, 111, false);
-            let packet = AudioPacket::new(hdr, payload, sample_rate, channels, 20);
+            let packet = AudioPacket::new(hdr, payload, sample_rate, channels, packet_duration_ms);
             if let Ok(mut n) = neteq.lock() {
                 let _ = n.insert_packet(packet);
             }
@@ -380,7 +391,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         loop {
             let loop_start = Instant::now();
             for idx in 0..total_remaining_chunks {
-                let packet_start_time = loop_start + Duration::from_millis(idx as u64 * 20);
+                let packet_start_time =
+                    loop_start + Duration::from_millis(idx as u64 * packet_duration_ms as u64);
 
                 let start = idx * packet_samples;
                 let chunk = &remaining_samples[start..start + packet_samples];
@@ -390,7 +402,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .expect("Opus encode");
                 encoded.truncate(bytes_written as usize);
                 let hdr = RtpHeader::new(loc_seq_no, loc_timestamp, ssrc, 111, false);
-                let packet = AudioPacket::new(hdr, encoded, sample_rate, channels, 20);
+                let packet =
+                    AudioPacket::new(hdr, encoded, sample_rate, channels, packet_duration_ms);
 
                 // More precise timing - sleep until the exact time this packet should be sent
                 let now = Instant::now();
@@ -456,7 +469,7 @@ fn start_audio_playback(
     // Request a fixed 10 ms buffer size per callback, based on chosen rate.
     let frames_per_buffer = cfg.sample_rate.0 / 100; // 10 ms worth
     cfg.buffer_size = BufferSize::Fixed(frames_per_buffer);
-    cfg.channels = 1; // mono output
+    cfg.channels = channels as u16;
 
     log::info!(
         "Final stream config - sample_rate={} buffer_size={:?}",

--- a/neteq/src/codec/native_opus.rs
+++ b/neteq/src/codec/native_opus.rs
@@ -20,59 +20,26 @@ use super::AudioDecoder;
 use crate::Result;
 
 // -----------------------------------------------------------------------------
-// Native decode backend (non-wasm): pure-Rust `ropus`.
+// Native decode backend (non-wasm): Xiph libopus or pure-Rust `ropus`.
 //
 // `OpusBackend` is a tiny surface (`new` + `decode_float`) so the
 // `NativeOpusDecoder` wrapper and its `AudioDecoder` impl below stay agnostic
 // of the codec crate.
 // -----------------------------------------------------------------------------
 
-#[cfg(not(target_arch = "wasm32"))]
-mod backend {
-    use crate::{NetEqError, Result};
-    use ropus::{Channels, DecodeMode, Decoder};
+#[cfg(feature = "native-libopus")]
+mod libopus;
+#[cfg(feature = "native-ropus")]
+#[path = "native_opus/ropus.rs"]
+mod ropus_backend;
 
-    /// Pure-Rust Opus decode backend (`ropus`).
-    pub struct OpusBackend(Decoder);
-
-    impl OpusBackend {
-        pub fn new(sample_rate: u32, channels: u8) -> Result<Self> {
-            Decoder::new(sample_rate, channels_enum(channels)?)
-                .map(Self)
-                .map_err(|e| NetEqError::DecoderError(format!("ropus init: {e}")))
-        }
-
-        /// Decode one packet into `out`; returns samples decoded per channel.
-        pub fn decode_float(&mut self, encoded: &[u8], out: &mut [f32]) -> Result<usize> {
-            self.0
-                .decode_float(encoded, out, DecodeMode::Normal)
-                .map_err(|e| NetEqError::DecoderError(format!("ropus decode: {e}")))
-        }
-    }
-
-    fn channels_enum(channels: u8) -> Result<Channels> {
-        match channels {
-            1 => Ok(Channels::Mono),
-            2 => Ok(Channels::Stereo),
-            n => Err(NetEqError::InvalidChannelCount(n)),
-        }
-    }
-}
-
-// `ropus::Decoder` does not implement `Debug`, so give the backend an opaque
-// manual impl. This keeps `NativeOpusDecoder`'s derived `Debug` working.
-#[cfg(not(target_arch = "wasm32"))]
-impl std::fmt::Debug for backend::OpusBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpusBackend").finish_non_exhaustive()
-    }
-}
+#[cfg(feature = "native-libopus")]
+use libopus::OpusBackend;
+#[cfg(all(not(feature = "native-libopus"), feature = "native-ropus"))]
+use ropus_backend::OpusBackend;
 
 #[cfg(not(target_arch = "wasm32"))]
-use backend::OpusBackend;
-
-#[cfg(not(target_arch = "wasm32"))]
-/// Synchronous native Opus decoder, backed by the pure-Rust `ropus` codec.
+/// Synchronous native Opus decoder using the selected native backend.
 #[derive(Debug)]
 pub struct NativeOpusDecoder {
     inner: OpusBackend,
@@ -112,6 +79,50 @@ impl AudioDecoder for NativeOpusDecoder {
         let decoded_samples = self.inner.decode_float(encoded, &mut buf)?;
         buf.truncate(decoded_samples * self.channels as usize);
         Ok(buf)
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_a_mono_silence_packet() {
+        let sample_rate = 48_000;
+        let samples = vec![0.0; 960];
+        let encoded = encode_float(sample_rate, &samples);
+        let mut decoder = NativeOpusDecoder::new(sample_rate, 1).unwrap();
+
+        let decoded = decoder.decode(&encoded).unwrap();
+
+        assert_eq!(decoded.len(), samples.len());
+        assert!(decoded.iter().all(|sample| sample.is_finite()));
+    }
+
+    #[cfg(feature = "native-libopus")]
+    fn encode_float(sample_rate: u32, samples: &[f32]) -> Vec<u8> {
+        let mut encoder =
+            opus::Encoder::new(sample_rate, opus::Channels::Mono, opus::Application::Audio)
+                .unwrap();
+        let mut encoded = vec![0; 4_000];
+        let len = encoder.encode_float(samples, &mut encoded).unwrap();
+        encoded.truncate(len);
+        encoded
+    }
+
+    #[cfg(all(not(feature = "native-libopus"), feature = "native-ropus"))]
+    fn encode_float(sample_rate: u32, samples: &[f32]) -> Vec<u8> {
+        let mut encoder = ropus::Encoder::builder(
+            sample_rate,
+            ropus::Channels::Mono,
+            ropus::Application::Audio,
+        )
+        .build()
+        .unwrap();
+        let mut encoded = vec![0; 4_000];
+        let len = encoder.encode_float(samples, &mut encoded).unwrap();
+        encoded.truncate(len);
+        encoded
     }
 }
 

--- a/neteq/src/codec/native_opus/libopus.rs
+++ b/neteq/src/codec/native_opus/libopus.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ */
+
+use crate::{NetEqError, Result};
+use opus::{Channels, Decoder};
+
+/// Native Xiph libopus decode backend.
+pub(super) struct OpusBackend(Decoder);
+
+impl OpusBackend {
+    pub(super) fn new(sample_rate: u32, channels: u8) -> Result<Self> {
+        Decoder::new(sample_rate, channels_enum(channels)?)
+            .map(Self)
+            .map_err(|e| NetEqError::DecoderError(format!("libopus init: {e}")))
+    }
+
+    /// Decode one packet into `out`; returns samples decoded per channel.
+    pub(super) fn decode_float(&mut self, encoded: &[u8], out: &mut [f32]) -> Result<usize> {
+        self.0
+            .decode_float(encoded, out, false)
+            .map_err(|e| NetEqError::DecoderError(format!("libopus decode: {e}")))
+    }
+}
+
+impl std::fmt::Debug for OpusBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpusBackend")
+            .field("implementation", &"libopus")
+            .finish_non_exhaustive()
+    }
+}
+
+fn channels_enum(channels: u8) -> Result<Channels> {
+    match channels {
+        1 => Ok(Channels::Mono),
+        2 => Ok(Channels::Stereo),
+        n => Err(NetEqError::InvalidChannelCount(n)),
+    }
+}

--- a/neteq/src/codec/native_opus/ropus.rs
+++ b/neteq/src/codec/native_opus/ropus.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ */
+
+use crate::{NetEqError, Result};
+use ropus::{Channels, DecodeMode, Decoder};
+
+/// Pure-Rust ropus decode backend.
+pub(super) struct OpusBackend(Decoder);
+
+impl OpusBackend {
+    pub(super) fn new(sample_rate: u32, channels: u8) -> Result<Self> {
+        Decoder::new(sample_rate, channels_enum(channels)?)
+            .map(Self)
+            .map_err(|e| NetEqError::DecoderError(format!("ropus init: {e}")))
+    }
+
+    /// Decode one packet into `out`; returns samples decoded per channel.
+    pub(super) fn decode_float(&mut self, encoded: &[u8], out: &mut [f32]) -> Result<usize> {
+        self.0
+            .decode_float(encoded, out, DecodeMode::Normal)
+            .map_err(|e| NetEqError::DecoderError(format!("ropus decode: {e}")))
+    }
+}
+
+impl std::fmt::Debug for OpusBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpusBackend")
+            .field("implementation", &"ropus")
+            .finish_non_exhaustive()
+    }
+}
+
+fn channels_enum(channels: u8) -> Result<Channels> {
+    match channels {
+        1 => Ok(Channels::Mono),
+        2 => Ok(Channels::Stereo),
+        n => Err(NetEqError::InvalidChannelCount(n)),
+    }
+}

--- a/neteq/src/delay_manager.rs
+++ b/neteq/src/delay_manager.rs
@@ -358,8 +358,8 @@ impl DelayManager {
         log::debug!(
             "Target delay updated: {}ms max {}ms min {}ms",
             self.target_level_ms,
-            self.effective_minimum_delay_ms,
-            self.effective_maximum_delay_ms
+            self.effective_maximum_delay_ms,
+            self.effective_minimum_delay_ms
         );
     }
 

--- a/neteq/src/delay_manager.rs
+++ b/neteq/src/delay_manager.rs
@@ -251,11 +251,13 @@ impl DelayManager {
 
         // When jitter is high, relative_delay fluctuates between high and near 0 values.
         // resampling helps by calculating the max over some time period.
+        let mut registered_relative_delay = false;
         if let Some(resample_interval_ms) = self.config.resample_interval_ms {
             if let Some(last_resample_time) = self.last_resample_time {
                 let elapsed_ms = arrival_time.duration_since(last_resample_time).as_millis() as u32;
                 if elapsed_ms >= resample_interval_ms {
                     self.register_relative_delay(self.resampled_relative_delay);
+                    registered_relative_delay = true;
                     self.resampled_relative_delay = 0;
 
                     // Round down to nearest multiples, so the interval doesn't drift.
@@ -271,9 +273,12 @@ impl DelayManager {
             self.resampled_relative_delay = self.resampled_relative_delay.max(relative_delay);
         } else {
             self.register_relative_delay(relative_delay);
+            registered_relative_delay = true;
         }
 
-        self.update_target_delay();
+        if registered_relative_delay {
+            self.update_target_delay();
+        }
 
         Ok(())
     }

--- a/neteq/src/lib.rs
+++ b/neteq/src/lib.rs
@@ -22,6 +22,15 @@
 //! This library provides functionality to handle network jitter, packet reordering,
 //! and adaptive buffering for real-time audio applications.
 
+#[cfg(all(feature = "native-libopus", feature = "native-ropus"))]
+compile_error!("native-libopus and native-ropus cannot both be enabled");
+
+#[cfg(all(
+    feature = "native",
+    not(any(feature = "native-libopus", feature = "native-ropus"))
+))]
+compile_error!("the native feature requires native-libopus or native-ropus");
+
 pub mod buffer;
 pub mod buffer_level_filter;
 pub mod codec;

--- a/neteq/src/neteq.rs
+++ b/neteq/src/neteq.rs
@@ -387,7 +387,7 @@ impl NetEq {
         let pre_buffer_ms = self.current_buffer_size_ms();
         let pre_target_delay = self.delay_manager.target_delay_ms();
         let pre_packet_count = self.packet_buffer.len();
-        log::debug!(
+        log::trace!(
             "get_audio pre-decision: buffer={pre_buffer_ms}ms, target={pre_target_delay}ms, packets={pre_packet_count}"
         );
         // -----------------------------------------------------

--- a/neteq/src/neteq.rs
+++ b/neteq/src/neteq.rs
@@ -506,15 +506,20 @@ impl NetEq {
 
     fn get_decision(&mut self) -> Result<Operation> {
         // Update buffer level filter first
-        let current_buffer_samples = self.current_buffer_size_samples();
+        let current_buffer_samples = self.current_buffer_size_samples_per_channel();
         let target_delay_ms: u32 = self.delay_manager.target_delay_ms();
 
         // Filter buffer level like WebRTC's FilterBufferLevel method
         self.buffer_level_filter
             .set_target_buffer_level(target_delay_ms);
 
-        self.buffer_level_filter
-            .update(current_buffer_samples, -self.timestretch_added_samples);
+        if self.buffer_level_filter.filtered_current_level() == 0 && current_buffer_samples > 0 {
+            self.buffer_level_filter
+                .set_filtered_buffer_level(current_buffer_samples);
+        } else {
+            self.buffer_level_filter
+                .update(current_buffer_samples, -self.timestretch_added_samples);
+        }
 
         // Reset for next frame (matches WebRTC decision_logic.cc:245-246)
         self.timestretch_added_samples = 0;
@@ -541,8 +546,11 @@ impl NetEq {
             return Ok(Operation::Expand);
         }
 
-        if current_buffer_samples < self.output_frame_size_samples * 3 / 2
-            && current_buffer_samples >= self.output_frame_size_samples / 2
+        let output_frame_size_samples_per_channel =
+            self.output_frame_size_samples / self.config.channels as usize;
+
+        if current_buffer_samples < output_frame_size_samples_per_channel * 3 / 2
+            && current_buffer_samples >= output_frame_size_samples_per_channel / 2
             && self.consecutive_expands == 0
         {
             self.consecutive_expands = self.consecutive_expands.saturating_add(1);
@@ -550,7 +558,7 @@ impl NetEq {
         }
 
         // Check if we have packets
-        if current_buffer_samples < self.output_frame_size_samples {
+        if current_buffer_samples < output_frame_size_samples_per_channel {
             self.consecutive_expands = self.consecutive_expands.saturating_add(1);
             return Ok(Operation::Expand);
         }
@@ -569,18 +577,18 @@ impl NetEq {
         let buffer_level_samples = self.buffer_level_filter.filtered_current_level();
 
         // Fast accelerate: 4x high limit (aggressive acceleration for large buffers)
-        if buffer_level_samples >= (high_limit << 2) as usize {
+        if buffer_level_samples > (high_limit << 2) as usize {
             return Ok(Operation::FastAccelerate);
         }
 
         // Normal accelerate: at high limit
-        if buffer_level_samples >= high_limit as usize {
+        if buffer_level_samples > high_limit as usize {
             return Ok(Operation::Accelerate);
         }
 
         // Preemptive expand: below low limit (requires ~30ms of audio)
         if buffer_level_samples < low_limit as usize
-            && current_buffer_samples >= self.output_frame_size_samples * 3
+            && current_buffer_samples >= output_frame_size_samples_per_channel * 3
         {
             return Ok(Operation::PreemptiveExpand);
         }
@@ -701,14 +709,17 @@ impl NetEq {
             let mut extended_frame = AudioFrame::new(
                 self.config.sample_rate,
                 self.config.channels,
-                required_samples,
+                required_samples / self.config.channels as usize,
             );
 
             self.decode_normal(&mut extended_frame)?;
 
             // Will output up to 30ms output
-            let mut output =
-                AudioFrame::new(self.config.sample_rate, self.config.channels, output_len);
+            let mut output = AudioFrame::new(
+                self.config.sample_rate,
+                self.config.channels,
+                output_len / self.config.channels as usize,
+            );
 
             // Apply accelerate algorithm
             let _result =
@@ -897,7 +908,7 @@ impl NetEq {
     pub fn current_buffer_size_ms(&self) -> u32 {
         // Use total content duration instead of timestamp span
         // This handles cases where packets have close/identical timestamps
-        self.current_buffer_size_samples() as u32 * 1000 / self.config.sample_rate
+        self.current_buffer_size_samples_per_channel() as u32 * 1000 / self.config.sample_rate
     }
 
     /// Get current buffer size in samples
@@ -905,6 +916,11 @@ impl NetEq {
         self.packet_buffer.num_samples_in_buffer()
             + self.leftover_samples.len()
             + self.leftover_time_stretched_samples.len()
+    }
+
+    /// Get current buffer size in samples per channel.
+    fn current_buffer_size_samples_per_channel(&self) -> usize {
+        self.current_buffer_size_samples() / self.config.channels as usize
     }
 
     /// Register a decoder for a given RTP payload type.
@@ -949,6 +965,20 @@ mod tests {
         AudioPacket::new(header, payload, 16000, 1, duration_ms)
     }
 
+    fn create_stereo_test_packet(seq: u16, ts: u32, duration_ms: u32) -> AudioPacket {
+        let header = RtpHeader::new(seq, ts, 12345, 96, false);
+        let samples_per_channel = (16000 * duration_ms / 1000) as usize;
+        let mut payload = Vec::new();
+        for i in 0..samples_per_channel {
+            let t = i as f32 / 16000.0;
+            let left = (2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.1;
+            let right = (2.0 * std::f32::consts::PI * 660.0 * t).sin() * 0.1;
+            payload.extend_from_slice(&left.to_le_bytes());
+            payload.extend_from_slice(&right.to_le_bytes());
+        }
+        AudioPacket::new(header, payload, 16000, 2, duration_ms)
+    }
+
     #[test]
     fn test_neteq_creation() {
         let config = NetEqConfig::default();
@@ -967,6 +997,38 @@ mod tests {
         neteq.insert_packet(packet).unwrap();
 
         assert!(!neteq.is_empty());
+    }
+
+    #[test]
+    fn test_stereo_buffer_duration_uses_samples_per_channel() {
+        let config = NetEqConfig {
+            channels: 2,
+            ..Default::default()
+        };
+        let mut neteq = NetEq::new(config).unwrap();
+
+        neteq
+            .insert_packet(create_stereo_test_packet(1, 0, 20))
+            .unwrap();
+
+        assert_eq!(neteq.current_buffer_size_samples(), 640);
+        assert_eq!(neteq.current_buffer_size_ms(), 20);
+    }
+
+    #[test]
+    fn test_first_decision_with_target_buffer_is_normal() {
+        let config = NetEqConfig::default();
+        let mut neteq = NetEq::new(config).unwrap();
+
+        for i in 0..4 {
+            neteq
+                .insert_packet(create_test_packet(i, i as u32 * 320, 20))
+                .unwrap();
+        }
+
+        let _ = neteq.get_audio().unwrap();
+
+        assert_eq!(neteq.last_operation, Operation::Normal);
     }
 
     #[test]
@@ -1131,12 +1193,16 @@ mod tests {
 
         // With the fix, buffer should stay reasonable (around 12 packets = ~240ms)
         // Allow some margin but ensure it's nowhere near the old 60 packets (~1200ms)
-        assert!(buffer_after_late_join <= 500,
-                "Buffer should not accumulate excessively after late peer join. Got {buffer_after_late_join}ms, expected ≤500ms");
+        assert!(
+            buffer_after_late_join <= 500,
+            "Buffer should not accumulate excessively after late peer join. Got {buffer_after_late_join}ms, expected ≤500ms"
+        );
 
         // More importantly, ensure it's significantly better than the old behavior (60 packets = 1200ms)
-        assert!(buffer_after_late_join <= 600,
-                "REGRESSION DETECTION: Buffer accumulated {buffer_after_late_join}ms, this exceeds acceptable threshold and may indicate the old 60-packet bug has returned");
+        assert!(
+            buffer_after_late_join <= 600,
+            "REGRESSION DETECTION: Buffer accumulated {buffer_after_late_join}ms, this exceeds acceptable threshold and may indicate the old 60-packet bug has returned"
+        );
 
         // Pull several audio frames and verify NetEQ handles the situation gracefully
         let mut total_operations = std::collections::HashMap::new();
@@ -1172,8 +1238,10 @@ mod tests {
         // Verify that NetEQ used acceleration to handle the large buffer
         // This confirms the fix is working - old code wouldn't accelerate enough
         let accelerate_count = total_operations.get("Accelerate").copied().unwrap_or(0);
-        assert!(accelerate_count > 0,
-                "NetEQ should have used acceleration to handle late-joining peer scenario. Operations: {total_operations:?}");
+        assert!(
+            accelerate_count > 0,
+            "NetEQ should have used acceleration to handle late-joining peer scenario. Operations: {total_operations:?}"
+        );
 
         // Final buffer should be reasonable
         let final_buffer = neteq.current_buffer_size_ms();

--- a/neteq/src/time_stretch.rs
+++ b/neteq/src/time_stretch.rs
@@ -58,15 +58,24 @@ impl Accelerate {
             _sample_rate: sample_rate,
             _channels: channels,
             used_input_samples: 0,
-            overlap_length: Self::calculate_overlap_length(sample_rate),
+            overlap_length: Self::calculate_overlap_length(sample_rate, channels),
             _max_change_rate: 0.25, // Maximum 25% reduction
             low_energy_threshold: 0.0001,
         }
     }
 
-    fn calculate_overlap_length(sample_rate: u32) -> usize {
+    fn calculate_overlap_length(sample_rate: u32, channels: u8) -> usize {
         // Calculate overlap length based on sample rate (typically 4-6ms)
-        ((sample_rate as f32 * 0.003) as usize).max(32) // Minimum 32 samples
+        let channel_count = channels as usize;
+        ((sample_rate as f32 * 0.003) as usize).max(32) * channel_count
+    }
+
+    fn channel_count(&self) -> usize {
+        self._channels as usize
+    }
+
+    fn align_to_channel_frame(&self, samples: usize) -> usize {
+        samples - samples % self.channel_count()
     }
 
     /// Accelerate the audio by removing samples
@@ -125,6 +134,14 @@ impl Accelerate {
             );
         }
 
+        best_pos = self.align_to_channel_frame(best_pos);
+        samples_to_remove = self.align_to_channel_frame(samples_to_remove);
+        if samples_to_remove < self.overlap_length {
+            output.copy_from_slice(&input[..output.len()]);
+            self.used_input_samples = output.len();
+            return TimeStretchResult::NoStretch;
+        }
+
         let usable_input = &input[..output.len() + samples_to_remove];
 
         // original samples: 12346789
@@ -170,7 +187,12 @@ impl Accelerate {
         let max_remove = (output.len() as f32 * acceleration_factor) as usize;
         let max_remove = max_remove.min(output.len() / 2); // Don't remove more than 1/3 of input (= 1/2 of output)
         let max_remove = max_remove.min(input.len() - output.len());
-        max_remove.max(self.overlap_length)
+        let max_remove = self.align_to_channel_frame(max_remove);
+        if max_remove < self.overlap_length {
+            0
+        } else {
+            max_remove
+        }
     }
 
     fn find_low_energy_to_remove(
@@ -203,7 +225,10 @@ impl Accelerate {
             return (0, 0);
         }
 
-        (best_pos, samples_to_remove)
+        (
+            self.align_to_channel_frame(best_pos),
+            self.align_to_channel_frame(samples_to_remove),
+        )
     }
 
     fn calculate_energy(&self, samples: &[f32]) -> f32 {
@@ -333,14 +358,23 @@ impl PreemptiveExpand {
             _sample_rate: sample_rate,
             _channels: channels,
             used_input_samples: 0,
-            overlap_length: Self::calculate_overlap_length(sample_rate),
+            overlap_length: Self::calculate_overlap_length(sample_rate, channels),
             corr_threshold: 0.99,
         }
     }
 
-    fn calculate_overlap_length(sample_rate: u32) -> usize {
+    fn calculate_overlap_length(sample_rate: u32, channels: u8) -> usize {
         // Calculate overlap length based on sample rate (typically 4-6ms)
-        ((sample_rate as f32 * 0.003) as usize).max(32) // Minimum 32 samples
+        let channel_count = channels as usize;
+        ((sample_rate as f32 * 0.003) as usize).max(32) * channel_count
+    }
+
+    fn channel_count(&self) -> usize {
+        self._channels as usize
+    }
+
+    fn align_to_channel_frame(&self, samples: usize) -> usize {
+        samples - samples % self.channel_count()
     }
 
     /// Expand the audio by duplicating/stretching samples
@@ -376,7 +410,7 @@ impl PreemptiveExpand {
         let mut best_corr = -1.0f32;
         let mut best_pos = 0;
         let mut best_add_len = 0;
-        for add_len in self.overlap_length..max_add {
+        for add_len in (self.overlap_length..max_add).step_by(self.channel_count()) {
             let correlation_len = output.len() - add_len * 2;
             let (pos, corr) = crate::signal::best_normalized_correlation(
                 &input[add_len..correlation_len + add_len],
@@ -385,7 +419,7 @@ impl PreemptiveExpand {
             );
             if corr > best_corr {
                 best_corr = corr;
-                best_pos = pos;
+                best_pos = self.align_to_channel_frame(pos);
                 best_add_len = add_len;
             }
         }
@@ -505,6 +539,26 @@ mod tests {
         assert!(accelerate.get_used_input_samples() > 0);
         // Output should be shorter than used samples
         assert!(output.len() < accelerate.get_used_input_samples());
+    }
+
+    #[test]
+    fn test_stereo_accelerate_preserves_channel_frame_alignment() {
+        let mut accelerate = Accelerate::new(48000, 2);
+        let mut input = Vec::new();
+        for i in 0..4800 {
+            let t = i as f32 / 48000.0;
+            input.push((2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.5);
+            input.push((2.0 * std::f32::consts::PI * 660.0 * t).sin() * 0.5);
+        }
+        let mut output = vec![0.0; 2880];
+
+        let result = accelerate.process(&input, &mut output, true);
+
+        assert!(matches!(
+            result,
+            TimeStretchResult::Success | TimeStretchResult::SuccessLowEnergy
+        ));
+        assert_eq!(accelerate.get_used_input_samples() % 2, 0);
     }
 
     #[test]


### PR DESCRIPTION
Add selectable libopus and pure-Rust ropus native backends.
Make libopus the default native Opus implementation.
Add feature validation, decoder tests, and example support.
Update dependencies, Nix packages, and usage documentation.

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Project / Infra

## Testing
- [X] Tests written or updated
- [ ] No tests needed

## Other
- [ ] Documentation updated
- [ ] Before/After Images provided

