### PR TITLE
ci: pin Chrome + chromedriver via nix and harden the flaky dioxus-ui wasm tests

### DIFF
--- a/.github/workflows/wasm-test.yaml
+++ b/.github/workflows/wasm-test.yaml
@@ -9,6 +9,7 @@ on:
       - 'videocall-types/**'
       - 'protobuf/**'
       - 'dioxus-ui/**'
+      - '.github/workflows/wasm-test.yaml'
   pull_request:
     paths:
       - 'videocall-client/**'
@@ -17,6 +18,7 @@ on:
       - 'videocall-types/**'
       - 'protobuf/**'
       - 'dioxus-ui/**'
+      - '.github/workflows/wasm-test.yaml'
 
 jobs:
   wasm-test:
@@ -86,27 +88,45 @@ jobs:
 
       - name: Run dioxus-ui component tests
         run: |
-          # device_integration's getUserMedia/fake-device path intermittently
-          # hangs the Chrome renderer (chromedriver's 300s "Timed out receiving
-          # message from renderer"), independent of the runtime-leak teardown
-          # fix. --no-fail-fast (below) stops one flaky binary from masking the
-          # other 7; this bounded retry rides out the transient renderer hang.
-          max_attempts=2
-          attempt=1
-          while true; do
-            echo "::group::dioxus-ui component tests (attempt ${attempt}/${max_attempts})"
-            if nix develop .#frontend --command bash -c "\
-              cd dioxus-ui && \
-              CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-fail-fast"; then
+          # Headless Chrome intermittently wedges its renderer at webdriver
+          # session startup (chromedriver's 300s "Timed out receiving message
+          # from renderer"), before any test code runs. Each test binary
+          # spawns its own chromedriver+Chrome, so retry per binary rather
+          # than per suite: a whole-suite retry re-rolls the flake across all
+          # binaries, and the SIGKILLed chromedriver leaves the wedged Chrome
+          # orphaned, starving later startups on the 2-core runner. Killing
+          # leftover Chrome processes between attempts stops that cascade.
+          run_target() {
+            local desc="$1"
+            shift
+            local max_attempts=3
+            local attempt
+            for attempt in $(seq 1 "${max_attempts}"); do
+              echo "::group::dioxus-ui ${desc} (attempt ${attempt}/${max_attempts})"
+              if nix develop .#frontend --command bash -c "\
+                cd dioxus-ui && \
+                CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown $*"; then
+                echo "::endgroup::"
+                echo "dioxus-ui ${desc} passed on attempt ${attempt}"
+                return 0
+              fi
               echo "::endgroup::"
-              echo "dioxus-ui component tests passed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "::endgroup::"
-            if [ "${attempt}" -ge "${max_attempts}" ]; then
-              echo "::error::dioxus-ui component tests failed after ${max_attempts} attempts"
-              exit 1
-            fi
-            echo "::warning::dioxus-ui component tests failed on attempt ${attempt}; retrying (headless-Chrome renderer flake)"
-            attempt=$((attempt + 1))
+              pkill -9 -f 'chromedriver|chrome|chromium' || true
+              sleep 2
+              if [ "${attempt}" -ge "${max_attempts}" ]; then
+                echo "::error::dioxus-ui ${desc} failed after ${max_attempts} attempts"
+                return 1
+              fi
+              echo "::warning::dioxus-ui ${desc} failed on attempt ${attempt}; retrying (headless-Chrome renderer flake)"
+            done
+          }
+          failed_targets=()
+          run_target "unit tests" --lib --bins || failed_targets+=("unit-tests")
+          for test_file in dioxus-ui/tests/*.rs; do
+            test_name="$(basename "${test_file}" .rs)"
+            run_target "integration test ${test_name}" --test "${test_name}" || failed_targets+=("${test_name}")
           done
+          if [ "${#failed_targets[@]}" -gt 0 ]; then
+            echo "::error::dioxus-ui targets failed: ${failed_targets[*]}"
+            exit 1
+          fi

--- a/.github/workflows/wasm-test.yaml
+++ b/.github/workflows/wasm-test.yaml
@@ -10,6 +10,8 @@ on:
       - 'protobuf/**'
       - 'dioxus-ui/**'
       - '.github/workflows/wasm-test.yaml'
+      - 'flake.nix'
+      - 'flake.lock'
   pull_request:
     paths:
       - 'videocall-client/**'
@@ -19,6 +21,8 @@ on:
       - 'protobuf/**'
       - 'dioxus-ui/**'
       - '.github/workflows/wasm-test.yaml'
+      - 'flake.nix'
+      - 'flake.lock'
 
 jobs:
   wasm-test:
@@ -84,49 +88,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-dioxus-tests-
 
-      - uses: nanasess/setup-chromedriver@v2
+      - name: Remove the runner's stock Chrome and chromedriver
+        run: |
+          # The browser for the wasm component tests is pinned via the nix
+          # flake (google-chrome + matching chromedriver from nixpkgs).
+          # Delete the runner image's auto-updating Chrome/chromedriver so
+          # any fallback to them fails loudly instead of silently unpinning.
+          sudo rm -rf /opt/google/chrome
+          sudo rm -f /usr/bin/google-chrome /usr/bin/google-chrome-stable
+          stock_driver="$(command -v chromedriver || true)"
+          if [ -n "${stock_driver}" ]; then
+            sudo rm -f "${stock_driver}"
+          fi
 
       - name: Run dioxus-ui component tests
-        run: |
-          # Headless Chrome intermittently wedges its renderer at webdriver
-          # session startup (chromedriver's 300s "Timed out receiving message
-          # from renderer"), before any test code runs. Each test binary
-          # spawns its own chromedriver+Chrome, so retry per binary rather
-          # than per suite: a whole-suite retry re-rolls the flake across all
-          # binaries, and the SIGKILLed chromedriver leaves the wedged Chrome
-          # orphaned, starving later startups on the 2-core runner. Killing
-          # leftover Chrome processes between attempts stops that cascade.
-          run_target() {
-            local desc="$1"
-            shift
-            local max_attempts=3
-            local attempt
-            for attempt in $(seq 1 "${max_attempts}"); do
-              echo "::group::dioxus-ui ${desc} (attempt ${attempt}/${max_attempts})"
-              if nix develop .#frontend --command bash -c "\
-                cd dioxus-ui && \
-                CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown $*"; then
-                echo "::endgroup::"
-                echo "dioxus-ui ${desc} passed on attempt ${attempt}"
-                return 0
-              fi
-              echo "::endgroup::"
-              pkill -9 -f 'chromedriver|chrome|chromium' || true
-              sleep 2
-              if [ "${attempt}" -ge "${max_attempts}" ]; then
-                echo "::error::dioxus-ui ${desc} failed after ${max_attempts} attempts"
-                return 1
-              fi
-              echo "::warning::dioxus-ui ${desc} failed on attempt ${attempt}; retrying (headless-Chrome renderer flake)"
-            done
-          }
-          failed_targets=()
-          run_target "unit tests" --lib --bins || failed_targets+=("unit-tests")
-          for test_file in dioxus-ui/tests/*.rs; do
-            test_name="$(basename "${test_file}" .rs)"
-            run_target "integration test ${test_name}" --test "${test_name}" || failed_targets+=("${test_name}")
-          done
-          if [ "${#failed_targets[@]}" -gt 0 ]; then
-            echo "::error::dioxus-ui targets failed: ${failed_targets[*]}"
-            exit 1
-          fi
+        # All logic (pinned-browser verification, per-binary retry, wedged
+        # Chrome cleanup) lives in nix/dioxus-ui-component-tests.sh, packaged
+        # and shellchecked by the flake.
+        run: nix develop .#frontend-tests --command dioxus-ui-component-tests

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,14 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ (import rust-overlay) ];
-        pkgs = import nixpkgs { inherit system overlays; };
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          # google-chrome is unfree; it's allowed so the dioxus-ui wasm
+          # component tests run against a nix-pinned browser instead of
+          # whatever the CI runner image happens to ship.
+          config.allowUnfreePredicate = pkg:
+            nixpkgs.lib.getName pkg == "google-chrome";
+        };
         pkgsLeptos = import nixpkgs-leptos { inherit system; };
 
         # leptos-website: pinned nightly required by cargo-leptos 0.2.x
@@ -57,6 +64,46 @@
           pkgs.wasm-bindgen-cli_0_2_100
           pkgs.nodejs_20
         ] ++ coreInputs;
+
+        # Pinned browser stack for the dioxus-ui wasm component tests.
+        # google-chrome and chromedriver come from the same nixpkgs pin, so
+        # browser and driver versions move in lockstep and only change when
+        # flake.lock is bumped — CI must not fall back to the runner image's
+        # auto-updating Chrome. Guarded by availableOn because google-chrome
+        # has no aarch64-linux build.
+        chromePinned = pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform
+          pkgs.google-chrome
+          && pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.chromedriver;
+        # chromedriver's browser discovery looks for a binary named
+        # "google-chrome"; the nix package only ships "google-chrome-stable",
+        # so expose an alias under the expected name.
+        googleChromeAlias = pkgs.runCommand "google-chrome-alias" { } ''
+          mkdir -p $out/bin
+          ln -s ${pkgs.google-chrome}/bin/google-chrome-stable $out/bin/google-chrome
+        '';
+        # Single entry point for the dioxus-ui wasm component tests:
+        #   nix develop .#frontend-tests --command dioxus-ui-component-tests
+        # writeShellApplication shellchecks the script at build time.
+        dioxusUiComponentTests = pkgs.writeShellApplication {
+          name = "dioxus-ui-component-tests";
+          runtimeInputs = [
+            pkgs.google-chrome
+            googleChromeAlias
+            pkgs.chromedriver
+            pkgs.jq
+          ];
+          text = builtins.readFile ./nix/dioxus-ui-component-tests.sh;
+        };
+
+        browserTestInputs = pkgs.lib.optionals chromePinned [
+          pkgs.google-chrome
+          googleChromeAlias
+          pkgs.chromedriver
+          dioxusUiComponentTests
+        ];
+        browserTestEnv = pkgs.lib.optionalAttrs chromePinned {
+          CHROMEDRIVER = "${pkgs.chromedriver}/bin/chromedriver";
+        };
 
         frontendBuildInputs = [
           pkgs.trunk
@@ -113,6 +160,15 @@
           nativeBuildInputs = [ frontendRustMinimal ] ++ frontendBuildInputs;
           shellHook = frontendHook;
         };
+
+        # frontend + the pinned browser stack; only needed to run the
+        # dioxus-ui wasm component tests, so it's a separate shell to keep
+        # plain `nix develop` from downloading google-chrome.
+        devShells.frontend-tests = pkgs.mkShell (browserTestEnv // {
+          nativeBuildInputs = [ frontendRustMinimal ] ++ frontendBuildInputs
+            ++ browserTestInputs;
+          shellHook = frontendHook;
+        });
 
         devShells.frontend-dev = pkgs.mkShell {
           nativeBuildInputs = [ frontendRustDev ] ++ frontendBuildInputs;

--- a/nix/dioxus-ui-component-tests.sh
+++ b/nix/dioxus-ui-component-tests.sh
@@ -1,0 +1,106 @@
+# Dioxus UI wasm component tests, run against the nix-pinned headless
+# Chrome + chromedriver (see browserTestInputs in flake.nix). Invoke via:
+#
+#   nix develop .#frontend-tests --command dioxus-ui-component-tests
+#
+# Packaged with writeShellApplication, so shellcheck gates the build and
+# `set -euo pipefail` is prepended automatically.
+#
+# Headless Chrome intermittently wedges its renderer at webdriver session
+# startup (chromedriver's 300s "Timed out receiving message from
+# renderer"), before any test code runs. Each test binary spawns its own
+# chromedriver+Chrome, so retry per binary rather than per suite, and (in
+# CI) kill leftover Chrome processes between attempts so a wedged renderer
+# can't starve later startups.
+
+if [ ! -f flake.nix ] || [ ! -d dioxus-ui ]; then
+  echo "error: must be run from the videocall-rs repo root" >&2
+  exit 1
+fi
+
+CHROMEDRIVER="${CHROMEDRIVER:-$(command -v chromedriver)}"
+export CHROMEDRIVER
+chrome="$(command -v google-chrome)"
+
+case "${chrome}" in
+  /nix/store/*) ;;
+  *)
+    echo "error: google-chrome is not the nix-pinned one: ${chrome}" >&2
+    exit 1
+    ;;
+esac
+case "${CHROMEDRIVER}" in
+  /nix/store/*) ;;
+  *)
+    echo "error: chromedriver is not the nix-pinned one: ${CHROMEDRIVER}" >&2
+    exit 1
+    ;;
+esac
+
+chrome_version="$("${chrome}" --version)"
+driver_version="$("${CHROMEDRIVER}" --version)"
+echo "google-chrome: ${chrome} (${chrome_version})"
+echo "chromedriver:  ${CHROMEDRIVER} (${driver_version})"
+chrome_major="$(grep -oE '[0-9]+' <<<"${chrome_version}" | head -1)"
+driver_major="$(grep -oE '[0-9]+' <<<"${driver_version}" | head -1)"
+if [ "${chrome_major}" != "${driver_major}" ]; then
+  echo "error: Chrome ${chrome_major} / chromedriver ${driver_major} major version mismatch" >&2
+  exit 1
+fi
+
+cd dioxus-ui
+
+# Pin the browser binary explicitly in the capabilities so chromedriver
+# launches exactly the nix Chrome, independent of its binary-discovery
+# heuristics. The checked-in webdriver.json is restored on exit so local
+# runs don't leave the working tree dirty.
+webdriver_json="${PWD}/webdriver.json"
+webdriver_backup="$(mktemp)"
+cp "${webdriver_json}" "${webdriver_backup}"
+trap 'cp "${webdriver_backup}" "${webdriver_json}"; rm -f "${webdriver_backup}"' EXIT
+jq --arg bin "${chrome}" '."goog:chromeOptions".binary = $bin' \
+  "${webdriver_backup}" > "${webdriver_json}"
+
+reap_stray_chrome() {
+  # Only in CI: on a dev machine this would kill the developer's browser.
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    pkill -9 -f 'chromedriver|chrome|chromium' || true
+    sleep 2
+  fi
+}
+
+run_target() {
+  local desc="$1"
+  shift
+  local max_attempts=3
+  local attempt
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    echo "::group::dioxus-ui ${desc} (attempt ${attempt}/${max_attempts})"
+    if cargo test --target wasm32-unknown-unknown "$@"; then
+      echo "::endgroup::"
+      echo "dioxus-ui ${desc} passed on attempt ${attempt}"
+      return 0
+    fi
+    echo "::endgroup::"
+    reap_stray_chrome
+    if [ "${attempt}" -ge "${max_attempts}" ]; then
+      echo "::error::dioxus-ui ${desc} failed after ${max_attempts} attempts"
+      return 1
+    fi
+    echo "::warning::dioxus-ui ${desc} failed on attempt ${attempt}; retrying (headless-Chrome renderer flake)"
+  done
+}
+
+failed_targets=()
+run_target "unit tests" --lib --bins || failed_targets+=("unit-tests")
+shopt -s nullglob
+for test_file in tests/*.rs; do
+  test_name="$(basename "${test_file}" .rs)"
+  run_target "integration test ${test_name}" --test "${test_name}" || failed_targets+=("${test_name}")
+done
+
+if [ "${#failed_targets[@]}" -gt 0 ]; then
+  echo "::error::dioxus-ui targets failed: ${failed_targets[*]}"
+  exit 1
+fi
+echo "all dioxus-ui component test targets passed"


### PR DESCRIPTION
## Problem

The **Dioxus UI Component Tests** job fails intermittently (e.g. [run 29397527100](https://github.com/security-union/videocall-rs/actions/runs/29397527100/job/87294308010)). The signature is always the same: a random test binary hangs at `Starting new webdriver session...` for exactly 300s, chromedriver logs `Timed out receiving message from renderer`, and the test page never gets past `Loading scripts...` — the Chrome renderer wedges **at session startup, before any test code runs**. The failing suites aren't broken: `device_selector` passed 12/12 on one attempt and hung on the next.

Compounding factors:
1. The tests ran against whatever Chrome the `ubuntu-latest` image ships (auto-updating, currently 150), with `setup-chromedriver` fetching a driver to match. Chrome 150's renderer-wedge rate is high enough that whole-suite retries failed repeatedly.
2. The retry re-ran the **entire suite**, re-rolling the flake across all 8 binaries per attempt.
3. The SIGKILLed chromedriver left the wedged Chrome orphaned, starving later Chrome startups on the 2-core runner (observed: retry attempts had *more* hangs than first attempts).

## Fix

**Pin the browser stack in the nix flake.** `google-chrome` and `chromedriver` now come from the flake's nixpkgs pin — 145.0.7632.75 in lockstep — and only change when `flake.lock` is bumped. Unfree is scoped to `google-chrome` only; the stack is guarded with `availableOn` (no google-chrome build for aarch64-linux).

**Move all test logic out of workflow YAML into `nix/dioxus-ui-component-tests.sh`**, packaged with `writeShellApplication` (shellcheck gates the nix build) and exposed as a command in a dedicated `frontend-tests` devshell — plain `nix develop` stays lean and never downloads Chrome. The script:
- asserts `google-chrome` and `CHROMEDRIVER` are `/nix/store` paths with matching major versions;
- injects the exact Chrome binary path into `webdriver.json` capabilities (`goog:chromeOptions.binary`), restoring the file on exit, so chromedriver launches precisely the pinned browser — no discovery heuristics;
- retries **per test binary** (3 attempts) instead of per suite, reaping stray chrome/chromedriver processes between attempts (CI-only, so it can never kill a dev's local browser);
- accumulates failures across binaries so one persistent failure doesn't mask others.

**The workflow shrinks to:** delete the runner's stock Chrome/chromedriver (any fallback fails loudly instead of silently unpinning), then

```
nix develop .#frontend-tests --command dioxus-ui-component-tests
```

Runs identically on a dev machine with the same command.

Also added `flake.nix`, `flake.lock`, and the workflow file to the path filters so pin bumps and workflow changes trigger this job.

## Verification

- Flake evaluated for `x86_64-linux` and `aarch64-darwin`; `CHROMEDRIVER` confirmed present in the `frontend-tests` shell env and absent from the lean `frontend` shell.
- Script passes shellcheck (also enforced at nix build time by `writeShellApplication`).
- Retry/accumulation control flow exercised locally with stubbed pass/flaky/always-fail targets.
- Reviewed by code-reviewer agent; applied its findings (dedicated test shell so local shells don't download Chrome, nullglob guard, CI-gated pkill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)