### PR TITLE
build_ios: ship fat (arm64+x86_64) macOS & Mac Catalyst xcframework slices

### DIFF
--- a/videocall-codecs/README-ios.md
+++ b/videocall-codecs/README-ios.md
@@ -17,22 +17,27 @@ unchanged and still builds for wasm and native Rust as before.
 
 | xcframework slice          | Rust target(s)                          | Toolchain          | Min OS     |
 | -------------------------- | --------------------------------------- | ------------------ | ---------- |
-| `ios-arm64`                | `aarch64-apple-ios`                     | stable (Tier 2)    | iOS 15     |
-| `ios-arm64-simulator`      | `aarch64-apple-ios-sim`                 | stable (Tier 2)    | iOS 15     |
-| `ios-arm64-maccatalyst`    | `aarch64-apple-ios-macabi`              | stable (Tier 2)    | iOS 15     |
-| `macos-arm64`              | `aarch64-apple-darwin`                  | stable (Tier 2)    | macOS 12   |
-| `watchos-arm64_arm64_32`   | `arm64_32-apple-watchos` + `aarch64-apple-watchos` (lipo'd) | **nightly (Tier 3)** | watchOS 10 |
-| `watchos-arm64-simulator`  | `aarch64-apple-watchos-sim`             | **nightly (Tier 3)** | watchOS 10 |
+| `ios-arm64`                    | `aarch64-apple-ios`                     | stable (Tier 2)    | iOS 15     |
+| `ios-arm64-simulator`          | `aarch64-apple-ios-sim`                 | stable (Tier 2)    | iOS 15     |
+| `ios-arm64_x86_64-maccatalyst` | `aarch64-apple-ios-macabi` + `x86_64-apple-ios-macabi` (lipo'd) | stable (Tier 2) | iOS 15 |
+| `macos-arm64_x86_64`           | `aarch64-apple-darwin` + `x86_64-apple-darwin` (lipo'd) | stable (Tier 2) | macOS 12   |
+| `watchos-arm64_arm64_32`       | `arm64_32-apple-watchos` + `aarch64-apple-watchos` (lipo'd) | **nightly (Tier 3)** | watchOS 10 |
+| `watchos-arm64-simulator`      | `aarch64-apple-watchos-sim`             | **nightly (Tier 3)** | watchOS 10 |
 
 The watchOS device slice is a single fat static library containing both
 `arm64_32` (Apple Watch Series 4-8, the broad-coverage 32-bit-pointer ABI) and
 `arm64` (Series 9 / Ultra 2 and newer).
 
-**Mac Catalyst** (`ios-arm64-maccatalyst`) is a *distinct* slice from native
-`macos-arm64`: a Catalyst app (`SUPPORTS_MACCATALYST=YES`, iOS-on-Mac) links the
-`-macabi` ABI, which the native macOS slice does not provide. The remote-shutter
-app is a Catalyst app, so this slice is required; both it and `macos-arm64`
-coexist in the framework.
+**Mac Catalyst** (`ios-arm64_x86_64-maccatalyst`) is a *distinct* slice from
+native `macos-arm64_x86_64`: a Catalyst app (`SUPPORTS_MACCATALYST=YES`,
+iOS-on-Mac) links the `-macabi` ABI, which the native macOS slice does not
+provide. The remote-shutter app is a Catalyst app, so this slice is required;
+both it and the native macOS slice coexist in the framework.
+
+Both macOS-family slices are **fat (arm64 + x86_64)**: Apple Silicon *and* Intel
+Macs. This matters for the App Store — a Catalyst app whose deployment target is
+below macOS 13 must ship the x86_64 slice or upload is rejected with
+`ITMS-90981` (bundle supports Apple Silicon but not Intel).
 
 ---
 

--- a/videocall-codecs/build_ios.sh
+++ b/videocall-codecs/build_ios.sh
@@ -8,8 +8,8 @@
 # Slices produced (see README-ios.md for the full rationale):
 #   * ios-arm64               aarch64-apple-ios          device       (stable, Tier 2)
 #   * ios-arm64-simulator     aarch64-apple-ios-sim      simulator    (stable, Tier 2)
-#   * ios-arm64-maccatalyst   aarch64-apple-ios-macabi   Catalyst     (stable, Tier 2)
-#   * macos-arm64             aarch64-apple-darwin       macOS        (stable, Tier 2)
+#   * ios-arm64_x86_64-maccatalyst  arm64+x86_64-apple-ios-macabi  Catalyst  (stable, Tier 2)
+#   * macos-arm64_x86_64      arm64+x86_64-apple-darwin  macOS        (stable, Tier 2)
 #   * watchos                 arm64_32 + arm64           device (fat) (NIGHTLY, Tier 3)
 #   * watchos-simulator       aarch64-apple-watchos-sim  simulator    (NIGHTLY, Tier 3)
 #
@@ -58,18 +58,54 @@ RUSTFLAGS="-C link-arg=-mios-simulator-version-min=15.0" \
   cargo build -p videocall-codecs --no-default-features --features "$FEATURES" \
   --release --target aarch64-apple-ios-sim
 
+# macOS is fat (arm64 + x86_64) for the same reason as Catalyst below: the
+# `macosx` SDK spans both native macOS and Catalyst, so a consumer that drops
+# the x86_64 arch exclusion needs Intel objects on every macosx-SDK slice.
+MACOS_FAT_DIR="target/macos-fat"
+
 echo "Building for macOS (arm64)..."
 RUSTFLAGS="-C link-arg=-mmacosx-version-min=12.0" \
   cargo build -p videocall-codecs --no-default-features --features "$FEATURES" \
   --release --target aarch64-apple-darwin
 
+echo "Building for macOS (x86_64)..."
+RUSTFLAGS="-C link-arg=-mmacosx-version-min=12.0" \
+  cargo build -p videocall-codecs --no-default-features --features "$FEATURES" \
+  --release --target x86_64-apple-darwin
+
+echo "Fusing macOS slices (arm64 + x86_64) with lipo..."
+mkdir -p "$MACOS_FAT_DIR"
+lipo -create \
+  "target/aarch64-apple-darwin/release/$LIB_NAME" \
+  "target/x86_64-apple-darwin/release/$LIB_NAME" \
+  -output "$MACOS_FAT_DIR/$LIB_NAME"
+
 # Mac Catalyst: the `-macabi` variant needs the deployment target expressed via a
-# full `-target arm64-apple-ios<min>-macabi` triple (there is no `-macabi`
+# full `-target <arch>-apple-ios<min>-macabi` triple (there is no `-macabi`
 # min-version flag), otherwise clang defaults the object's Catalyst minos.
+#
+# The Catalyst slice is fat (arm64 + x86_64): Apple Silicon *and* Intel Macs. A
+# Catalyst app whose deployment target is below macOS 13 must ship x86_64 or the
+# App Store rejects it (ITMS-90981) — an arm64-only slice would force the host app
+# arm64-only via CocoaPods' auto-generated `EXCLUDED_ARCHS[sdk=macosx*] = x86_64`.
+MACCATALYST_FAT_DIR="target/maccatalyst-fat"
+
 echo "Building for Mac Catalyst (arm64, ios-macabi)..."
 RUSTFLAGS="-C link-arg=-target -C link-arg=arm64-apple-ios15.0-macabi" \
   cargo build -p videocall-codecs --no-default-features --features "$FEATURES" \
   --release --target aarch64-apple-ios-macabi
+
+echo "Building for Mac Catalyst (x86_64, ios-macabi)..."
+RUSTFLAGS="-C link-arg=-target -C link-arg=x86_64-apple-ios15.0-macabi" \
+  cargo build -p videocall-codecs --no-default-features --features "$FEATURES" \
+  --release --target x86_64-apple-ios-macabi
+
+echo "Fusing Mac Catalyst slices (arm64 + x86_64) with lipo..."
+mkdir -p "$MACCATALYST_FAT_DIR"
+lipo -create \
+  "target/aarch64-apple-ios-macabi/release/$LIB_NAME" \
+  "target/x86_64-apple-ios-macabi/release/$LIB_NAME" \
+  -output "$MACCATALYST_FAT_DIR/$LIB_NAME"
 
 # --- watchOS: NIGHTLY + build-std, Tier 3 ------------------------------------
 #
@@ -138,8 +174,8 @@ cat "$OUT_SWIFT"/*FFI.modulemap > "$OUT_SWIFT/include/module.modulemap"
 SIGN_LIBS=(
   "target/aarch64-apple-ios/release/$LIB_NAME"
   "target/aarch64-apple-ios-sim/release/$LIB_NAME"
-  "target/aarch64-apple-ios-macabi/release/$LIB_NAME"
-  "target/aarch64-apple-darwin/release/$LIB_NAME"
+  "$MACCATALYST_FAT_DIR/$LIB_NAME"
+  "$MACOS_FAT_DIR/$LIB_NAME"
 )
 if [ "$BUILD_WATCHOS" = "1" ]; then
   SIGN_LIBS+=(
@@ -156,8 +192,8 @@ rm -rf target/VideocallCodecs.xcframework
 XCARGS=(
   -library "target/aarch64-apple-ios/release/$LIB_NAME" -headers "$OUT_SWIFT/include"
   -library "target/aarch64-apple-ios-sim/release/$LIB_NAME" -headers "$OUT_SWIFT/include"
-  -library "target/aarch64-apple-ios-macabi/release/$LIB_NAME" -headers "$OUT_SWIFT/include"
-  -library "target/aarch64-apple-darwin/release/$LIB_NAME" -headers "$OUT_SWIFT/include"
+  -library "$MACCATALYST_FAT_DIR/$LIB_NAME" -headers "$OUT_SWIFT/include"
+  -library "$MACOS_FAT_DIR/$LIB_NAME" -headers "$OUT_SWIFT/include"
 )
 if [ "$BUILD_WATCHOS" = "1" ]; then
   XCARGS+=(
@@ -172,9 +208,9 @@ echo "=== Build completed successfully ==="
 echo "XCFramework:    $ROOT_DIR/target/VideocallCodecs.xcframework"
 echo "Swift bindings: $ROOT_DIR/$OUT_SWIFT/videocall_codecs.swift"
 if [ "$BUILD_WATCHOS" = "1" ]; then
-  echo "Slices:         ios-arm64, ios-arm64-simulator, ios-arm64-maccatalyst, macos-arm64, watchos (arm64_32+arm64), watchos-simulator"
+  echo "Slices:         ios-arm64, ios-arm64-simulator, ios-arm64_x86_64-maccatalyst, macos-arm64_x86_64, watchos (arm64_32+arm64), watchos-simulator"
 else
-  echo "Slices:         ios-arm64, ios-arm64-simulator, ios-arm64-maccatalyst, macos-arm64  (watchOS skipped)"
+  echo "Slices:         ios-arm64, ios-arm64-simulator, ios-arm64_x86_64-maccatalyst, macos-arm64  (watchOS skipped)"
 fi
 echo ""
 echo "To use in Swift:"


### PR DESCRIPTION
## What

Makes the macOS-family slices of `VideocallCodecs.xcframework` **fat (arm64 + x86_64)** so the framework supports Intel Macs, not just Apple Silicon.

`build_ios.sh` now additionally builds:
- `x86_64-apple-ios-macabi` → lipo'd with arm64 into `ios-arm64_x86_64-maccatalyst`
- `x86_64-apple-darwin` → lipo'd with arm64 into `macos-arm64_x86_64`

iOS and watchOS device + simulator slices are unchanged (still arm64-only; no Intel simulator is needed).

## Why

The Mac Catalyst slice was arm64-only. When a Catalyst host app (e.g. Remote Shutter) with a deployment target below macOS 13 links an arm64-only vendored xcframework:

1. CocoaPods auto-generates `EXCLUDED_ARCHS[sdk=macosx*] = x86_64`, forcing the whole app arm64-only.
2. App Store Connect then rejects the upload:

   > **ITMS-90981**: the bundle supports Apple silicon but not Intel-based Mac computers. Because this app currently supports Intel-based Mac computers, you must either continue to include the x86_64 architecture in your build, or set the minimum system version to 13.0 or later to drop support.

Shipping the x86_64 slice keeps Intel support without bumping the minimum OS.

## Verification

```
$ lipo -info target/VideocallCodecs.xcframework/ios-arm64_x86_64-maccatalyst/libvideocall_codecs.a
Architectures in the fat file: ... are: x86_64 arm64
$ lipo -info target/VideocallCodecs.xcframework/macos-arm64_x86_64/libvideocall_codecs.a
Architectures in the fat file: ... are: x86_64 arm64
```

Consuming Remote Shutter (Catalyst) now archives a universal binary (x86_64 + arm64) with all embedded frameworks universal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)