### PR TITLE
feat(meeting-api): optional SQLite backend via a dialect shim (alternative to #802)

### DIFF
--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -4,26 +4,49 @@ on:
   pull_request:
     paths:
       - 'actix-api/**'
+      - 'meeting-api/**'
       - 'videocall-types/**'
+      - 'videocall-meeting-types/**'
       - 'protobuf/**'
       - 'dioxus-ui/**'
       - 'docker/**'
       - 'neteq/**'
       - 'videocall-client/**'
       - 'dbmate/**'
+      - 'Makefile'
+      - '.github/workflows/cargo-test.yaml'
 name: check backend
 
 jobs:
+  # meeting-api compiles against either PostgreSQL or SQLite, so the same suite
+  # runs once per backend. Both legs execute the identical cargo command from the
+  # Makefile (`$(MEETING_API_TEST)`) in the same container; only DATABASE_URL,
+  # the dbmate directory and the cargo feature differ. Keeping this a matrix
+  # rather than two hand-written jobs is what stops the two backends' coverage
+  # drifting apart.
+  #
+  # The postgres leg is also the workspace-wide clippy/fmt gate and runs
+  # videocall-api, so it is not merely "the other half" of the matrix.
   test:
-    name: cargo tests_run
+    name: cargo ${{ matrix.target }}
     runs-on: ubuntu-latest
+    strategy:
+      # Report both backends on a failure; knowing whether a break is
+      # backend-specific or shared is most of the diagnosis.
+      fail-fast: false
+      matrix:
+        include:
+          - backend: postgres
+            target: tests_run
+          - backend: sqlite
+            target: tests_run_sqlite
     steps:
       - uses: actions/checkout@v4
 
       - name: Clean up Docker resources
         run: docker system prune -f --volumes
 
-      - run: make tests_run
+      - run: make ${{ matrix.target }}
 
       - name: Teardown
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,6 +4144,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,17 @@ COMPOSE_E2E := docker compose -p videocall-e2e -f docker/docker-compose.e2e.yaml
 # Do not inline these commands into a target. The moment the two legs spell the
 # invocation out separately they can drift, which is the failure mode this
 # structure exists to prevent.
+#
+# `--test-threads=1` is part of the shared command, so both legs run identically;
+# it predates this branch (it was already on the PostgreSQL `cargo test
+# -p meeting-api` line) and it is load-bearing, not defensive. The suite shares a
+# single database and cleans up by `room_id`, so overlapping test functions would
+# delete each other's fixtures — which is why ~97 tests carry `#[serial]`.
+#
+# It does not weaken the concurrency coverage. `--test-threads=1` bounds how many
+# `#[test]` functions run at once; every race test builds its concurrency *inside*
+# one test with `tokio::spawn` (two writers on the same pool), which this flag
+# cannot serialize. The race tests are `#[serial]` regardless.
 MEETING_API_FEATURES ?=
 MEETING_API_TEST = cargo test -p meeting-api $(MEETING_API_FEATURES) -- --nocapture --test-threads=1
 MEETING_API_CLIPPY = cargo clippy -p meeting-api --all-targets $(MEETING_API_FEATURES) -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -2,37 +2,22 @@ COMPOSE_IT := docker/docker-compose.integration.yaml
 COMPOSE_E2E := docker compose -p videocall-e2e -f docker/docker-compose.e2e.yaml
 
 # ---------------------------------------------------------------------------
-# meeting-api backend matrix
+# meeting-api backend matrix — one test suite, run twice (postgres + sqlite).
 # ---------------------------------------------------------------------------
-# meeting-api compiles against either PostgreSQL or SQLite. There is ONE test
-# suite, run twice — not a suite per backend. `tests_run` and `tests_run_sqlite`
-# below invoke the identical $(MEETING_API_TEST) and $(MEETING_API_CLIPPY)
-# commands; the only differences are DATABASE_URL, which dbmate directory is
-# migrated, and this feature flag. Coverage is equal by construction, so a test
-# added to meeting-api/tests is automatically run against both backends and
-# there is no second harness to keep in sync.
+# `tests_run` and `tests_run_sqlite` invoke the identical $(MEETING_API_TEST) /
+# $(MEETING_API_CLIPPY); only DATABASE_URL, the dbmate dir, and the feature flag
+# differ, so coverage is equal by construction. Keep the commands in these
+# variables — spelling them out per target lets the two legs drift.
 #
-# Do not inline these commands into a target. The moment the two legs spell the
-# invocation out separately they can drift, which is the failure mode this
-# structure exists to prevent.
-#
-# `--test-threads=1` is part of the shared command, so both legs run identically;
-# it predates this branch (it was already on the PostgreSQL `cargo test
-# -p meeting-api` line) and it is load-bearing, not defensive. The suite shares a
-# single database and cleans up by `room_id`, so overlapping test functions would
-# delete each other's fixtures — which is why ~97 tests carry `#[serial]`.
-#
-# It does not weaken the concurrency coverage. `--test-threads=1` bounds how many
-# `#[test]` functions run at once; every race test builds its concurrency *inside*
-# one test with `tokio::spawn` (two writers on the same pool), which this flag
-# cannot serialize. The race tests are `#[serial]` regardless.
+# `--test-threads=1` is shared and load-bearing: the suite shares one database
+# and cleans up by room_id, so ~97 tests are `#[serial]`. It does not weaken race
+# coverage — each race test spawns its own writers inside one test.
 MEETING_API_FEATURES ?=
 MEETING_API_TEST = cargo test -p meeting-api $(MEETING_API_FEATURES) -- --nocapture --test-threads=1
 MEETING_API_CLIPPY = cargo clippy -p meeting-api --all-targets $(MEETING_API_FEATURES) -- -D warnings
 
-# SQLite has no server, so its "instance" is a file. dbmate creates and migrates
-# it exactly as it does the PostgreSQL database; it lives outside the bind-mounted
-# repo so a test run never dirties the working tree.
+# SQLite's "instance" is a file; dbmate creates and migrates it like the
+# PostgreSQL database. Kept outside the repo so a run never dirties the tree.
 SQLITE_TEST_DB := /tmp/meeting-api-test.sqlite3
 SQLITE_TEST_URL := sqlite:$(SQLITE_TEST_DB)
 
@@ -50,13 +35,9 @@ tests_run:
 		cargo test -p videocall-api -- --nocapture --test-threads=1 && \
 		$(MEETING_API_TEST)"
 
-# SQLite leg of the backend matrix.
-#
-# Same container, same nix devshell, same cargo command as `tests_run` — so this
-# is genuinely the same suite, not a lookalike. `--no-deps` skips postgres and
-# nats, which SQLite does not need, and dbmate migrates dbmate/sqlite exactly as
-# the PostgreSQL leg migrates dbmate/db. The suite therefore runs against the
-# migration files production applies, not a schema assembled in test code.
+# SQLite leg: same container and cargo command as `tests_run`; `--no-deps` skips
+# postgres/nats, and dbmate migrates dbmate/sqlite as the pg leg migrates
+# dbmate/db, so the suite runs against production's migration files.
 tests_run_sqlite: MEETING_API_FEATURES = --no-default-features --features sqlite
 tests_run_sqlite:
 	docker compose -f $(COMPOSE_IT) run --rm --no-deps \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,33 @@
 COMPOSE_IT := docker/docker-compose.integration.yaml
 COMPOSE_E2E := docker compose -p videocall-e2e -f docker/docker-compose.e2e.yaml
 
-.PHONY: tests_up test up down build connect_to_db connect_to_nats clippy-fix fmt check clean clean-docker rebuild rebuild-up e2e e2e-headed e2e-debug e2e-interop e2e-lint e2e-fmt e2e-install e2e-up e2e-down e2e-build e2e-ci
+# ---------------------------------------------------------------------------
+# meeting-api backend matrix
+# ---------------------------------------------------------------------------
+# meeting-api compiles against either PostgreSQL or SQLite. There is ONE test
+# suite, run twice — not a suite per backend. `tests_run` and `tests_run_sqlite`
+# below invoke the identical $(MEETING_API_TEST) and $(MEETING_API_CLIPPY)
+# commands; the only differences are DATABASE_URL, which dbmate directory is
+# migrated, and this feature flag. Coverage is equal by construction, so a test
+# added to meeting-api/tests is automatically run against both backends and
+# there is no second harness to keep in sync.
+#
+# Do not inline these commands into a target. The moment the two legs spell the
+# invocation out separately they can drift, which is the failure mode this
+# structure exists to prevent.
+MEETING_API_FEATURES ?=
+MEETING_API_TEST = cargo test -p meeting-api $(MEETING_API_FEATURES) -- --nocapture --test-threads=1
+MEETING_API_CLIPPY = cargo clippy -p meeting-api --all-targets $(MEETING_API_FEATURES) -- -D warnings
 
+# SQLite has no server, so its "instance" is a file. dbmate creates and migrates
+# it exactly as it does the PostgreSQL database; it lives outside the bind-mounted
+# repo so a test run never dirties the working tree.
+SQLITE_TEST_DB := /tmp/meeting-api-test.sqlite3
+SQLITE_TEST_URL := sqlite:$(SQLITE_TEST_DB)
+
+.PHONY: tests_up test up down build connect_to_db connect_to_nats clippy-fix fmt check clean clean-docker rebuild rebuild-up e2e e2e-headed e2e-debug e2e-interop e2e-lint e2e-fmt e2e-install e2e-up e2e-down e2e-build e2e-ci tests_run_sqlite
+
+# PostgreSQL leg of the backend matrix (also the workspace-wide lint/fmt gate).
 tests_run:
 	docker compose -f $(COMPOSE_IT) up -d postgres nats && docker compose -f $(COMPOSE_IT) run --rm rust-tests \
 		nix develop /app#backend-dev --command bash -c "\
@@ -12,7 +37,26 @@ tests_run:
 		cargo clippy --all -- -D warnings && \
 		cargo fmt --all --check && \
 		cargo test -p videocall-api -- --nocapture --test-threads=1 && \
-		cargo test -p meeting-api -- --nocapture --test-threads=1"
+		$(MEETING_API_TEST)"
+
+# SQLite leg of the backend matrix.
+#
+# Same container, same nix devshell, same cargo command as `tests_run` — so this
+# is genuinely the same suite, not a lookalike. `--no-deps` skips postgres and
+# nats, which SQLite does not need, and dbmate migrates dbmate/sqlite exactly as
+# the PostgreSQL leg migrates dbmate/db. The suite therefore runs against the
+# migration files production applies, not a schema assembled in test code.
+tests_run_sqlite: MEETING_API_FEATURES = --no-default-features --features sqlite
+tests_run_sqlite:
+	docker compose -f $(COMPOSE_IT) run --rm --no-deps \
+		-e DATABASE_URL=$(SQLITE_TEST_URL) rust-tests \
+		nix develop /app#backend-dev --command bash -c "\
+		set -euo pipefail && \
+		rm -f $(SQLITE_TEST_DB) $(SQLITE_TEST_DB)-wal $(SQLITE_TEST_DB)-shm && \
+		cd /app/dbmate/sqlite && dbmate --no-dump-schema up && \
+		cd /app && \
+		$(MEETING_API_CLIPPY) && \
+		$(MEETING_API_TEST)"
 
 tests_build:
 	docker compose -f $(COMPOSE_IT) build

--- a/dbmate/db/schema.sql
+++ b/dbmate/db/schema.sql
@@ -1,3 +1,8 @@
+\restrict 7l9rsfZCnQFCGbfw5pT2UlnAAGWlELLe9nFBa2hHK8bvX0UrBvfQpSafiTmqAym
+
+-- Dumped from database version 16.14
+-- Dumped by pg_dump version 16.14
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -28,18 +33,66 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: meeting_participants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.meeting_participants (
+    id integer NOT NULL,
+    meeting_id integer NOT NULL,
+    user_id character varying(255) NOT NULL,
+    status character varying(50) DEFAULT 'waiting'::character varying NOT NULL,
+    is_host boolean DEFAULT false NOT NULL,
+    is_required boolean DEFAULT false NOT NULL,
+    joined_at timestamp with time zone DEFAULT now() NOT NULL,
+    admitted_at timestamp with time zone,
+    left_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    display_name character varying(255),
+    CONSTRAINT chk_participant_status CHECK (((status)::text = ANY ((ARRAY['waiting'::character varying, 'admitted'::character varying, 'rejected'::character varying, 'left'::character varying])::text[])))
+);
+
+
+--
+-- Name: meeting_participants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.meeting_participants_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: meeting_participants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.meeting_participants_id_seq OWNED BY public.meeting_participants.id;
+
+
+--
 -- Name: meetings; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.meetings (
     id integer NOT NULL,
-    room_id text NOT NULL,
+    room_id character varying(255) NOT NULL,
     started_at timestamp with time zone NOT NULL,
     ended_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now(),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
     deleted_at timestamp with time zone,
-    creator_id integer NOT NULL
+    creator_id character varying(255),
+    password_hash character varying(255),
+    state character varying(50) DEFAULT 'idle'::character varying NOT NULL,
+    attendees jsonb DEFAULT '[]'::jsonb NOT NULL,
+    host_display_name character varying(255),
+    waiting_room_enabled boolean DEFAULT true NOT NULL,
+    CONSTRAINT chk_attendees_max_100 CHECK ((jsonb_array_length(attendees) <= 100)),
+    CONSTRAINT chk_meeting_state CHECK (((state)::text = ANY ((ARRAY['idle'::character varying, 'active'::character varying, 'ended'::character varying])::text[])))
 );
 
 
@@ -70,7 +123,9 @@ ALTER SEQUENCE public.meetings_id_seq OWNED BY public.meetings.id;
 CREATE TABLE public.oauth_requests (
     pkce_challenge text,
     pkce_verifier text,
-    csrf_state text
+    csrf_state text,
+    return_to text,
+    nonce character varying(255)
 );
 
 
@@ -79,8 +134,42 @@ CREATE TABLE public.oauth_requests (
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying NOT NULL
+    version character varying(128) NOT NULL
 );
+
+
+--
+-- Name: session_participants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session_participants (
+    id integer NOT NULL,
+    room_id character varying(255) NOT NULL,
+    user_id character varying(255) NOT NULL,
+    joined_at timestamp with time zone DEFAULT now() NOT NULL,
+    left_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: session_participants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.session_participants_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: session_participants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.session_participants_id_seq OWNED BY public.session_participants.id;
 
 
 --
@@ -98,10 +187,32 @@ CREATE TABLE public.users (
 
 
 --
+-- Name: meeting_participants id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.meeting_participants ALTER COLUMN id SET DEFAULT nextval('public.meeting_participants_id_seq'::regclass);
+
+
+--
 -- Name: meetings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.meetings ALTER COLUMN id SET DEFAULT nextval('public.meetings_id_seq'::regclass);
+
+
+--
+-- Name: session_participants id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_participants ALTER COLUMN id SET DEFAULT nextval('public.session_participants_id_seq'::regclass);
+
+
+--
+-- Name: meeting_participants meeting_participants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.meeting_participants
+    ADD CONSTRAINT meeting_participants_pkey PRIMARY KEY (id);
 
 
 --
@@ -113,19 +224,35 @@ ALTER TABLE ONLY public.meetings
 
 
 --
--- Name: meetings meetings_room_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.meetings
-    ADD CONSTRAINT meetings_room_id_key UNIQUE (room_id);
-
-
---
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: session_participants session_participants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_participants
+    ADD CONSTRAINT session_participants_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: session_participants session_participants_room_id_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_participants
+    ADD CONSTRAINT session_participants_room_id_user_id_key UNIQUE (room_id, user_id);
+
+
+--
+-- Name: meeting_participants uq_meeting_participant_user; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.meeting_participants
+    ADD CONSTRAINT uq_meeting_participant_user UNIQUE (meeting_id, user_id);
 
 
 --
@@ -137,10 +264,73 @@ ALTER TABLE ONLY public.users
 
 
 --
+-- Name: idx_meeting_participants_meeting_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_meeting_participants_meeting_id ON public.meeting_participants USING btree (meeting_id);
+
+
+--
+-- Name: idx_meeting_participants_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_meeting_participants_status ON public.meeting_participants USING btree (status);
+
+
+--
+-- Name: idx_meeting_participants_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_meeting_participants_user_id ON public.meeting_participants USING btree (user_id);
+
+
+--
+-- Name: idx_meetings_creator_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_meetings_creator_id ON public.meetings USING btree (creator_id);
+
+
+--
 -- Name: idx_meetings_room_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_meetings_room_id ON public.meetings USING btree (room_id);
+
+
+--
+-- Name: idx_meetings_room_id_unique_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_meetings_room_id_unique_active ON public.meetings USING btree (room_id) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: idx_meetings_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_meetings_state ON public.meetings USING btree (state);
+
+
+--
+-- Name: idx_session_participants_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_session_participants_active ON public.session_participants USING btree (room_id) WHERE (left_at IS NULL);
+
+
+--
+-- Name: idx_session_participants_room_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_session_participants_room_id ON public.session_participants USING btree (room_id);
+
+
+--
+-- Name: meeting_participants update_meeting_participants_updated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER update_meeting_participants_updated_at BEFORE UPDATE ON public.meeting_participants FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
 
 --
@@ -151,8 +341,18 @@ CREATE TRIGGER update_meetings_updated_at BEFORE UPDATE ON public.meetings FOR E
 
 
 --
+-- Name: meeting_participants meeting_participants_meeting_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.meeting_participants
+    ADD CONSTRAINT meeting_participants_meeting_id_fkey FOREIGN KEY (meeting_id) REFERENCES public.meetings(id) ON DELETE CASCADE;
+
+
+--
 -- PostgreSQL database dump complete
 --
+
+\unrestrict 7l9rsfZCnQFCGbfw5pT2UlnAAGWlELLe9nFBa2hHK8bvX0UrBvfQpSafiTmqAym
 
 
 --
@@ -162,7 +362,13 @@ CREATE TRIGGER update_meetings_updated_at BEFORE UPDATE ON public.meetings FOR E
 INSERT INTO public.schema_migrations (version) VALUES
     ('20220807000000'),
     ('20250101000000'),
+    ('20250113000000'),
     ('20251109111824'),
-    ('20251109143240'),
-    ('20251110232152'),
-    ('20251129183430');
+    ('20251225000000'),
+    ('20260203000000'),
+    ('20260203000001'),
+    ('20260203000002'),
+    ('20260203000003'),
+    ('20260211000000'),
+    ('20260302000000'),
+    ('20260307000001');

--- a/dbmate/sqlite/README.md
+++ b/dbmate/sqlite/README.md
@@ -3,10 +3,8 @@
 The SQLite equivalent of `dbmate/db/`, used when `meeting-api` is built with
 `--no-default-features --features sqlite`.
 
-The layout matches `dbmate/db/` on purpose: `db/migrations` and `db/schema.sql`
-are dbmate's defaults, so no config file is needed. (dbmate only reads
-`.dbmate.yml` from v2.28 onwards; earlier versions silently ignore it and fall
-back to the defaults, so relying on one is a trap.)
+The layout matches `dbmate/db/`: `db/migrations` and `db/schema.sql` are
+dbmate's defaults, so no config file is needed.
 
 Run dbmate from *this* directory, exactly as `dbmate/startup.sh` does for
 PostgreSQL from `dbmate/`:

--- a/dbmate/sqlite/README.md
+++ b/dbmate/sqlite/README.md
@@ -1,0 +1,22 @@
+# SQLite migrations
+
+The SQLite equivalent of `dbmate/db/`, used when `meeting-api` is built with
+`--no-default-features --features sqlite`.
+
+The layout matches `dbmate/db/` on purpose: `db/migrations` and `db/schema.sql`
+are dbmate's defaults, so no config file is needed. (dbmate only reads
+`.dbmate.yml` from v2.28 onwards; earlier versions silently ignore it and fall
+back to the defaults, so relying on one is a trap.)
+
+Run dbmate from *this* directory, exactly as `dbmate/startup.sh` does for
+PostgreSQL from `dbmate/`:
+
+```bash
+cd dbmate/sqlite
+DATABASE_URL="sqlite:meeting-api.sqlite3" dbmate up
+```
+
+`dbmate/db/migrations` remains the source of truth for the schema. dbmate has no
+dialect layer, so a new PostgreSQL migration needs a hand-written SQLite
+counterpart here. `db/migrations/20260307000001_initial_schema.sql` documents the
+deliberate differences between the two.

--- a/dbmate/sqlite/db/migrations/20260307000001_initial_schema.sql
+++ b/dbmate/sqlite/db/migrations/20260307000001_initial_schema.sql
@@ -11,15 +11,18 @@
 -- Deviations from a literal transliteration, all deliberate:
 --
 --  * `session_participants` is omitted. It has no Rust references.
---  * Timestamps are TEXT holding RFC 3339. The application always binds
---    `chrono::Utc::now()` rather than writing `datetime('now')`, whose
---    `2026-07-21 04:39:04` rendering would not sort against RFC 3339 in the
---    same column. The DEFAULTs below emit RFC 3339 for the same reason.
+--  * Timestamps are TEXT holding RFC 3339. Where PostgreSQL writes `NOW()`,
+--    the SQLite build binds `chrono::Utc::now()` (see `db::now_expr`) rather
+--    than writing `datetime('now')`, whose `2026-07-21 04:39:04` rendering
+--    would not sort lexicographically against RFC 3339 in the same column and
+--    would break `ORDER BY created_at DESC`. The DEFAULTs below emit RFC 3339
+--    for that same reason, so a DEFAULT and a bound value stay comparable.
 --  * There are no `updated_at` triggers. SQLite evaluates `RETURNING` *before*
 --    AFTER-triggers run, so an `UPDATE ... RETURNING updated_at` driven by a
 --    trigger returns the stale value. Every UPDATE sets `updated_at`
---    explicitly instead (PostgreSQL keeps its BEFORE trigger, which writes the
---    same value a beat later).
+--    explicitly instead. PostgreSQL keeps its BEFORE trigger and overwrites
+--    that explicit write with the same `transaction_timestamp()`, so the two
+--    backends agree without the SQL diverging.
 --  * `VARCHAR(n)` becomes `TEXT` plus a `CHECK (length(col) <= n)`, because
 --    SQLite ignores type-name length limits entirely.
 
@@ -56,8 +59,12 @@ CREATE TABLE meetings (
     password_hash        TEXT CHECK (password_hash IS NULL OR length(password_hash) <= 255),
     state                TEXT NOT NULL DEFAULT 'idle'
                          CHECK (state IN ('idle', 'active', 'ended')),
+    -- `json_type(...) = 'array'` is not redundant: json_array_length returns 0
+    -- for a JSON object, so without it `{"a":1}` would pass here while
+    -- PostgreSQL's jsonb_array_length raises.
     attendees            TEXT NOT NULL DEFAULT '[]'
-                         CHECK (json_array_length(attendees) <= 100),
+                         CHECK (json_type(attendees) = 'array'
+                                AND json_array_length(attendees) <= 100),
     host_display_name    TEXT CHECK (host_display_name IS NULL OR length(host_display_name) <= 255),
     waiting_room_enabled BOOLEAN NOT NULL DEFAULT TRUE
 );
@@ -73,7 +80,8 @@ CREATE UNIQUE INDEX idx_meetings_room_id_unique_active
 
 -- Meeting participants: waiting room and admission tracking.
 -- The ON DELETE CASCADE is inert unless `PRAGMA foreign_keys = ON`, which
--- `connect_db` sets via SqliteConnectOptions::foreign_keys for every connection.
+-- `meeting_api::db::connect` sets via SqliteConnectOptions::foreign_keys on
+-- every pooled connection.
 CREATE TABLE meeting_participants (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     meeting_id   INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,

--- a/dbmate/sqlite/db/migrations/20260307000001_initial_schema.sql
+++ b/dbmate/sqlite/db/migrations/20260307000001_initial_schema.sql
@@ -1,0 +1,104 @@
+-- migrate:up
+
+-- Consolidated SQLite schema, equivalent to the PostgreSQL migration set in
+-- `dbmate/db/migrations/` through 20260307000001_rename_email_to_user_id.
+--
+-- dbmate has no dialect layer, so this file is the one place where duplication
+-- between the two backends is unavoidable. It is deliberately named after the
+-- last PostgreSQL migration it covers, so any new migration ported here sorts
+-- after it. When you add a PostgreSQL migration, add the matching SQLite one.
+--
+-- Deviations from a literal transliteration, all deliberate:
+--
+--  * `session_participants` is omitted. It has no Rust references.
+--  * Timestamps are TEXT holding RFC 3339. The application always binds
+--    `chrono::Utc::now()` rather than writing `datetime('now')`, whose
+--    `2026-07-21 04:39:04` rendering would not sort against RFC 3339 in the
+--    same column. The DEFAULTs below emit RFC 3339 for the same reason.
+--  * There are no `updated_at` triggers. SQLite evaluates `RETURNING` *before*
+--    AFTER-triggers run, so an `UPDATE ... RETURNING updated_at` driven by a
+--    trigger returns the stale value. Every UPDATE sets `updated_at`
+--    explicitly instead (PostgreSQL keeps its BEFORE trigger, which writes the
+--    same value a beat later).
+--  * `VARCHAR(n)` becomes `TEXT` plus a `CHECK (length(col) <= n)`, because
+--    SQLite ignores type-name length limits entirely.
+
+-- OAuth request storage for in-flight PKCE/CSRF flows.
+CREATE TABLE oauth_requests (
+    pkce_challenge TEXT,
+    pkce_verifier  TEXT,
+    csrf_state     TEXT,
+    return_to      TEXT,
+    nonce          TEXT CHECK (nonce IS NULL OR length(nonce) <= 255)
+);
+
+-- User accounts with OAuth tokens.
+-- `created_at` / `last_login` mirror PostgreSQL `TIMESTAMP` (no time zone) and
+-- are bound as naive datetimes, hence the space-separated DEFAULT.
+CREATE TABLE users (
+    email         TEXT PRIMARY KEY CHECK (length(email) <= 255),
+    access_token  TEXT,
+    refresh_token TEXT,
+    name          TEXT,
+    created_at    TEXT DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+    last_login    TEXT DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now'))
+);
+
+CREATE TABLE meetings (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    room_id              TEXT NOT NULL CHECK (length(room_id) <= 255),
+    started_at           TEXT NOT NULL,
+    ended_at             TEXT,
+    created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    updated_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    deleted_at           TEXT,
+    creator_id           TEXT CHECK (creator_id IS NULL OR length(creator_id) <= 255),
+    password_hash        TEXT CHECK (password_hash IS NULL OR length(password_hash) <= 255),
+    state                TEXT NOT NULL DEFAULT 'idle'
+                         CHECK (state IN ('idle', 'active', 'ended')),
+    attendees            TEXT NOT NULL DEFAULT '[]'
+                         CHECK (json_array_length(attendees) <= 100),
+    host_display_name    TEXT CHECK (host_display_name IS NULL OR length(host_display_name) <= 255),
+    waiting_room_enabled BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX idx_meetings_room_id ON meetings(room_id);
+CREATE INDEX idx_meetings_creator_id ON meetings(creator_id);
+CREATE INDEX idx_meetings_state ON meetings(state);
+
+-- Partial unique index: a room_id may be reused once the meeting is soft-deleted.
+CREATE UNIQUE INDEX idx_meetings_room_id_unique_active
+    ON meetings(room_id)
+    WHERE deleted_at IS NULL;
+
+-- Meeting participants: waiting room and admission tracking.
+-- The ON DELETE CASCADE is inert unless `PRAGMA foreign_keys = ON`, which
+-- `connect_db` sets via SqliteConnectOptions::foreign_keys for every connection.
+CREATE TABLE meeting_participants (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    meeting_id   INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+    user_id      TEXT NOT NULL CHECK (length(user_id) <= 255),
+    status       TEXT NOT NULL DEFAULT 'waiting'
+                 CHECK (status IN ('waiting', 'admitted', 'rejected', 'left')),
+    is_host      BOOLEAN NOT NULL DEFAULT FALSE,
+    is_required  BOOLEAN NOT NULL DEFAULT FALSE,
+    joined_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    admitted_at  TEXT,
+    left_at      TEXT,
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    display_name TEXT CHECK (display_name IS NULL OR length(display_name) <= 255),
+
+    CONSTRAINT uq_meeting_participant_user UNIQUE (meeting_id, user_id)
+);
+
+CREATE INDEX idx_meeting_participants_meeting_id ON meeting_participants(meeting_id);
+CREATE INDEX idx_meeting_participants_user_id ON meeting_participants(user_id);
+CREATE INDEX idx_meeting_participants_status ON meeting_participants(status);
+
+-- migrate:down
+
+DROP TABLE meeting_participants;
+DROP TABLE meetings;
+DROP TABLE users;
+DROP TABLE oauth_requests;

--- a/dbmate/sqlite/db/schema.sql
+++ b/dbmate/sqlite/db/schema.sql
@@ -26,8 +26,12 @@ CREATE TABLE meetings (
     password_hash        TEXT CHECK (password_hash IS NULL OR length(password_hash) <= 255),
     state                TEXT NOT NULL DEFAULT 'idle'
                          CHECK (state IN ('idle', 'active', 'ended')),
+    -- `json_type(...) = 'array'` is not redundant: json_array_length returns 0
+    -- for a JSON object, so without it `{"a":1}` would pass here while
+    -- PostgreSQL's jsonb_array_length raises.
     attendees            TEXT NOT NULL DEFAULT '[]'
-                         CHECK (json_array_length(attendees) <= 100),
+                         CHECK (json_type(attendees) = 'array'
+                                AND json_array_length(attendees) <= 100),
     host_display_name    TEXT CHECK (host_display_name IS NULL OR length(host_display_name) <= 255),
     waiting_room_enabled BOOLEAN NOT NULL DEFAULT TRUE
 );

--- a/dbmate/sqlite/db/schema.sql
+++ b/dbmate/sqlite/db/schema.sql
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS "schema_migrations" (version varchar(128) primary key);
+CREATE TABLE oauth_requests (
+    pkce_challenge TEXT,
+    pkce_verifier  TEXT,
+    csrf_state     TEXT,
+    return_to      TEXT,
+    nonce          TEXT CHECK (nonce IS NULL OR length(nonce) <= 255)
+);
+CREATE TABLE users (
+    email         TEXT PRIMARY KEY CHECK (length(email) <= 255),
+    access_token  TEXT,
+    refresh_token TEXT,
+    name          TEXT,
+    created_at    TEXT DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+    last_login    TEXT DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now'))
+);
+CREATE TABLE meetings (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    room_id              TEXT NOT NULL CHECK (length(room_id) <= 255),
+    started_at           TEXT NOT NULL,
+    ended_at             TEXT,
+    created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    updated_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    deleted_at           TEXT,
+    creator_id           TEXT CHECK (creator_id IS NULL OR length(creator_id) <= 255),
+    password_hash        TEXT CHECK (password_hash IS NULL OR length(password_hash) <= 255),
+    state                TEXT NOT NULL DEFAULT 'idle'
+                         CHECK (state IN ('idle', 'active', 'ended')),
+    attendees            TEXT NOT NULL DEFAULT '[]'
+                         CHECK (json_array_length(attendees) <= 100),
+    host_display_name    TEXT CHECK (host_display_name IS NULL OR length(host_display_name) <= 255),
+    waiting_room_enabled BOOLEAN NOT NULL DEFAULT TRUE
+);
+CREATE INDEX idx_meetings_room_id ON meetings(room_id);
+CREATE INDEX idx_meetings_creator_id ON meetings(creator_id);
+CREATE INDEX idx_meetings_state ON meetings(state);
+CREATE UNIQUE INDEX idx_meetings_room_id_unique_active
+    ON meetings(room_id)
+    WHERE deleted_at IS NULL;
+CREATE TABLE meeting_participants (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    meeting_id   INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+    user_id      TEXT NOT NULL CHECK (length(user_id) <= 255),
+    status       TEXT NOT NULL DEFAULT 'waiting'
+                 CHECK (status IN ('waiting', 'admitted', 'rejected', 'left')),
+    is_host      BOOLEAN NOT NULL DEFAULT FALSE,
+    is_required  BOOLEAN NOT NULL DEFAULT FALSE,
+    joined_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    admitted_at  TEXT,
+    left_at      TEXT,
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')),
+    display_name TEXT CHECK (display_name IS NULL OR length(display_name) <= 255),
+
+    CONSTRAINT uq_meeting_participant_user UNIQUE (meeting_id, user_id)
+);
+CREATE INDEX idx_meeting_participants_meeting_id ON meeting_participants(meeting_id);
+CREATE INDEX idx_meeting_participants_user_id ON meeting_participants(user_id);
+CREATE INDEX idx_meeting_participants_status ON meeting_participants(status);
+-- Dbmate schema migrations
+INSERT INTO "schema_migrations" (version) VALUES
+  ('20260307000001');

--- a/meeting-api/Cargo.toml
+++ b/meeting-api/Cargo.toml
@@ -17,6 +17,14 @@ path = "src/lib.rs"
 name = "meeting-api"
 path = "src/main.rs"
 
+[features]
+default = ["postgres"]
+# Exactly one backend feature must be enabled; `db::mod` enforces this with
+# `compile_error!` so `--all-features` fails loudly instead of silently
+# defining `DbPool` twice.
+postgres = ["sqlx/postgres"]
+sqlite = ["sqlx/sqlite"]
+
 [dependencies]
 videocall-meeting-types = { path = "../videocall-meeting-types", version = "0.2.0" }
 videocall-types = { path = "../videocall-types", version = "6.0.0" }
@@ -28,7 +36,7 @@ axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }
 
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "json"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "chrono", "json"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/meeting-api/src/auth.rs
+++ b/meeting-api/src/auth.rs
@@ -108,7 +108,6 @@ mod tests {
     use super::*;
     use crate::token::generate_session_token;
     use axum::http::Request;
-    use sqlx::postgres::PgPoolOptions;
 
     const TEST_SECRET: &str = "test-secret-for-auth-tests";
 
@@ -119,9 +118,15 @@ mod tests {
     fn make_state_with_cookie_name(name: &str) -> AppState {
         // connect_lazy creates a pool handle without actually connecting.
         // The URL is never used because no queries are executed in unit tests.
-        let db = PgPoolOptions::new()
+        #[cfg(feature = "postgres")]
+        let db = sqlx::postgres::PgPoolOptions::new()
             .max_connections(1)
             .connect_lazy("postgres://localhost/unused")
+            .expect("lazy pool creation should not fail");
+        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("sqlite::memory:")
             .expect("lazy pool creation should not fail");
         AppState {
             db,

--- a/meeting-api/src/config.rs
+++ b/meeting-api/src/config.rs
@@ -83,7 +83,12 @@ impl Config {
     /// Load configuration from environment variables.
     ///
     /// # Required
-    /// - `DATABASE_URL`
+    /// - `DATABASE_URL` — the scheme selects the backend and must match the build:
+    ///   - PostgreSQL (default build): `postgres://user:pass@host:5432/dbname`
+    ///   - SQLite (build with `--no-default-features --features sqlite`):
+    ///     `sqlite:/var/lib/videocall/meeting-api.sqlite3`. The file must already
+    ///     exist and be migrated (`dbmate up` against `dbmate/sqlite`) on a
+    ///     persistent volume; the server fails fast at startup if it is missing.
     /// - `JWT_SECRET`
     ///
     /// # Optional

--- a/meeting-api/src/db/lock.rs
+++ b/meeting-api/src/db/lock.rs
@@ -11,24 +11,17 @@
  * at your option.
  */
 
-//! Write-transaction primitives, the one place the two dialects genuinely differ.
+//! Write-transaction primitives.
 //!
-//! Two code paths mutate the waiting room and must serialize against each other:
-//! [`crate::db::participants::join_attendee`] (reads `waiting_room_enabled`,
-//! then inserts the participant as `waiting` or `admitted`) and
-//! [`crate::db::meetings::update_waiting_room_enabled`] (flips the flag and, when
-//! disabling, admits everyone who is currently waiting). If they interleave, a
-//! participant can be parked in the waiting room of a meeting whose waiting room
-//! was just turned off, and nothing will ever admit them.
+//! `join_attendee` (reads `waiting_room_enabled`, then inserts) and
+//! `update_waiting_room_enabled` (flips the flag, admits the waiting) must
+//! serialize, or an attendee lands in the waiting room of a meeting whose
+//! waiting room was just turned off and is never admitted. PostgreSQL serializes
+//! them with `SELECT ... FOR UPDATE`; SQLite has no row locks, so the
+//! transaction takes the database write lock up front with `BEGIN IMMEDIATE`.
 //!
-//! PostgreSQL serializes them with `SELECT ... FOR UPDATE` on the `meetings` row.
-//! SQLite has no row locks, so the transaction has to take the database write
-//! lock up front with `BEGIN IMMEDIATE`; a deferred transaction that upgrades to
-//! a write mid-flight can fail with `SQLITE_BUSY_SNAPSHOT` and, worse, would have
-//! read the flag before taking the lock.
-//!
-//! **Both** paths must use [`begin_write`]. Making only one of them immediate
-//! moves the race rather than closing it.
+//! Both paths must use [`begin_write`] — making only one immediate moves the
+//! race rather than closing it.
 
 use crate::db::DbPool;
 use futures::future::BoxFuture;
@@ -41,24 +34,21 @@ pub type Db = sqlx::Postgres;
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub type Db = sqlx::Sqlite;
 
-/// A transaction that has already taken whatever write lock the backend needs.
+/// A transaction that already holds the backend's write lock.
 pub type WriteTransaction = sqlx::Transaction<'static, Db>;
 
-/// Read `waiting_room_enabled` for one meeting under the transaction's write lock.
-///
-/// On PostgreSQL the row lock is acquired by this statement. On SQLite the
-/// database write lock was already acquired by `BEGIN IMMEDIATE`, so the plain
-/// `SELECT` is equally serialized.
+/// Read `waiting_room_enabled` under the write lock: `FOR UPDATE` locks the row
+/// on PostgreSQL; on SQLite `BEGIN IMMEDIATE` already holds the write lock.
 #[cfg(feature = "postgres")]
 pub const SELECT_WAITING_ROOM_LOCKED: &str =
     "SELECT waiting_room_enabled FROM meetings WHERE id = $1 FOR UPDATE";
 
-/// Read `waiting_room_enabled` for one meeting under the transaction's write lock.
+/// See the PostgreSQL variant.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub const SELECT_WAITING_ROOM_LOCKED: &str =
     "SELECT waiting_room_enabled FROM meetings WHERE id = $1";
 
-/// Begin a transaction intended to write, acquiring the write lock immediately.
+/// Begin a write transaction, acquiring the write lock immediately.
 #[cfg(feature = "postgres")]
 pub async fn begin_write(pool: &DbPool) -> Result<WriteTransaction, sqlx::Error> {
     pool.begin().await
@@ -70,10 +60,8 @@ pub async fn begin_write(pool: &DbPool) -> Result<WriteTransaction, sqlx::Error>
     pool.begin_with("BEGIN IMMEDIATE").await
 }
 
-/// Run a write transaction, retrying it if the backend reports lock contention.
-///
-/// PostgreSQL takes row locks and waits, so this simply awaits `op` once and the
-/// behaviour is unchanged from before the SQLite work.
+/// Await `op` once. PostgreSQL waits on its row locks, so there is nothing to
+/// retry.
 #[cfg(feature = "postgres")]
 pub async fn with_write_retry<'a, T, F>(mut op: F) -> Result<T, sqlx::Error>
 where
@@ -82,32 +70,17 @@ where
     op().await
 }
 
-/// Run a write transaction, retrying it if SQLite reports `SQLITE_BUSY` /
-/// `SQLITE_LOCKED`.
+/// Retry `op` while SQLite reports `SQLITE_BUSY` / `SQLITE_LOCKED`.
 ///
-/// `busy_timeout` (set on every pooled connection by [`crate::db::connect`])
-/// already makes SQLite spin internally, so reaching this retry means contention
-/// outlasted that timeout. `op` must be replayable — either it opens its own
-/// transaction, which a failed attempt has already rolled back, or it is a
-/// single autocommit statement, which applied nothing if it failed.
+/// `op` must be replayable — it owns its transaction (rolled back on failure) or
+/// is one autocommit statement. Bounded by [`RETRY_DEADLINE`] wall-clock, not an
+/// attempt count: an attempt can itself burn `busy_timeout` (5s in production),
+/// so counting attempts would hold an HTTP handler open long past the caller's
+/// timeout. The deadline gates *starting* an attempt, not interrupting one, so
+/// the worst case is `RETRY_DEADLINE + busy_timeout`.
 ///
-/// # Latency budget
-///
-/// Retries are bounded by [`RETRY_DEADLINE`] wall-clock, not by an attempt
-/// count. This is a real-time conferencing API sitting behind a client timeout:
-/// a bound of "5 attempts" is really "5 × `busy_timeout` + backoff", which at
-/// the production `busy_timeout` of 5s is ~25s of an HTTP handler holding a
-/// connection open long after the caller has given up.
-///
-/// The deadline gates *starting* a new attempt, so the true worst case is
-/// `RETRY_DEADLINE + busy_timeout` (~8s) — an attempt already in flight is not
-/// interrupted, because cancelling a transaction mid-commit is worse than
-/// waiting for it.
-///
-/// Only lock contention is retried. Notably [`sqlx::Error::PoolTimedOut`] is
-/// passed straight through: it means every connection is checked out, so
-/// retrying would queue behind the same exhausted pool and multiply a 30s
-/// acquire timeout rather than shorten it.
+/// Only contention is retried; [`sqlx::Error::PoolTimedOut`] passes through,
+/// since retrying an exhausted pool only multiplies its acquire timeout.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub async fn with_write_retry<'a, T, F>(mut op: F) -> Result<T, sqlx::Error>
 where
@@ -151,12 +124,10 @@ const BASE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(20);
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
 
-/// Whether an error is SQLite refusing to take the write lock.
+/// Whether an error is SQLite refusing the write lock (`SQLITE_BUSY` / `LOCKED`).
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 fn is_lock_contention(err: &sqlx::Error) -> bool {
-    /// `SQLITE_BUSY`
     const BUSY: i32 = 5;
-    /// `SQLITE_LOCKED`
     const LOCKED: i32 = 6;
 
     let sqlx::Error::Database(db_err) = err else {
@@ -165,7 +136,7 @@ fn is_lock_contention(err: &sqlx::Error) -> bool {
     let Some(code) = db_err.code() else {
         return false;
     };
-    // sqlx surfaces SQLite's *extended* result code; the primary code is the
-    // low byte (e.g. 517 = SQLITE_BUSY_SNAPSHOT -> 5).
+    // sqlx reports the extended result code; the primary code is the low byte
+    // (e.g. 517 = SQLITE_BUSY_SNAPSHOT -> 5).
     matches!(code.parse::<i32>().map(|c| c & 0xff), Ok(BUSY | LOCKED))
 }

--- a/meeting-api/src/db/lock.rs
+++ b/meeting-api/src/db/lock.rs
@@ -85,36 +85,71 @@ where
 /// Run a write transaction, retrying it if SQLite reports `SQLITE_BUSY` /
 /// `SQLITE_LOCKED`.
 ///
-/// `busy_timeout` (set on every pooled connection in `main.rs`) already makes
-/// SQLite spin internally, so reaching this retry means contention outlasted
-/// that timeout. `op` must open its own transaction: a failed attempt has been
-/// rolled back, which is what makes replaying it safe.
+/// `busy_timeout` (set on every pooled connection by [`crate::db::connect`])
+/// already makes SQLite spin internally, so reaching this retry means contention
+/// outlasted that timeout. `op` must be replayable — either it opens its own
+/// transaction, which a failed attempt has already rolled back, or it is a
+/// single autocommit statement, which applied nothing if it failed.
+///
+/// # Latency budget
+///
+/// Retries are bounded by [`RETRY_DEADLINE`] wall-clock, not by an attempt
+/// count. This is a real-time conferencing API sitting behind a client timeout:
+/// a bound of "5 attempts" is really "5 × `busy_timeout` + backoff", which at
+/// the production `busy_timeout` of 5s is ~25s of an HTTP handler holding a
+/// connection open long after the caller has given up.
+///
+/// The deadline gates *starting* a new attempt, so the true worst case is
+/// `RETRY_DEADLINE + busy_timeout` (~8s) — an attempt already in flight is not
+/// interrupted, because cancelling a transaction mid-commit is worse than
+/// waiting for it.
+///
+/// Only lock contention is retried. Notably [`sqlx::Error::PoolTimedOut`] is
+/// passed straight through: it means every connection is checked out, so
+/// retrying would queue behind the same exhausted pool and multiply a 30s
+/// acquire timeout rather than shorten it.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub async fn with_write_retry<'a, T, F>(mut op: F) -> Result<T, sqlx::Error>
 where
     F: FnMut() -> BoxFuture<'a, Result<T, sqlx::Error>>,
 {
-    use std::time::Duration;
+    use std::time::Instant;
 
-    const MAX_ATTEMPTS: u32 = 5;
-    const BASE_BACKOFF: Duration = Duration::from_millis(20);
-
+    let started = Instant::now();
+    let mut backoff = BASE_BACKOFF;
     let mut attempt: u32 = 1;
+
     loop {
         match op().await {
-            Err(err) if attempt < MAX_ATTEMPTS && is_lock_contention(&err) => {
-                let backoff = BASE_BACKOFF * (1 << (attempt - 1));
+            Err(err)
+                if is_lock_contention(&err)
+                    && started.elapsed().saturating_add(backoff) < RETRY_DEADLINE =>
+            {
                 tracing::warn!(
-                    "SQLite write contention on attempt {attempt}/{MAX_ATTEMPTS}, \
-                     retrying in {backoff:?}: {err}"
+                    "SQLite write contention on attempt {attempt} ({:?} elapsed of {RETRY_DEADLINE:?}), \
+                     retrying in {backoff:?}: {err}",
+                    started.elapsed()
                 );
                 tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
                 attempt += 1;
             }
             result => return result,
         }
     }
 }
+
+/// How long [`with_write_retry`] may keep starting fresh attempts.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub const RETRY_DEADLINE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Delay before the first retry; doubles up to [`MAX_BACKOFF`].
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+const BASE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// Ceiling on the exponential backoff, so a long deadline still retries often.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// Whether an error is SQLite refusing to take the write lock.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]

--- a/meeting-api/src/db/lock.rs
+++ b/meeting-api/src/db/lock.rs
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ *
+ * at your option.
+ */
+
+//! Write-transaction primitives, the one place the two dialects genuinely differ.
+//!
+//! Two code paths mutate the waiting room and must serialize against each other:
+//! [`crate::db::participants::join_attendee`] (reads `waiting_room_enabled`,
+//! then inserts the participant as `waiting` or `admitted`) and
+//! [`crate::db::meetings::update_waiting_room_enabled`] (flips the flag and, when
+//! disabling, admits everyone who is currently waiting). If they interleave, a
+//! participant can be parked in the waiting room of a meeting whose waiting room
+//! was just turned off, and nothing will ever admit them.
+//!
+//! PostgreSQL serializes them with `SELECT ... FOR UPDATE` on the `meetings` row.
+//! SQLite has no row locks, so the transaction has to take the database write
+//! lock up front with `BEGIN IMMEDIATE`; a deferred transaction that upgrades to
+//! a write mid-flight can fail with `SQLITE_BUSY_SNAPSHOT` and, worse, would have
+//! read the flag before taking the lock.
+//!
+//! **Both** paths must use [`begin_write`]. Making only one of them immediate
+//! moves the race rather than closing it.
+
+use crate::db::DbPool;
+use futures::future::BoxFuture;
+
+/// The compiled-in sqlx driver.
+#[cfg(feature = "postgres")]
+pub type Db = sqlx::Postgres;
+
+/// The compiled-in sqlx driver.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub type Db = sqlx::Sqlite;
+
+/// A transaction that has already taken whatever write lock the backend needs.
+pub type WriteTransaction = sqlx::Transaction<'static, Db>;
+
+/// Read `waiting_room_enabled` for one meeting under the transaction's write lock.
+///
+/// On PostgreSQL the row lock is acquired by this statement. On SQLite the
+/// database write lock was already acquired by `BEGIN IMMEDIATE`, so the plain
+/// `SELECT` is equally serialized.
+#[cfg(feature = "postgres")]
+pub const SELECT_WAITING_ROOM_LOCKED: &str =
+    "SELECT waiting_room_enabled FROM meetings WHERE id = $1 FOR UPDATE";
+
+/// Read `waiting_room_enabled` for one meeting under the transaction's write lock.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub const SELECT_WAITING_ROOM_LOCKED: &str =
+    "SELECT waiting_room_enabled FROM meetings WHERE id = $1";
+
+/// Begin a transaction intended to write, acquiring the write lock immediately.
+#[cfg(feature = "postgres")]
+pub async fn begin_write(pool: &DbPool) -> Result<WriteTransaction, sqlx::Error> {
+    pool.begin().await
+}
+
+/// Begin a transaction intended to write, acquiring the write lock immediately.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub async fn begin_write(pool: &DbPool) -> Result<WriteTransaction, sqlx::Error> {
+    pool.begin_with("BEGIN IMMEDIATE").await
+}
+
+/// Run a write transaction, retrying it if the backend reports lock contention.
+///
+/// PostgreSQL takes row locks and waits, so this simply awaits `op` once and the
+/// behaviour is unchanged from before the SQLite work.
+#[cfg(feature = "postgres")]
+pub async fn with_write_retry<'a, T, F>(mut op: F) -> Result<T, sqlx::Error>
+where
+    F: FnMut() -> BoxFuture<'a, Result<T, sqlx::Error>>,
+{
+    op().await
+}
+
+/// Run a write transaction, retrying it if SQLite reports `SQLITE_BUSY` /
+/// `SQLITE_LOCKED`.
+///
+/// `busy_timeout` (set on every pooled connection in `main.rs`) already makes
+/// SQLite spin internally, so reaching this retry means contention outlasted
+/// that timeout. `op` must open its own transaction: a failed attempt has been
+/// rolled back, which is what makes replaying it safe.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub async fn with_write_retry<'a, T, F>(mut op: F) -> Result<T, sqlx::Error>
+where
+    F: FnMut() -> BoxFuture<'a, Result<T, sqlx::Error>>,
+{
+    use std::time::Duration;
+
+    const MAX_ATTEMPTS: u32 = 5;
+    const BASE_BACKOFF: Duration = Duration::from_millis(20);
+
+    let mut attempt: u32 = 1;
+    loop {
+        match op().await {
+            Err(err) if attempt < MAX_ATTEMPTS && is_lock_contention(&err) => {
+                let backoff = BASE_BACKOFF * (1 << (attempt - 1));
+                tracing::warn!(
+                    "SQLite write contention on attempt {attempt}/{MAX_ATTEMPTS}, \
+                     retrying in {backoff:?}: {err}"
+                );
+                tokio::time::sleep(backoff).await;
+                attempt += 1;
+            }
+            result => return result,
+        }
+    }
+}
+
+/// Whether an error is SQLite refusing to take the write lock.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+fn is_lock_contention(err: &sqlx::Error) -> bool {
+    /// `SQLITE_BUSY`
+    const BUSY: i32 = 5;
+    /// `SQLITE_LOCKED`
+    const LOCKED: i32 = 6;
+
+    let sqlx::Error::Database(db_err) = err else {
+        return false;
+    };
+    let Some(code) = db_err.code() else {
+        return false;
+    };
+    // sqlx surfaces SQLite's *extended* result code; the primary code is the
+    // low byte (e.g. 517 = SQLITE_BUSY_SNAPSHOT -> 5).
+    matches!(code.parse::<i32>().map(|c| c & 0xff), Ok(BUSY | LOCKED))
+}

--- a/meeting-api/src/db/meetings.rs
+++ b/meeting-api/src/db/meetings.rs
@@ -13,24 +13,16 @@
 
 //! Meeting table queries.
 //!
-//! # `updated_at` on UPDATE
-//!
-//! Every `UPDATE` here sets `updated_at` explicitly, via [`crate::db::now_expr`].
-//! On SQLite that is the only thing maintaining the column: the port has no
-//! `updated_at` trigger, because SQLite evaluates `RETURNING` *before*
-//! AFTER-triggers fire and a trigger-driven value would come back stale.
-//!
-//! On PostgreSQL the write is redundant — the `update_meetings_updated_at`
-//! `BEFORE UPDATE` trigger overwrites it. It is not, however, a *divergent*
-//! write: `NOW()` is `transaction_timestamp()`, so the statement and the trigger
-//! that fires inside it produce the identical value. That is what lets the same
-//! SQL serve both backends without changing what PostgreSQL stores. Do not
-//! "optimize" these away — SQLite depends on them.
+//! Every `UPDATE` sets `updated_at` explicitly. On SQLite that is the only thing
+//! maintaining the column (no `updated_at` trigger, because SQLite evaluates
+//! `RETURNING` before AFTER-triggers). On PostgreSQL the `BEFORE UPDATE` trigger
+//! overwrites it with the same `transaction_timestamp()`, so the write is
+//! redundant but not divergent — do not drop it, SQLite depends on it.
 
 use chrono::{DateTime, Utc};
 use serde_json::Value as JsonValue;
 
-use crate::db::{bind_now, lock, now_expr, q, DbPool};
+use crate::db::{bind_now, lock, now_sql, q, with_retry, DbPool};
 
 /// Row returned from the `meetings` table.
 #[derive(Debug, sqlx::FromRow)]
@@ -51,12 +43,21 @@ pub struct MeetingRow {
     pub waiting_room_enabled: bool,
 }
 
+const MEETING_COLUMNS: &str = "id, room_id, started_at, ended_at, created_at, updated_at, \
+    deleted_at, creator_id, password_hash, state, attendees, host_display_name, \
+    waiting_room_enabled";
+
+/// Render a write statement: substitute `{cols}` and `{now}` (at `slot`), rewrite
+/// placeholders. Pair with `bind_now!`.
+fn stmt(template: &str, slot: usize) -> String {
+    now_sql(&template.replace("{cols}", MEETING_COLUMNS), slot)
+}
+
 /// Create a new meeting.
 ///
-/// A `room_id` already in use by a live meeting violates the partial unique
-/// index `idx_meetings_room_id_unique_active` and surfaces as a unique-violation
-/// error for the caller to map; the index is partial, so a `room_id` becomes
-/// available again once its meeting is soft-deleted.
+/// A `room_id` already live violates `idx_meetings_room_id_unique_active` and
+/// surfaces as a unique violation; the index is partial, so a `room_id` frees up
+/// once its meeting is soft-deleted.
 pub async fn create(
     pool: &DbPool,
     room_id: &str,
@@ -76,19 +77,13 @@ pub async fn create_with_options(
     attendees: &JsonValue,
     waiting_room_enabled: bool,
 ) -> Result<MeetingRow, sqlx::Error> {
-    // `created_at` / `updated_at` are left to the column DEFAULTs on both
-    // backends, which is the database's clock in each case.
-    let sql = format!(
-        r#"
-        INSERT INTO meetings (room_id, creator_id, started_at, password_hash, state, attendees, waiting_room_enabled)
-        VALUES ($1, $2, {now}, $3, 'idle', $4, $5)
-        RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
-                  deleted_at, creator_id, password_hash, state, attendees, host_display_name,
-                  waiting_room_enabled
-        "#,
-        now = now_expr(6)
+    // `created_at` / `updated_at` are left to the column DEFAULTs (the DB clock).
+    let sql = stmt(
+        "INSERT INTO meetings (room_id, creator_id, started_at, password_hash, state, attendees, waiting_room_enabled)
+         VALUES ($1, $2, {now}, $3, 'idle', $4, $5)
+         RETURNING {cols}",
+        6,
     );
-    let sql = q(&sql);
     bind_now!(sqlx::query_as::<_, MeetingRow>(&sql)
         .bind(room_id)
         .bind(creator_id)
@@ -104,13 +99,9 @@ pub async fn get_by_room_id(
     pool: &DbPool,
     room_id: &str,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(&q(r#"
-        SELECT id, room_id, started_at, ended_at, created_at, updated_at,
-               deleted_at, creator_id, password_hash, state, attendees, host_display_name,
-               waiting_room_enabled
-        FROM meetings
-        WHERE room_id = $1 AND deleted_at IS NULL
-        "#))
+    sqlx::query_as::<_, MeetingRow>(&q(&format!(
+        "SELECT {MEETING_COLUMNS} FROM meetings WHERE room_id = $1 AND deleted_at IS NULL"
+    )))
     .bind(room_id)
     .fetch_optional(pool)
     .await
@@ -123,15 +114,10 @@ pub async fn list_by_owner(
     limit: i64,
     offset: i64,
 ) -> Result<Vec<MeetingRow>, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(&q(r#"
-        SELECT id, room_id, started_at, ended_at, created_at, updated_at,
-               deleted_at, creator_id, password_hash, state, attendees, host_display_name,
-               waiting_room_enabled
-        FROM meetings
-        WHERE deleted_at IS NULL AND creator_id = $1
-        ORDER BY created_at DESC
-        LIMIT $2 OFFSET $3
-        "#))
+    sqlx::query_as::<_, MeetingRow>(&q(&format!(
+        "SELECT {MEETING_COLUMNS} FROM meetings WHERE deleted_at IS NULL AND creator_id = $1 \
+         ORDER BY created_at DESC LIMIT $2 OFFSET $3"
+    )))
     .bind(creator_id)
     .bind(limit)
     .bind(offset)
@@ -156,18 +142,12 @@ pub async fn soft_delete(
     room_id: &str,
     creator_id: &str,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
-    let sql = format!(
-        r#"
-        UPDATE meetings
-        SET deleted_at = {now}, updated_at = {now}
-        WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
-        RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
-                  deleted_at, creator_id, password_hash, state, attendees, host_display_name,
-                  waiting_room_enabled
-        "#,
-        now = now_expr(3)
+    let sql = stmt(
+        "UPDATE meetings SET deleted_at = {now}, updated_at = {now}
+         WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
+         RETURNING {cols}",
+        3,
     );
-    let sql = q(&sql);
     bind_now!(sqlx::query_as::<_, MeetingRow>(&sql)
         .bind(room_id)
         .bind(creator_id))
@@ -177,11 +157,10 @@ pub async fn soft_delete(
 
 /// Activate a meeting (set state to 'active').
 pub async fn activate(pool: &DbPool, meeting_id: i32) -> Result<(), sqlx::Error> {
-    let sql = format!(
+    let sql = now_sql(
         "UPDATE meetings SET state = 'active', updated_at = {now} WHERE id = $1",
-        now = now_expr(2)
+        2,
     );
-    let sql = q(&sql);
     bind_now!(sqlx::query(&sql).bind(meeting_id))
         .execute(pool)
         .await?;
@@ -190,11 +169,10 @@ pub async fn activate(pool: &DbPool, meeting_id: i32) -> Result<(), sqlx::Error>
 
 /// End a meeting (set state to 'ended', set ended_at).
 pub async fn end_meeting(pool: &DbPool, meeting_id: i32) -> Result<(), sqlx::Error> {
-    let sql = format!(
+    let sql = now_sql(
         "UPDATE meetings SET state = 'ended', ended_at = {now}, updated_at = {now} WHERE id = $1",
-        now = now_expr(2)
+        2,
     );
-    let sql = q(&sql);
     bind_now!(sqlx::query(&sql).bind(meeting_id))
         .execute(pool)
         .await?;
@@ -207,82 +185,58 @@ pub async fn set_host_display_name(
     meeting_id: i32,
     display_name: &str,
 ) -> Result<(), sqlx::Error> {
-    let sql = format!(
+    let sql = now_sql(
         "UPDATE meetings SET host_display_name = $1, updated_at = {now} WHERE id = $2",
-        now = now_expr(3)
+        3,
     );
-    let sql = q(&sql);
     bind_now!(sqlx::query(&sql).bind(display_name).bind(meeting_id))
         .execute(pool)
         .await?;
     Ok(())
 }
 
-/// Atomically update the waiting_room_enabled setting for a meeting.
-/// When disabling the waiting room, auto-admits all currently waiting participants
-/// within the same transaction to prevent race conditions.
+/// Atomically update `waiting_room_enabled`, admitting everyone waiting when it
+/// is turned off — in one transaction so a concurrent join cannot strand.
 ///
-/// Opens the transaction through [`lock::begin_write`] so it takes the write lock
-/// up front, matching [`crate::db::participants::join_attendee`]. If only one of
-/// the two were immediate the race would simply move to the other side.
+/// Takes the write lock up front via [`lock::begin_write`], matching
+/// [`crate::db::participants::join_attendee`]; only one side being immediate
+/// would move the race, not close it.
 pub async fn update_waiting_room_enabled(
     pool: &DbPool,
     room_id: &str,
     creator_id: &str,
     enabled: bool,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
-    lock::with_write_retry(|| {
-        Box::pin(update_waiting_room_enabled_txn(
-            pool, room_id, creator_id, enabled,
-        ))
-    })
-    .await
-}
+    with_retry! {
+        let mut tx = lock::begin_write(pool).await?;
 
-/// One attempt of [`update_waiting_room_enabled`]. Replayable: a failure rolls
-/// the transaction back before returning.
-async fn update_waiting_room_enabled_txn(
-    pool: &DbPool,
-    room_id: &str,
-    creator_id: &str,
-    enabled: bool,
-) -> Result<Option<MeetingRow>, sqlx::Error> {
-    let mut tx = lock::begin_write(pool).await?;
+        let sql = stmt(
+            "UPDATE meetings SET waiting_room_enabled = $3, updated_at = {now}
+             WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
+             RETURNING {cols}",
+            4,
+        );
+        let updated = bind_now!(sqlx::query_as::<_, MeetingRow>(&sql)
+            .bind(room_id)
+            .bind(creator_id)
+            .bind(enabled))
+        .fetch_optional(&mut *tx)
+        .await?;
 
-    let sql = format!(
-        r#"
-        UPDATE meetings
-        SET waiting_room_enabled = $3, updated_at = {now}
-        WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
-        RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
-                  deleted_at, creator_id, password_hash, state, attendees, host_display_name,
-                  waiting_room_enabled
-        "#,
-        now = now_expr(4)
-    );
-    let sql = q(&sql);
-    let updated = bind_now!(sqlx::query_as::<_, MeetingRow>(&sql)
-        .bind(room_id)
-        .bind(creator_id)
-        .bind(enabled))
-    .fetch_optional(&mut *tx)
-    .await?;
-
-    // When disabling the waiting room, admit everyone currently waiting.
-    if let Some(ref row) = updated {
-        if !enabled {
-            let sql = format!(
-                "UPDATE meeting_participants SET status = 'admitted', admitted_at = {now}, \
-                 updated_at = {now} WHERE meeting_id = $1 AND status = 'waiting'",
-                now = now_expr(2)
-            );
-            let sql = q(&sql);
-            bind_now!(sqlx::query(&sql).bind(row.id))
-                .execute(&mut *tx)
-                .await?;
+        if let Some(ref row) = updated {
+            if !enabled {
+                let sql = now_sql(
+                    "UPDATE meeting_participants SET status = 'admitted', admitted_at = {now}, \
+                     updated_at = {now} WHERE meeting_id = $1 AND status = 'waiting'",
+                    2,
+                );
+                bind_now!(sqlx::query(&sql).bind(row.id))
+                    .execute(&mut *tx)
+                    .await?;
+            }
         }
-    }
 
-    tx.commit().await?;
-    Ok(updated)
+        tx.commit().await?;
+        Ok(updated)
+    }
 }

--- a/meeting-api/src/db/meetings.rs
+++ b/meeting-api/src/db/meetings.rs
@@ -12,11 +12,25 @@
  */
 
 //! Meeting table queries.
+//!
+//! # `updated_at` on UPDATE
+//!
+//! Every `UPDATE` here sets `updated_at` explicitly, via [`crate::db::now_expr`].
+//! On SQLite that is the only thing maintaining the column: the port has no
+//! `updated_at` trigger, because SQLite evaluates `RETURNING` *before*
+//! AFTER-triggers fire and a trigger-driven value would come back stale.
+//!
+//! On PostgreSQL the write is redundant — the `update_meetings_updated_at`
+//! `BEFORE UPDATE` trigger overwrites it. It is not, however, a *divergent*
+//! write: `NOW()` is `transaction_timestamp()`, so the statement and the trigger
+//! that fires inside it produce the identical value. That is what lets the same
+//! SQL serve both backends without changing what PostgreSQL stores. Do not
+//! "optimize" these away — SQLite depends on them.
 
 use chrono::{DateTime, Utc};
 use serde_json::Value as JsonValue;
 
-use crate::db::{lock, q, DbPool};
+use crate::db::{bind_now, lock, now_expr, q, DbPool};
 
 /// Row returned from the `meetings` table.
 #[derive(Debug, sqlx::FromRow)]
@@ -37,7 +51,12 @@ pub struct MeetingRow {
     pub waiting_room_enabled: bool,
 }
 
-/// Create a new meeting. Uses INSERT ... ON CONFLICT to handle the partial unique index.
+/// Create a new meeting.
+///
+/// A `room_id` already in use by a live meeting violates the partial unique
+/// index `idx_meetings_room_id_unique_active` and surfaces as a unique-violation
+/// error for the caller to map; the index is partial, so a `room_id` becomes
+/// available again once its meeting is soft-deleted.
 pub async fn create(
     pool: &DbPool,
     room_id: &str,
@@ -57,21 +76,25 @@ pub async fn create_with_options(
     attendees: &JsonValue,
     waiting_room_enabled: bool,
 ) -> Result<MeetingRow, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(&q(
+    // `created_at` / `updated_at` are left to the column DEFAULTs on both
+    // backends, which is the database's clock in each case.
+    let sql = format!(
         r#"
-        INSERT INTO meetings (room_id, creator_id, started_at, password_hash, state, attendees, waiting_room_enabled, created_at, updated_at)
-        VALUES ($1, $2, $6, $3, 'idle', $4, $5, $6, $6)
+        INSERT INTO meetings (room_id, creator_id, started_at, password_hash, state, attendees, waiting_room_enabled)
+        VALUES ($1, $2, {now}, $3, 'idle', $4, $5)
         RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
                   deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                   waiting_room_enabled
         "#,
-    ))
-    .bind(room_id)
-    .bind(creator_id)
-    .bind(password_hash)
-    .bind(attendees)
-    .bind(waiting_room_enabled)
-    .bind(Utc::now())
+        now = now_expr(6)
+    );
+    let sql = q(&sql);
+    bind_now!(sqlx::query_as::<_, MeetingRow>(&sql)
+        .bind(room_id)
+        .bind(creator_id)
+        .bind(password_hash)
+        .bind(attendees)
+        .bind(waiting_room_enabled))
     .fetch_one(pool)
     .await
 }
@@ -133,42 +156,48 @@ pub async fn soft_delete(
     room_id: &str,
     creator_id: &str,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(&q(r#"
+    let sql = format!(
+        r#"
         UPDATE meetings
-        SET deleted_at = $3, updated_at = $3
+        SET deleted_at = {now}, updated_at = {now}
         WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
         RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
                   deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                   waiting_room_enabled
-        "#))
-    .bind(room_id)
-    .bind(creator_id)
-    .bind(Utc::now())
+        "#,
+        now = now_expr(3)
+    );
+    let sql = q(&sql);
+    bind_now!(sqlx::query_as::<_, MeetingRow>(&sql)
+        .bind(room_id)
+        .bind(creator_id))
     .fetch_optional(pool)
     .await
 }
 
 /// Activate a meeting (set state to 'active').
 pub async fn activate(pool: &DbPool, meeting_id: i32) -> Result<(), sqlx::Error> {
-    sqlx::query(&q(
-        "UPDATE meetings SET state = 'active', updated_at = $2 WHERE id = $1",
-    ))
-    .bind(meeting_id)
-    .bind(Utc::now())
-    .execute(pool)
-    .await?;
+    let sql = format!(
+        "UPDATE meetings SET state = 'active', updated_at = {now} WHERE id = $1",
+        now = now_expr(2)
+    );
+    let sql = q(&sql);
+    bind_now!(sqlx::query(&sql).bind(meeting_id))
+        .execute(pool)
+        .await?;
     Ok(())
 }
 
 /// End a meeting (set state to 'ended', set ended_at).
 pub async fn end_meeting(pool: &DbPool, meeting_id: i32) -> Result<(), sqlx::Error> {
-    sqlx::query(&q(
-        "UPDATE meetings SET state = 'ended', ended_at = $2, updated_at = $2 WHERE id = $1",
-    ))
-    .bind(meeting_id)
-    .bind(Utc::now())
-    .execute(pool)
-    .await?;
+    let sql = format!(
+        "UPDATE meetings SET state = 'ended', ended_at = {now}, updated_at = {now} WHERE id = $1",
+        now = now_expr(2)
+    );
+    let sql = q(&sql);
+    bind_now!(sqlx::query(&sql).bind(meeting_id))
+        .execute(pool)
+        .await?;
     Ok(())
 }
 
@@ -178,14 +207,14 @@ pub async fn set_host_display_name(
     meeting_id: i32,
     display_name: &str,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query(&q(
-        "UPDATE meetings SET host_display_name = $1, updated_at = $3 WHERE id = $2",
-    ))
-    .bind(display_name)
-    .bind(meeting_id)
-    .bind(Utc::now())
-    .execute(pool)
-    .await?;
+    let sql = format!(
+        "UPDATE meetings SET host_display_name = $1, updated_at = {now} WHERE id = $2",
+        now = now_expr(3)
+    );
+    let sql = q(&sql);
+    bind_now!(sqlx::query(&sql).bind(display_name).bind(meeting_id))
+        .execute(pool)
+        .await?;
     Ok(())
 }
 
@@ -219,34 +248,38 @@ async fn update_waiting_room_enabled_txn(
     enabled: bool,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
     let mut tx = lock::begin_write(pool).await?;
-    let now = Utc::now();
 
-    let updated = sqlx::query_as::<_, MeetingRow>(&q(r#"
+    let sql = format!(
+        r#"
         UPDATE meetings
-        SET waiting_room_enabled = $3, updated_at = $4
+        SET waiting_room_enabled = $3, updated_at = {now}
         WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
         RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
                   deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                   waiting_room_enabled
-        "#))
-    .bind(room_id)
-    .bind(creator_id)
-    .bind(enabled)
-    .bind(now)
+        "#,
+        now = now_expr(4)
+    );
+    let sql = q(&sql);
+    let updated = bind_now!(sqlx::query_as::<_, MeetingRow>(&sql)
+        .bind(room_id)
+        .bind(creator_id)
+        .bind(enabled))
     .fetch_optional(&mut *tx)
     .await?;
 
     // When disabling the waiting room, admit everyone currently waiting.
     if let Some(ref row) = updated {
         if !enabled {
-            sqlx::query(&q(
-                "UPDATE meeting_participants SET status = 'admitted', admitted_at = $2, updated_at = $2 \
-                 WHERE meeting_id = $1 AND status = 'waiting'",
-            ))
-            .bind(row.id)
-            .bind(now)
-            .execute(&mut *tx)
-            .await?;
+            let sql = format!(
+                "UPDATE meeting_participants SET status = 'admitted', admitted_at = {now}, \
+                 updated_at = {now} WHERE meeting_id = $1 AND status = 'waiting'",
+                now = now_expr(2)
+            );
+            let sql = q(&sql);
+            bind_now!(sqlx::query(&sql).bind(row.id))
+                .execute(&mut *tx)
+                .await?;
         }
     }
 

--- a/meeting-api/src/db/meetings.rs
+++ b/meeting-api/src/db/meetings.rs
@@ -15,7 +15,8 @@
 
 use chrono::{DateTime, Utc};
 use serde_json::Value as JsonValue;
-use sqlx::PgPool;
+
+use crate::db::{lock, q, DbPool};
 
 /// Row returned from the `meetings` table.
 #[derive(Debug, sqlx::FromRow)]
@@ -38,7 +39,7 @@ pub struct MeetingRow {
 
 /// Create a new meeting. Uses INSERT ... ON CONFLICT to handle the partial unique index.
 pub async fn create(
-    pool: &PgPool,
+    pool: &DbPool,
     room_id: &str,
     creator_id: &str,
     password_hash: Option<&str>,
@@ -49,45 +50,44 @@ pub async fn create(
 
 /// Create a new meeting with explicit waiting_room_enabled setting.
 pub async fn create_with_options(
-    pool: &PgPool,
+    pool: &DbPool,
     room_id: &str,
     creator_id: &str,
     password_hash: Option<&str>,
     attendees: &JsonValue,
     waiting_room_enabled: bool,
 ) -> Result<MeetingRow, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(
+    sqlx::query_as::<_, MeetingRow>(&q(
         r#"
-        INSERT INTO meetings (room_id, creator_id, started_at, password_hash, state, attendees, waiting_room_enabled)
-        VALUES ($1, $2, NOW(), $3, 'idle', $4, $5)
+        INSERT INTO meetings (room_id, creator_id, started_at, password_hash, state, attendees, waiting_room_enabled, created_at, updated_at)
+        VALUES ($1, $2, $6, $3, 'idle', $4, $5, $6, $6)
         RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
                   deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                   waiting_room_enabled
         "#,
-    )
+    ))
     .bind(room_id)
     .bind(creator_id)
     .bind(password_hash)
     .bind(attendees)
     .bind(waiting_room_enabled)
+    .bind(Utc::now())
     .fetch_one(pool)
     .await
 }
 
 /// Get a non-deleted meeting by room_id.
 pub async fn get_by_room_id(
-    pool: &PgPool,
+    pool: &DbPool,
     room_id: &str,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(
-        r#"
+    sqlx::query_as::<_, MeetingRow>(&q(r#"
         SELECT id, room_id, started_at, ended_at, created_at, updated_at,
                deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                waiting_room_enabled
         FROM meetings
         WHERE room_id = $1 AND deleted_at IS NULL
-        "#,
-    )
+        "#))
     .bind(room_id)
     .fetch_optional(pool)
     .await
@@ -95,13 +95,12 @@ pub async fn get_by_room_id(
 
 /// List meetings owned by `creator_id` (non-deleted), ordered by created_at DESC.
 pub async fn list_by_owner(
-    pool: &PgPool,
+    pool: &DbPool,
     creator_id: &str,
     limit: i64,
     offset: i64,
 ) -> Result<Vec<MeetingRow>, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(
-        r#"
+    sqlx::query_as::<_, MeetingRow>(&q(r#"
         SELECT id, room_id, started_at, ended_at, created_at, updated_at,
                deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                waiting_room_enabled
@@ -109,8 +108,7 @@ pub async fn list_by_owner(
         WHERE deleted_at IS NULL AND creator_id = $1
         ORDER BY created_at DESC
         LIMIT $2 OFFSET $3
-        "#,
-    )
+        "#))
     .bind(creator_id)
     .bind(limit)
     .bind(offset)
@@ -119,10 +117,10 @@ pub async fn list_by_owner(
 }
 
 /// Count meetings owned by `creator_id` (non-deleted).
-pub async fn count_by_owner(pool: &PgPool, creator_id: &str) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as(
+pub async fn count_by_owner(pool: &DbPool, creator_id: &str) -> Result<i64, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as(&q(
         "SELECT COUNT(*) FROM meetings WHERE deleted_at IS NULL AND creator_id = $1",
-    )
+    ))
     .bind(creator_id)
     .fetch_one(pool)
     .await?;
@@ -131,93 +129,122 @@ pub async fn count_by_owner(pool: &PgPool, creator_id: &str) -> Result<i64, sqlx
 
 /// Soft-delete a meeting (set `deleted_at`).
 pub async fn soft_delete(
-    pool: &PgPool,
+    pool: &DbPool,
     room_id: &str,
     creator_id: &str,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
-    sqlx::query_as::<_, MeetingRow>(
-        r#"
+    sqlx::query_as::<_, MeetingRow>(&q(r#"
         UPDATE meetings
-        SET deleted_at = NOW()
+        SET deleted_at = $3, updated_at = $3
         WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
         RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
                   deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                   waiting_room_enabled
-        "#,
-    )
+        "#))
     .bind(room_id)
     .bind(creator_id)
+    .bind(Utc::now())
     .fetch_optional(pool)
     .await
 }
 
 /// Activate a meeting (set state to 'active').
-pub async fn activate(pool: &PgPool, meeting_id: i32) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE meetings SET state = 'active' WHERE id = $1")
-        .bind(meeting_id)
-        .execute(pool)
-        .await?;
+pub async fn activate(pool: &DbPool, meeting_id: i32) -> Result<(), sqlx::Error> {
+    sqlx::query(&q(
+        "UPDATE meetings SET state = 'active', updated_at = $2 WHERE id = $1",
+    ))
+    .bind(meeting_id)
+    .bind(Utc::now())
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
 /// End a meeting (set state to 'ended', set ended_at).
-pub async fn end_meeting(pool: &PgPool, meeting_id: i32) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE meetings SET state = 'ended', ended_at = NOW() WHERE id = $1")
-        .bind(meeting_id)
-        .execute(pool)
-        .await?;
+pub async fn end_meeting(pool: &DbPool, meeting_id: i32) -> Result<(), sqlx::Error> {
+    sqlx::query(&q(
+        "UPDATE meetings SET state = 'ended', ended_at = $2, updated_at = $2 WHERE id = $1",
+    ))
+    .bind(meeting_id)
+    .bind(Utc::now())
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
 /// Update the cached host display name.
 pub async fn set_host_display_name(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
     display_name: &str,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query("UPDATE meetings SET host_display_name = $1 WHERE id = $2")
-        .bind(display_name)
-        .bind(meeting_id)
-        .execute(pool)
-        .await?;
+    sqlx::query(&q(
+        "UPDATE meetings SET host_display_name = $1, updated_at = $3 WHERE id = $2",
+    ))
+    .bind(display_name)
+    .bind(meeting_id)
+    .bind(Utc::now())
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
 /// Atomically update the waiting_room_enabled setting for a meeting.
 /// When disabling the waiting room, auto-admits all currently waiting participants
 /// within the same transaction to prevent race conditions.
+///
+/// Opens the transaction through [`lock::begin_write`] so it takes the write lock
+/// up front, matching [`crate::db::participants::join_attendee`]. If only one of
+/// the two were immediate the race would simply move to the other side.
 pub async fn update_waiting_room_enabled(
-    pool: &PgPool,
+    pool: &DbPool,
     room_id: &str,
     creator_id: &str,
     enabled: bool,
 ) -> Result<Option<MeetingRow>, sqlx::Error> {
-    let mut tx = pool.begin().await?;
+    lock::with_write_retry(|| {
+        Box::pin(update_waiting_room_enabled_txn(
+            pool, room_id, creator_id, enabled,
+        ))
+    })
+    .await
+}
 
-    let updated = sqlx::query_as::<_, MeetingRow>(
-        r#"
+/// One attempt of [`update_waiting_room_enabled`]. Replayable: a failure rolls
+/// the transaction back before returning.
+async fn update_waiting_room_enabled_txn(
+    pool: &DbPool,
+    room_id: &str,
+    creator_id: &str,
+    enabled: bool,
+) -> Result<Option<MeetingRow>, sqlx::Error> {
+    let mut tx = lock::begin_write(pool).await?;
+    let now = Utc::now();
+
+    let updated = sqlx::query_as::<_, MeetingRow>(&q(r#"
         UPDATE meetings
-        SET waiting_room_enabled = $3
+        SET waiting_room_enabled = $3, updated_at = $4
         WHERE room_id = $1 AND creator_id = $2 AND deleted_at IS NULL
         RETURNING id, room_id, started_at, ended_at, created_at, updated_at,
                   deleted_at, creator_id, password_hash, state, attendees, host_display_name,
                   waiting_room_enabled
-        "#,
-    )
+        "#))
     .bind(room_id)
     .bind(creator_id)
     .bind(enabled)
+    .bind(now)
     .fetch_optional(&mut *tx)
     .await?;
 
     // When disabling the waiting room, admit everyone currently waiting.
     if let Some(ref row) = updated {
         if !enabled {
-            sqlx::query(
-                "UPDATE meeting_participants SET status = 'admitted', admitted_at = NOW() \
+            sqlx::query(&q(
+                "UPDATE meeting_participants SET status = 'admitted', admitted_at = $2, updated_at = $2 \
                  WHERE meeting_id = $1 AND status = 'waiting'",
-            )
+            ))
             .bind(row.id)
+            .bind(now)
             .execute(&mut *tx)
             .await?;
         }

--- a/meeting-api/src/db/mod.rs
+++ b/meeting-api/src/db/mod.rs
@@ -12,7 +12,196 @@
  */
 
 //! Database query modules.
+//!
+//! The backend is selected at compile time by a Cargo feature:
+//!
+//! - `postgres` (default) — [`DbPool`] is [`sqlx::PgPool`]
+//! - `sqlite` — [`DbPool`] is [`sqlx::SqlitePool`]
+//!
+//! The query modules themselves are shared. Everything the two dialects
+//! disagree about is funnelled through two small shims so that there is exactly
+//! one copy of every statement:
+//!
+//! - [`q`] rewrites `$N` placeholders to `?N` for SQLite. Both dialects accept
+//!   *numbered* parameters, so bind order is identical and callers never change.
+//! - [`lock`] provides the write-transaction primitives (`FOR UPDATE` on
+//!   PostgreSQL, `BEGIN IMMEDIATE` + busy retry on SQLite).
+//!
+//! Timestamps are always bound as `chrono::Utc::now()` parameters rather than
+//! written as `NOW()` / `CURRENT_TIMESTAMP`. Besides removing dialect
+//! divergence this keeps every timestamp SQLite stores in one lexicographically
+//! sortable format: `datetime('now')` renders `2026-07-21 04:39:04` (space
+//! separator, no sub-second, no offset) while a bound `DateTime<Utc>` renders
+//! RFC 3339. Mixing both in a TEXT column makes `ORDER BY created_at DESC`
+//! return rows out of order.
 
+use std::borrow::Cow;
+
+pub mod lock;
 pub mod meetings;
 pub mod oauth;
 pub mod participants;
+
+#[cfg(all(feature = "postgres", feature = "sqlite"))]
+compile_error!(
+    "meeting-api: the `postgres` and `sqlite` features are mutually exclusive. \
+     Build with `--no-default-features --features sqlite` to select SQLite."
+);
+
+#[cfg(not(any(feature = "postgres", feature = "sqlite")))]
+compile_error!(
+    "meeting-api: exactly one database backend feature must be enabled \
+     (`postgres` or `sqlite`)."
+);
+
+/// Connection pool for the compiled-in backend.
+#[cfg(feature = "postgres")]
+pub type DbPool = sqlx::PgPool;
+
+/// Connection pool for the compiled-in backend.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub type DbPool = sqlx::SqlitePool;
+
+/// Connect to PostgreSQL.
+#[cfg(feature = "postgres")]
+pub async fn connect(database_url: &str) -> DbPool {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(20)
+        .connect(database_url)
+        .await
+        .expect("failed to connect to PostgreSQL");
+
+    tracing::info!("Connected to PostgreSQL");
+    pool
+}
+
+/// Connect to SQLite.
+///
+/// Everything here is set through `SqliteConnectOptions` rather than by issuing
+/// `PRAGMA` statements against the pool: `busy_timeout`, `foreign_keys` and
+/// `journal_mode` are *per connection*, so a `PRAGMA` executed on one pooled
+/// connection leaves every other connection on the defaults.
+///
+/// - `Wal` lets readers proceed while a writer holds the write lock.
+/// - `busy_timeout` makes SQLite wait rather than immediately returning
+///   `SQLITE_BUSY`; [`lock::with_write_retry`] is the backstop beyond it.
+/// - `foreign_keys(true)` is mandatory. SQLite ignores foreign keys unless the
+///   pragma is on, which would silently disable the `ON DELETE CASCADE` from
+///   `meeting_participants` to `meetings`.
+///
+/// `max_connections(5)` is safe despite SQLite's single-writer model: WAL keeps
+/// readers off the write lock, and every write transaction starts with
+/// `BEGIN IMMEDIATE` (see [`lock`]) so writers queue on the write lock instead
+/// of deadlocking on a mid-transaction upgrade.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub async fn connect(database_url: &str) -> DbPool {
+    use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    let options = SqliteConnectOptions::from_str(database_url)
+        .expect("invalid SQLite DATABASE_URL")
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(5))
+        .foreign_keys(true)
+        .create_if_missing(true);
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect_with(options)
+        .await
+        .expect("failed to connect to SQLite");
+
+    tracing::info!("Connected to SQLite");
+    pool
+}
+
+/// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect.
+///
+/// On PostgreSQL this is the identity function and borrows the input.
+#[cfg(feature = "postgres")]
+#[inline]
+pub fn q(sql: &str) -> Cow<'_, str> {
+    Cow::Borrowed(sql)
+}
+
+/// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect.
+///
+/// On SQLite this rewrites `$N` placeholders to `?N`. SQLite supports numbered
+/// parameters natively, so `$1 -> ?1` preserves both the numbering and the bind
+/// order, including statements that reference the same parameter twice.
+///
+/// Single-quoted string literals are skipped so a literal `$` inside a value is
+/// never touched. (No current query contains one; the scanner keeps that from
+/// becoming a silent trap if one is added.)
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub fn q(sql: &str) -> Cow<'_, str> {
+    if !sql.contains('$') {
+        return Cow::Borrowed(sql);
+    }
+
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    let mut in_string_literal = false;
+
+    while let Some(c) = chars.next() {
+        match c {
+            // A doubled quote inside a literal closes and immediately reopens
+            // it, which leaves `in_string_literal` correct either way.
+            '\'' => {
+                in_string_literal = !in_string_literal;
+                out.push(c);
+            }
+            '$' if !in_string_literal && chars.peek().is_some_and(char::is_ascii_digit) => {
+                out.push('?');
+            }
+            _ => out.push(c),
+        }
+    }
+
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::q;
+
+    #[test]
+    fn leaves_statements_without_placeholders_borrowed() {
+        let sql = "SELECT COUNT(*) FROM meetings";
+        assert!(matches!(q(sql), std::borrow::Cow::Borrowed(_)));
+        assert_eq!(q(sql), sql);
+    }
+
+    #[test]
+    fn rewrites_placeholders_for_the_active_dialect() {
+        let sql = "SELECT 1 FROM meetings WHERE room_id = $1 AND creator_id = $2";
+        if cfg!(feature = "postgres") {
+            assert_eq!(q(sql), sql);
+        } else {
+            assert_eq!(
+                q(sql),
+                "SELECT 1 FROM meetings WHERE room_id = ?1 AND creator_id = ?2"
+            );
+        }
+    }
+
+    #[test]
+    fn never_rewrites_inside_string_literals() {
+        let sql = "UPDATE meetings SET state = 'a$1b' WHERE id = $1";
+        if cfg!(feature = "postgres") {
+            assert_eq!(q(sql), sql);
+        } else {
+            assert_eq!(q(sql), "UPDATE meetings SET state = 'a$1b' WHERE id = ?1");
+        }
+    }
+
+    /// Every query in this crate is written with `$N` placeholders. A bare `$`
+    /// (PostgreSQL dollar-quoting, `$$`) would be silently mangled, so assert
+    /// the scanner only reacts to `$` followed by a digit.
+    #[test]
+    fn ignores_dollars_not_followed_by_a_digit() {
+        let sql = "SELECT '$' , $$tag$$ FROM meetings";
+        assert_eq!(q(sql), sql);
+    }
+}

--- a/meeting-api/src/db/mod.rs
+++ b/meeting-api/src/db/mod.rs
@@ -19,21 +19,44 @@
 //! - `sqlite` — [`DbPool`] is [`sqlx::SqlitePool`]
 //!
 //! The query modules themselves are shared. Everything the two dialects
-//! disagree about is funnelled through two small shims so that there is exactly
-//! one copy of every statement:
+//! disagree about is funnelled through three small shims so that there is
+//! exactly one copy of every statement:
 //!
-//! - [`q`] rewrites `$N` placeholders to `?N` for SQLite. Both dialects accept
-//!   *numbered* parameters, so bind order is identical and callers never change.
+//! - [`q`] rewrites `$N` placeholders to `?N` for SQLite.
+//! - [`now_expr`] / [`bind_now`] supply "now": the server's clock on
+//!   PostgreSQL, a bound parameter on SQLite.
 //! - [`lock`] provides the write-transaction primitives (`FOR UPDATE` on
 //!   PostgreSQL, `BEGIN IMMEDIATE` + busy retry on SQLite).
 //!
-//! Timestamps are always bound as `chrono::Utc::now()` parameters rather than
-//! written as `NOW()` / `CURRENT_TIMESTAMP`. Besides removing dialect
-//! divergence this keeps every timestamp SQLite stores in one lexicographically
-//! sortable format: `datetime('now')` renders `2026-07-21 04:39:04` (space
-//! separator, no sub-second, no offset) while a bound `DateTime<Utc>` renders
-//! RFC 3339. Mixing both in a TEXT column makes `ORDER BY created_at DESC`
-//! return rows out of order.
+//! # Where "now" comes from
+//!
+//! **PostgreSQL keeps using its own clock**, exactly as it did before SQLite
+//! was supported: every timestamp is written by `NOW()` / `CURRENT_TIMESTAMP`
+//! evaluated server-side. This is not incidental. Binding a client timestamp
+//! instead would key `list_by_owner`'s `ORDER BY created_at DESC` on API-pod
+//! wall clock, so two replicas with NTP skew — or one backward NTP step — could
+//! invert meetings created seconds apart. It would also let a row end up with
+//! `updated_at < created_at`, since `updated_at` comes from a `BEFORE UPDATE`
+//! trigger on the server while `created_at` would not.
+//!
+//! SQLite has no equivalent, so there [`now_expr`] emits a placeholder and
+//! [`bind_now`] binds `chrono::Utc::now()`. That is safe for the ordering
+//! concern because a SQLite deployment is a single file written by a single
+//! process — there is no second clock to skew against.
+//!
+//! Bound `DateTime<Utc>` values serialize as RFC 3339, and the SQLite schema's
+//! `DEFAULT`s are written to match, so a single column never mixes formats:
+//! `datetime('now')` would render `2026-07-21 04:39:04` (space separator, no
+//! sub-second, no offset), which does not sort lexicographically against
+//! RFC 3339 and would corrupt `ORDER BY created_at DESC`.
+//!
+//! The one exception is `users.created_at` / `users.last_login`, the only
+//! `TIMESTAMP`-without-time-zone columns in the schema. Those use
+//! [`now_naive_expr`] / [`bind_now_naive`] and store a *naive* datetime
+//! (`2026-07-21 09:06:06.635`), a second and deliberately different format.
+//! Binding an aware `DateTime<Utc>` there would send a `TIMESTAMPTZ` that
+//! PostgreSQL converts using the session time zone. Neither column is read
+//! back or ordered on, so the format difference is inert.
 
 use std::borrow::Cow;
 
@@ -83,11 +106,19 @@ pub async fn connect(database_url: &str) -> DbPool {
 /// connection leaves every other connection on the defaults.
 ///
 /// - `Wal` lets readers proceed while a writer holds the write lock.
+/// - `synchronous(Normal)` is the standard WAL pairing: fsync at checkpoint
+///   rather than at every commit. Under WAL this is still crash-safe — a power
+///   loss can lose the most recent transactions but cannot corrupt the database.
 /// - `busy_timeout` makes SQLite wait rather than immediately returning
 ///   `SQLITE_BUSY`; [`lock::with_write_retry`] is the backstop beyond it.
 /// - `foreign_keys(true)` is mandatory. SQLite ignores foreign keys unless the
 ///   pragma is on, which would silently disable the `ON DELETE CASCADE` from
 ///   `meeting_participants` to `meetings`.
+///
+/// `create_if_missing` is deliberately **not** forced on. It is left to the URL
+/// (`?mode=rwc`), so a typo in `DATABASE_URL` fails loudly at startup instead of
+/// silently creating an empty, unmigrated database that then answers every
+/// request with "no such table". Tests opt in explicitly.
 ///
 /// `max_connections(5)` is safe despite SQLite's single-writer model: WAL keeps
 /// readers off the write lock, and every write transaction starts with
@@ -95,16 +126,18 @@ pub async fn connect(database_url: &str) -> DbPool {
 /// of deadlocking on a mid-transaction upgrade.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub async fn connect(database_url: &str) -> DbPool {
-    use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+    use sqlx::sqlite::{
+        SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
+    };
     use std::str::FromStr;
     use std::time::Duration;
 
     let options = SqliteConnectOptions::from_str(database_url)
         .expect("invalid SQLite DATABASE_URL")
         .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Normal)
         .busy_timeout(Duration::from_secs(5))
-        .foreign_keys(true)
-        .create_if_missing(true);
+        .foreign_keys(true);
 
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
@@ -116,6 +149,74 @@ pub async fn connect(database_url: &str) -> DbPool {
     pool
 }
 
+/// SQL expression producing the current `TIMESTAMPTZ`, for parameter slot `slot`.
+///
+/// PostgreSQL evaluates this server-side, so `slot` is unused and no
+/// corresponding bind exists — see the module docs for why the database, not
+/// the API pod, is the clock here.
+#[cfg(feature = "postgres")]
+#[inline]
+pub fn now_expr(_slot: usize) -> Cow<'static, str> {
+    Cow::Borrowed("NOW()")
+}
+
+/// SQL expression producing the current `TIMESTAMPTZ`, for parameter slot `slot`.
+///
+/// SQLite has no server clock to borrow, so this is a placeholder that
+/// [`bind_now`] fills in. `slot` must be the 1-based position of the bind that
+/// [`bind_now`] appends, i.e. one past the statement's other parameters. Repeat
+/// the same `now_expr` value to reuse one bind across several columns.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[inline]
+pub fn now_expr(slot: usize) -> Cow<'static, str> {
+    Cow::Owned(format!("${slot}"))
+}
+
+/// SQL expression producing the current naive `TIMESTAMP`, for parameter `slot`.
+///
+/// Only `users.created_at` / `users.last_login` need this; see the module docs.
+#[cfg(feature = "postgres")]
+#[inline]
+pub fn now_naive_expr(_slot: usize) -> Cow<'static, str> {
+    Cow::Borrowed("CURRENT_TIMESTAMP")
+}
+
+/// SQL expression producing the current naive `TIMESTAMP`, for parameter `slot`.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+#[inline]
+pub fn now_naive_expr(slot: usize) -> Cow<'static, str> {
+    Cow::Owned(format!("${slot}"))
+}
+
+/// Bind the value that [`now_expr`] reserved a placeholder for.
+///
+/// Expands to nothing on PostgreSQL, where `NOW()` needs no parameter, and to
+/// `.bind(Utc::now())` on SQLite. Always call it *after* the statement's other
+/// `.bind`s so the appended parameter lands in the slot `now_expr` was given.
+macro_rules! bind_now {
+    ($query:expr) => {{
+        #[cfg(feature = "postgres")]
+        let query = $query;
+        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+        let query = $query.bind(::chrono::Utc::now());
+        query
+    }};
+}
+
+/// Bind the value that [`now_naive_expr`] reserved a placeholder for.
+macro_rules! bind_now_naive {
+    ($query:expr) => {{
+        #[cfg(feature = "postgres")]
+        let query = $query;
+        #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+        let query = $query.bind(::chrono::Utc::now().naive_utc());
+        query
+    }};
+}
+
+pub(crate) use bind_now;
+pub(crate) use bind_now_naive;
+
 /// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect.
 ///
 /// On PostgreSQL this is the identity function and borrows the input.
@@ -125,37 +226,94 @@ pub fn q(sql: &str) -> Cow<'_, str> {
     Cow::Borrowed(sql)
 }
 
-/// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect.
+/// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect: on SQLite,
+/// rewrite `$N` placeholders to `?N`.
 ///
-/// On SQLite this rewrites `$N` placeholders to `?N`. SQLite supports numbered
-/// parameters natively, so `$1 -> ?1` preserves both the numbering and the bind
-/// order, including statements that reference the same parameter twice.
+/// **This rewrite is defence in depth, not a requirement.** SQLite accepts `$1`
+/// as a parameter name in its own right, and sqlx-sqlite's binder explicitly
+/// parses the `$NNN` form (`sqlx-sqlite/src/arguments.rs`), so the statements
+/// would bind correctly even if this function were the identity. It exists
+/// because `?N` is SQLite's documented numbered-parameter syntax and relying on
+/// an sqlx implementation detail across upgrades is a bet with no upside. If
+/// this function is ever removed, the queries are expected to keep working —
+/// verify that rather than assuming it, but do not treat `q` as load-bearing.
 ///
-/// Single-quoted string literals are skipped so a literal `$` inside a value is
-/// never touched. (No current query contains one; the scanner keeps that from
-/// becoming a silent trap if one is added.)
+/// `$N -> ?N` preserves the numbering, so bind order is unchanged and a
+/// statement may reference the same parameter more than once.
+///
+/// The scanner skips anywhere a `$` could legitimately appear verbatim: single-
+/// quoted literals, `"double-quoted identifiers"`, `-- line comments` and
+/// `/* block comments */`. Doubled quotes (`''`, `""`) close and immediately
+/// reopen, which lands on the correct state either way. A `$` not followed by a
+/// digit — PostgreSQL dollar-quoting, `$$` — is left alone.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn q(sql: &str) -> Cow<'_, str> {
+    #[derive(PartialEq)]
+    enum Mode {
+        Sql,
+        SingleQuoted,
+        DoubleQuoted,
+        LineComment,
+        BlockComment,
+    }
+
     if !sql.contains('$') {
         return Cow::Borrowed(sql);
     }
 
     let mut out = String::with_capacity(sql.len());
     let mut chars = sql.chars().peekable();
-    let mut in_string_literal = false;
+    let mut mode = Mode::Sql;
 
     while let Some(c) = chars.next() {
-        match c {
-            // A doubled quote inside a literal closes and immediately reopens
-            // it, which leaves `in_string_literal` correct either way.
-            '\'' => {
-                in_string_literal = !in_string_literal;
+        match mode {
+            Mode::Sql => match c {
+                '\'' => {
+                    mode = Mode::SingleQuoted;
+                    out.push(c);
+                }
+                '"' => {
+                    mode = Mode::DoubleQuoted;
+                    out.push(c);
+                }
+                '-' if chars.peek() == Some(&'-') => {
+                    mode = Mode::LineComment;
+                    out.push(c);
+                    out.push(chars.next().expect("peeked"));
+                }
+                '/' if chars.peek() == Some(&'*') => {
+                    mode = Mode::BlockComment;
+                    out.push(c);
+                    out.push(chars.next().expect("peeked"));
+                }
+                '$' if chars.peek().is_some_and(char::is_ascii_digit) => out.push('?'),
+                _ => out.push(c),
+            },
+            Mode::SingleQuoted => {
                 out.push(c);
+                if c == '\'' {
+                    mode = Mode::Sql;
+                }
             }
-            '$' if !in_string_literal && chars.peek().is_some_and(char::is_ascii_digit) => {
-                out.push('?');
+            Mode::DoubleQuoted => {
+                out.push(c);
+                if c == '"' {
+                    mode = Mode::Sql;
+                }
             }
-            _ => out.push(c),
+            Mode::LineComment => {
+                out.push(c);
+                if c == '\n' {
+                    mode = Mode::Sql;
+                }
+            }
+            Mode::BlockComment => {
+                out.push(c);
+                if c == '*' && chars.peek() == Some(&'/') {
+                    out.push(chars.next().expect("peeked"));
+                    mode = Mode::Sql;
+                }
+            }
         }
     }
 
@@ -203,5 +361,45 @@ mod tests {
     fn ignores_dollars_not_followed_by_a_digit() {
         let sql = "SELECT '$' , $$tag$$ FROM meetings";
         assert_eq!(q(sql), sql);
+    }
+
+    #[test]
+    fn never_rewrites_inside_quoted_identifiers_or_comments() {
+        let sql = concat!(
+            "SELECT \"weird$1col\" -- trailing $1 note\n",
+            "FROM meetings /* block $1 note */ WHERE id = $1"
+        );
+        let expected = if cfg!(feature = "postgres") {
+            sql.to_string()
+        } else {
+            sql.replace("WHERE id = $1", "WHERE id = ?1")
+        };
+        assert_eq!(q(sql), expected);
+    }
+
+    /// A doubled quote is an escape, not a close, so the scanner must still be
+    /// inside the literal afterwards — otherwise the `$1` here gets rewritten.
+    #[test]
+    fn handles_doubled_quote_escapes() {
+        let sql = "SELECT 'it''s $1 fine', \"a\"\"b$1\" FROM meetings WHERE id = $1";
+        let expected = if cfg!(feature = "postgres") {
+            sql.to_string()
+        } else {
+            sql.replace("WHERE id = $1", "WHERE id = ?1")
+        };
+        assert_eq!(q(sql), expected);
+    }
+
+    /// The whole point of [`super::now_expr`]: PostgreSQL uses its own clock and
+    /// consumes no parameter slot, SQLite gets a placeholder for [`super::bind_now`].
+    #[test]
+    fn now_expr_matches_the_dialects_clock_strategy() {
+        if cfg!(feature = "postgres") {
+            assert_eq!(super::now_expr(6), "NOW()");
+            assert_eq!(super::now_naive_expr(5), "CURRENT_TIMESTAMP");
+        } else {
+            assert_eq!(super::now_expr(6), "$6");
+            assert_eq!(super::now_naive_expr(5), "$5");
+        }
     }
 }

--- a/meeting-api/src/db/mod.rs
+++ b/meeting-api/src/db/mod.rs
@@ -11,52 +11,27 @@
  * at your option.
  */
 
-//! Database query modules.
+//! Database queries, shared across both backends. The active backend is a
+//! compile-time Cargo feature: `postgres` (default) or `sqlite`. Three shims
+//! absorb the dialect differences so each statement is written once:
 //!
-//! The backend is selected at compile time by a Cargo feature:
+//! - [`q`] rewrites `$N` placeholders to `?N` on SQLite.
+//! - [`now_sql`] + [`bind_now`] supply the current timestamp.
+//! - [`lock`] provides the write-transaction primitives.
 //!
-//! - `postgres` (default) — [`DbPool`] is [`sqlx::PgPool`]
-//! - `sqlite` — [`DbPool`] is [`sqlx::SqlitePool`]
+//! # Clock source
 //!
-//! The query modules themselves are shared. Everything the two dialects
-//! disagree about is funnelled through three small shims so that there is
-//! exactly one copy of every statement:
+//! Timestamps use the *database* clock on PostgreSQL (`NOW()`) and a bound
+//! `Utc::now()` on SQLite. The split is deliberate: a client clock would key
+//! `list_by_owner`'s `ORDER BY created_at DESC` on per-pod wall time — NTP skew
+//! could invert rows — and could yield `updated_at < created_at` against the
+//! `BEFORE UPDATE` trigger. SQLite is a single-writer file with no second clock,
+//! so binding is safe there; its schema DEFAULTs also emit RFC 3339 so a TEXT
+//! column never mixes sort-incompatible formats.
 //!
-//! - [`q`] rewrites `$N` placeholders to `?N` for SQLite.
-//! - [`now_expr`] / [`bind_now`] supply "now": the server's clock on
-//!   PostgreSQL, a bound parameter on SQLite.
-//! - [`lock`] provides the write-transaction primitives (`FOR UPDATE` on
-//!   PostgreSQL, `BEGIN IMMEDIATE` + busy retry on SQLite).
-//!
-//! # Where "now" comes from
-//!
-//! **PostgreSQL keeps using its own clock**, exactly as it did before SQLite
-//! was supported: every timestamp is written by `NOW()` / `CURRENT_TIMESTAMP`
-//! evaluated server-side. This is not incidental. Binding a client timestamp
-//! instead would key `list_by_owner`'s `ORDER BY created_at DESC` on API-pod
-//! wall clock, so two replicas with NTP skew — or one backward NTP step — could
-//! invert meetings created seconds apart. It would also let a row end up with
-//! `updated_at < created_at`, since `updated_at` comes from a `BEFORE UPDATE`
-//! trigger on the server while `created_at` would not.
-//!
-//! SQLite has no equivalent, so there [`now_expr`] emits a placeholder and
-//! [`bind_now`] binds `chrono::Utc::now()`. That is safe for the ordering
-//! concern because a SQLite deployment is a single file written by a single
-//! process — there is no second clock to skew against.
-//!
-//! Bound `DateTime<Utc>` values serialize as RFC 3339, and the SQLite schema's
-//! `DEFAULT`s are written to match, so a single column never mixes formats:
-//! `datetime('now')` would render `2026-07-21 04:39:04` (space separator, no
-//! sub-second, no offset), which does not sort lexicographically against
-//! RFC 3339 and would corrupt `ORDER BY created_at DESC`.
-//!
-//! The one exception is `users.created_at` / `users.last_login`, the only
-//! `TIMESTAMP`-without-time-zone columns in the schema. Those use
-//! [`now_naive_expr`] / [`bind_now_naive`] and store a *naive* datetime
-//! (`2026-07-21 09:06:06.635`), a second and deliberately different format.
-//! Binding an aware `DateTime<Utc>` there would send a `TIMESTAMPTZ` that
-//! PostgreSQL converts using the session time zone. Neither column is read
-//! back or ordered on, so the format difference is inert.
+//! `users.created_at` / `last_login` are the schema's only `TIMESTAMP` (no time
+//! zone) columns and use [`now_naive_sql`] / [`bind_now_naive`] so PostgreSQL
+//! applies no session-timezone cast. Neither is ordered on.
 
 use std::borrow::Cow;
 
@@ -100,30 +75,20 @@ pub async fn connect(database_url: &str) -> DbPool {
 
 /// Connect to SQLite.
 ///
-/// Everything here is set through `SqliteConnectOptions` rather than by issuing
-/// `PRAGMA` statements against the pool: `busy_timeout`, `foreign_keys` and
-/// `journal_mode` are *per connection*, so a `PRAGMA` executed on one pooled
-/// connection leaves every other connection on the defaults.
+/// Options go on `SqliteConnectOptions`, not `PRAGMA` on the pool: pragmas are
+/// per-connection, so setting them once would leave the other pooled connections
+/// on SQLite's defaults.
 ///
-/// - `Wal` lets readers proceed while a writer holds the write lock.
-/// - `synchronous(Normal)` is the standard WAL pairing: fsync at checkpoint
-///   rather than at every commit. Under WAL this is still crash-safe — a power
-///   loss can lose the most recent transactions but cannot corrupt the database.
-/// - `busy_timeout` makes SQLite wait rather than immediately returning
-///   `SQLITE_BUSY`; [`lock::with_write_retry`] is the backstop beyond it.
-/// - `foreign_keys(true)` is mandatory. SQLite ignores foreign keys unless the
-///   pragma is on, which would silently disable the `ON DELETE CASCADE` from
-///   `meeting_participants` to `meetings`.
+/// - `foreign_keys(true)` is required, or `ON DELETE CASCADE` is silently inert.
+/// - `Wal` + `synchronous(Normal)` let readers proceed past the writer and fsync
+///   at checkpoint rather than every commit; still crash-safe under WAL.
+/// - `busy_timeout` waits instead of returning `SQLITE_BUSY`;
+///   [`lock::with_write_retry`] is the backstop past it.
+/// - `create_if_missing` is left to the URL (`?mode=rwc`) so a bad `DATABASE_URL`
+///   fails at startup instead of serving an empty, unmigrated database.
 ///
-/// `create_if_missing` is deliberately **not** forced on. It is left to the URL
-/// (`?mode=rwc`), so a typo in `DATABASE_URL` fails loudly at startup instead of
-/// silently creating an empty, unmigrated database that then answers every
-/// request with "no such table". Tests opt in explicitly.
-///
-/// `max_connections(5)` is safe despite SQLite's single-writer model: WAL keeps
-/// readers off the write lock, and every write transaction starts with
-/// `BEGIN IMMEDIATE` (see [`lock`]) so writers queue on the write lock instead
-/// of deadlocking on a mid-transaction upgrade.
+/// `max_connections(5)` is safe: WAL keeps readers off the write lock and every
+/// writer takes it up front via `BEGIN IMMEDIATE` (see [`lock`]).
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub async fn connect(database_url: &str) -> DbPool {
     use sqlx::sqlite::{
@@ -149,50 +114,39 @@ pub async fn connect(database_url: &str) -> DbPool {
     pool
 }
 
-/// SQL expression producing the current `TIMESTAMPTZ`, for parameter slot `slot`.
+/// Render `template` for the active dialect: replace each `{now}` with the
+/// current timestamp and rewrite placeholders.
 ///
-/// PostgreSQL evaluates this server-side, so `slot` is unused and no
-/// corresponding bind exists — see the module docs for why the database, not
-/// the API pod, is the clock here.
+/// On SQLite `{now}` becomes a `$slot` placeholder that [`bind_now`] fills, so
+/// `slot` must be one past the statement's other parameters — the position
+/// `bind_now` binds into. Reuse the same slot to write several columns from one
+/// bind. On PostgreSQL `{now}` is `NOW()` and `slot` is unused.
 #[cfg(feature = "postgres")]
-#[inline]
-pub fn now_expr(_slot: usize) -> Cow<'static, str> {
-    Cow::Borrowed("NOW()")
+pub(crate) fn now_sql(template: &str, _slot: usize) -> String {
+    template.replace("{now}", "NOW()")
 }
 
-/// SQL expression producing the current `TIMESTAMPTZ`, for parameter slot `slot`.
-///
-/// SQLite has no server clock to borrow, so this is a placeholder that
-/// [`bind_now`] fills in. `slot` must be the 1-based position of the bind that
-/// [`bind_now`] appends, i.e. one past the statement's other parameters. Repeat
-/// the same `now_expr` value to reuse one bind across several columns.
+/// Render `template` for the active dialect. See the PostgreSQL variant.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
-#[inline]
-pub fn now_expr(slot: usize) -> Cow<'static, str> {
-    Cow::Owned(format!("${slot}"))
+pub(crate) fn now_sql(template: &str, slot: usize) -> String {
+    q(&template.replace("{now}", &format!("${slot}"))).into_owned()
 }
 
-/// SQL expression producing the current naive `TIMESTAMP`, for parameter `slot`.
-///
-/// Only `users.created_at` / `users.last_login` need this; see the module docs.
+/// Like [`now_sql`], but `{now}` is a naive `TIMESTAMP` — only for the two
+/// `users` columns (see the module docs).
 #[cfg(feature = "postgres")]
-#[inline]
-pub fn now_naive_expr(_slot: usize) -> Cow<'static, str> {
-    Cow::Borrowed("CURRENT_TIMESTAMP")
+pub(crate) fn now_naive_sql(template: &str, _slot: usize) -> String {
+    template.replace("{now}", "CURRENT_TIMESTAMP")
 }
 
-/// SQL expression producing the current naive `TIMESTAMP`, for parameter `slot`.
+/// Like [`now_sql`], but `{now}` is a naive `TIMESTAMP`.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
-#[inline]
-pub fn now_naive_expr(slot: usize) -> Cow<'static, str> {
-    Cow::Owned(format!("${slot}"))
+pub(crate) fn now_naive_sql(template: &str, slot: usize) -> String {
+    q(&template.replace("{now}", &format!("${slot}"))).into_owned()
 }
 
-/// Bind the value that [`now_expr`] reserved a placeholder for.
-///
-/// Expands to nothing on PostgreSQL, where `NOW()` needs no parameter, and to
-/// `.bind(Utc::now())` on SQLite. Always call it *after* the statement's other
-/// `.bind`s so the appended parameter lands in the slot `now_expr` was given.
+/// Append the bind that [`now_sql`]'s `{now}` reserved: nothing on PostgreSQL,
+/// `Utc::now()` on SQLite. Call it after the statement's other `.bind`s.
 macro_rules! bind_now {
     ($query:expr) => {{
         #[cfg(feature = "postgres")]
@@ -203,7 +157,7 @@ macro_rules! bind_now {
     }};
 }
 
-/// Bind the value that [`now_naive_expr`] reserved a placeholder for.
+/// [`bind_now`] for [`now_naive_sql`]: binds a `NaiveDateTime` on SQLite.
 macro_rules! bind_now_naive {
     ($query:expr) => {{
         #[cfg(feature = "postgres")]
@@ -214,41 +168,39 @@ macro_rules! bind_now_naive {
     }};
 }
 
+/// Run an async block through [`lock::with_write_retry`], so on SQLite it replays
+/// past `SQLITE_BUSY`. The body must be replayable: it either owns its
+/// transaction (rolled back on failure) or is one autocommit statement. Captures
+/// are moved into a fresh future each attempt, so they must be `Copy`.
+macro_rules! with_retry {
+    ($($body:tt)*) => {
+        $crate::db::lock::with_write_retry(|| ::std::boxed::Box::pin(async move { $($body)* })).await
+    };
+}
+
 pub(crate) use bind_now;
 pub(crate) use bind_now_naive;
+pub(crate) use with_retry;
 
-/// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect.
-///
-/// On PostgreSQL this is the identity function and borrows the input.
+/// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect. Identity on
+/// PostgreSQL.
 #[cfg(feature = "postgres")]
 #[inline]
 pub fn q(sql: &str) -> Cow<'_, str> {
     Cow::Borrowed(sql)
 }
 
-/// Adapt a PostgreSQL-flavoured statement to the compiled-in dialect: on SQLite,
-/// rewrite `$N` placeholders to `?N`.
+/// Rewrite `$N` placeholders to `?N` for SQLite.
 ///
-/// **This rewrite is defence in depth, not a requirement.** SQLite accepts `$1`
-/// as a parameter name in its own right, and sqlx-sqlite's binder explicitly
-/// parses the `$NNN` form (`sqlx-sqlite/src/arguments.rs`), so the statements
-/// would bind correctly even if this function were the identity. It exists
-/// because `?N` is SQLite's documented numbered-parameter syntax and relying on
-/// an sqlx implementation detail across upgrades is a bet with no upside. If
-/// this function is ever removed, the queries are expected to keep working —
-/// verify that rather than assuming it, but do not treat `q` as load-bearing.
+/// Defence in depth, not required: sqlx-sqlite binds `$N` natively, so removing
+/// this leaves queries working. `?N` is SQLite's documented form and avoids
+/// depending on that internal.
 ///
-/// `$N -> ?N` preserves the numbering, so bind order is unchanged and a
-/// statement may reference the same parameter more than once.
-///
-/// The scanner skips anywhere a `$` could legitimately appear verbatim: single-
-/// quoted literals, `"double-quoted identifiers"`, `-- line comments` and
-/// `/* block comments */`. Doubled quotes (`''`, `""`) close and immediately
-/// reopen, which lands on the correct state either way. A `$` not followed by a
-/// digit — PostgreSQL dollar-quoting, `$$` — is left alone.
+/// Skips `$` inside single-/double-quoted strings and `--` / `/* */` comments so
+/// only real placeholders are touched. Doubled quotes (`''`, `""`) escape, and a
+/// `$` not followed by a digit (e.g. `$$`) is left alone.
 #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
 pub fn q(sql: &str) -> Cow<'_, str> {
-    #[derive(PartialEq)]
     enum Mode {
         Sql,
         SingleQuoted,
@@ -322,84 +274,58 @@ pub fn q(sql: &str) -> Cow<'_, str> {
 
 #[cfg(test)]
 mod tests {
-    use super::q;
+    use super::{now_naive_sql, now_sql, q};
 
     #[test]
-    fn leaves_statements_without_placeholders_borrowed() {
-        let sql = "SELECT COUNT(*) FROM meetings";
-        assert!(matches!(q(sql), std::borrow::Cow::Borrowed(_)));
-        assert_eq!(q(sql), sql);
+    fn q_borrows_when_there_is_nothing_to_rewrite() {
+        assert!(matches!(
+            q("SELECT 1 FROM meetings"),
+            std::borrow::Cow::Borrowed(_)
+        ));
     }
 
+    /// Real placeholders become `?N` on SQLite; a `$` inside a string literal,
+    /// quoted identifier, comment, or `$$` is left alone.
     #[test]
-    fn rewrites_placeholders_for_the_active_dialect() {
-        let sql = "SELECT 1 FROM meetings WHERE room_id = $1 AND creator_id = $2";
-        if cfg!(feature = "postgres") {
-            assert_eq!(q(sql), sql);
-        } else {
-            assert_eq!(
-                q(sql),
-                "SELECT 1 FROM meetings WHERE room_id = ?1 AND creator_id = ?2"
-            );
-        }
-    }
-
-    #[test]
-    fn never_rewrites_inside_string_literals() {
-        let sql = "UPDATE meetings SET state = 'a$1b' WHERE id = $1";
-        if cfg!(feature = "postgres") {
-            assert_eq!(q(sql), sql);
-        } else {
-            assert_eq!(q(sql), "UPDATE meetings SET state = 'a$1b' WHERE id = ?1");
-        }
-    }
-
-    /// Every query in this crate is written with `$N` placeholders. A bare `$`
-    /// (PostgreSQL dollar-quoting, `$$`) would be silently mangled, so assert
-    /// the scanner only reacts to `$` followed by a digit.
-    #[test]
-    fn ignores_dollars_not_followed_by_a_digit() {
-        let sql = "SELECT '$' , $$tag$$ FROM meetings";
-        assert_eq!(q(sql), sql);
-    }
-
-    #[test]
-    fn never_rewrites_inside_quoted_identifiers_or_comments() {
+    fn q_rewrites_only_real_placeholders() {
         let sql = concat!(
-            "SELECT \"weird$1col\" -- trailing $1 note\n",
-            "FROM meetings /* block $1 note */ WHERE id = $1"
+            "SELECT \"weird$1col\", 'a$1b' -- $1\n",
+            "FROM meetings /* $1 */ WHERE id = $1 AND z = $$tag$$"
         );
         let expected = if cfg!(feature = "postgres") {
             sql.to_string()
         } else {
-            sql.replace("WHERE id = $1", "WHERE id = ?1")
+            sql.replace("id = $1", "id = ?1")
         };
         assert_eq!(q(sql), expected);
     }
 
-    /// A doubled quote is an escape, not a close, so the scanner must still be
-    /// inside the literal afterwards — otherwise the `$1` here gets rewritten.
+    /// A doubled quote escapes rather than closes, so the `$1` inside stays put.
     #[test]
-    fn handles_doubled_quote_escapes() {
-        let sql = "SELECT 'it''s $1 fine', \"a\"\"b$1\" FROM meetings WHERE id = $1";
+    fn q_treats_doubled_quotes_as_escapes() {
+        let sql = "SELECT 'it''s $1', \"a\"\"b$1\" FROM meetings WHERE id = $1";
         let expected = if cfg!(feature = "postgres") {
             sql.to_string()
         } else {
-            sql.replace("WHERE id = $1", "WHERE id = ?1")
+            sql.replace("id = $1", "id = ?1")
         };
         assert_eq!(q(sql), expected);
     }
 
-    /// The whole point of [`super::now_expr`]: PostgreSQL uses its own clock and
-    /// consumes no parameter slot, SQLite gets a placeholder for [`super::bind_now`].
     #[test]
-    fn now_expr_matches_the_dialects_clock_strategy() {
+    fn now_sql_renders_the_dialects_clock() {
         if cfg!(feature = "postgres") {
-            assert_eq!(super::now_expr(6), "NOW()");
-            assert_eq!(super::now_naive_expr(5), "CURRENT_TIMESTAMP");
+            assert_eq!(
+                now_sql("t = {now} WHERE id = $1", 2),
+                "t = NOW() WHERE id = $1"
+            );
+            assert_eq!(now_naive_sql("t = {now}", 1), "t = CURRENT_TIMESTAMP");
         } else {
-            assert_eq!(super::now_expr(6), "$6");
-            assert_eq!(super::now_naive_expr(5), "$5");
+            assert_eq!(
+                now_sql("t = {now} WHERE id = $1", 2),
+                "t = ?2 WHERE id = ?1"
+            );
+            assert_eq!(now_naive_sql("t = {now}", 1), "t = ?1");
         }
     }
 }

--- a/meeting-api/src/db/oauth.rs
+++ b/meeting-api/src/db/oauth.rs
@@ -13,7 +13,7 @@
 
 //! OAuth request and user storage queries.
 
-use crate::db::{bind_now_naive, now_naive_expr, q, DbPool};
+use crate::db::{bind_now_naive, now_naive_sql, q, DbPool};
 
 /// Stored PKCE challenge/verifier and CSRF state for an in-flight OAuth flow.
 #[derive(Debug, sqlx::FromRow)]
@@ -66,12 +66,9 @@ pub async fn fetch_oauth_request(
 
 /// Upsert a user after successful OAuth login.
 ///
-/// `created_at` / `last_login` go through [`now_naive_expr`] rather than the
-/// usual [`crate::db::now_expr`]: they are the schema's only `TIMESTAMP`
-/// (no time zone) columns. On PostgreSQL that is `CURRENT_TIMESTAMP`, evaluated
-/// server-side; on SQLite it is a bound `NaiveDateTime`. Binding an aware
-/// `DateTime<Utc>` would send a `TIMESTAMPTZ` that PostgreSQL converts using the
-/// session time zone.
+/// `created_at` / `last_login` use [`now_naive_sql`] because they are the
+/// schema's only `TIMESTAMP` (no time zone) columns; an aware `DateTime<Utc>`
+/// would send a `TIMESTAMPTZ` that PostgreSQL casts by session time zone.
 pub async fn upsert_user(
     pool: &DbPool,
     email: &str,
@@ -79,16 +76,13 @@ pub async fn upsert_user(
     access_token: &str,
     refresh_token: Option<&str>,
 ) -> Result<(), sqlx::Error> {
-    let sql = format!(
-        r#"
-        INSERT INTO users (email, name, access_token, refresh_token, created_at, last_login)
-        VALUES ($1, $2, $3, $4, {now}, {now})
-        ON CONFLICT (email)
-        DO UPDATE SET access_token = $3, refresh_token = $4, name = $2, last_login = {now}
-        "#,
-        now = now_naive_expr(5)
+    let sql = now_naive_sql(
+        "INSERT INTO users (email, name, access_token, refresh_token, created_at, last_login)
+         VALUES ($1, $2, $3, $4, {now}, {now})
+         ON CONFLICT (email)
+         DO UPDATE SET access_token = $3, refresh_token = $4, name = $2, last_login = {now}",
+        5,
     );
-    let sql = q(&sql);
     bind_now_naive!(sqlx::query(&sql)
         .bind(email)
         .bind(name)

--- a/meeting-api/src/db/oauth.rs
+++ b/meeting-api/src/db/oauth.rs
@@ -13,7 +13,9 @@
 
 //! OAuth request and user storage queries.
 
-use sqlx::PgPool;
+use chrono::Utc;
+
+use crate::db::{q, DbPool};
 
 /// Stored PKCE challenge/verifier and CSRF state for an in-flight OAuth flow.
 #[derive(Debug, sqlx::FromRow)]
@@ -29,19 +31,17 @@ pub struct OAuthRequestRow {
 /// Store a new OAuth request (PKCE + CSRF state + optional nonce) for later
 /// retrieval in the callback.
 pub async fn store_oauth_request(
-    pool: &PgPool,
+    pool: &DbPool,
     pkce_challenge: &str,
     pkce_verifier: &str,
     csrf_state: &str,
     return_to: Option<&str>,
     nonce: Option<&str>,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        r#"
+    sqlx::query(&q(r#"
         INSERT INTO oauth_requests (pkce_challenge, pkce_verifier, csrf_state, return_to, nonce)
         VALUES ($1, $2, $3, $4, $5)
-        "#,
-    )
+        "#))
     .bind(pkce_challenge)
     .bind(pkce_verifier)
     .bind(csrf_state)
@@ -55,37 +55,41 @@ pub async fn store_oauth_request(
 /// Fetch and consume an OAuth request by CSRF state.
 /// The row is atomically deleted so that each state token can only be used once.
 pub async fn fetch_oauth_request(
-    pool: &PgPool,
+    pool: &DbPool,
     csrf_state: &str,
 ) -> Result<Option<OAuthRequestRow>, sqlx::Error> {
-    sqlx::query_as::<_, OAuthRequestRow>(
+    sqlx::query_as::<_, OAuthRequestRow>(&q(
         "DELETE FROM oauth_requests WHERE csrf_state = $1 RETURNING pkce_challenge, pkce_verifier, csrf_state, return_to, nonce",
-    )
+    ))
     .bind(csrf_state)
     .fetch_optional(pool)
     .await
 }
 
 /// Upsert a user after successful OAuth login.
+///
+/// `created_at` / `last_login` are bound as a `NaiveDateTime` because both
+/// columns are `TIMESTAMP` (no time zone) on PostgreSQL; binding a
+/// `DateTime<Utc>` would send a `TIMESTAMPTZ` that the server converts using
+/// the session time zone.
 pub async fn upsert_user(
-    pool: &PgPool,
+    pool: &DbPool,
     email: &str,
     name: &str,
     access_token: &str,
     refresh_token: Option<&str>,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        r#"
+    sqlx::query(&q(r#"
         INSERT INTO users (email, name, access_token, refresh_token, created_at, last_login)
-        VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        VALUES ($1, $2, $3, $4, $5, $5)
         ON CONFLICT (email)
-        DO UPDATE SET access_token = $3, refresh_token = $4, name = $2, last_login = CURRENT_TIMESTAMP
-        "#,
-    )
+        DO UPDATE SET access_token = $3, refresh_token = $4, name = $2, last_login = $5
+        "#))
     .bind(email)
     .bind(name)
     .bind(access_token)
     .bind(refresh_token)
+    .bind(Utc::now().naive_utc())
     .execute(pool)
     .await?;
     Ok(())

--- a/meeting-api/src/db/oauth.rs
+++ b/meeting-api/src/db/oauth.rs
@@ -13,9 +13,7 @@
 
 //! OAuth request and user storage queries.
 
-use chrono::Utc;
-
-use crate::db::{q, DbPool};
+use crate::db::{bind_now_naive, now_naive_expr, q, DbPool};
 
 /// Stored PKCE challenge/verifier and CSRF state for an in-flight OAuth flow.
 #[derive(Debug, sqlx::FromRow)]
@@ -68,10 +66,12 @@ pub async fn fetch_oauth_request(
 
 /// Upsert a user after successful OAuth login.
 ///
-/// `created_at` / `last_login` are bound as a `NaiveDateTime` because both
-/// columns are `TIMESTAMP` (no time zone) on PostgreSQL; binding a
-/// `DateTime<Utc>` would send a `TIMESTAMPTZ` that the server converts using
-/// the session time zone.
+/// `created_at` / `last_login` go through [`now_naive_expr`] rather than the
+/// usual [`crate::db::now_expr`]: they are the schema's only `TIMESTAMP`
+/// (no time zone) columns. On PostgreSQL that is `CURRENT_TIMESTAMP`, evaluated
+/// server-side; on SQLite it is a bound `NaiveDateTime`. Binding an aware
+/// `DateTime<Utc>` would send a `TIMESTAMPTZ` that PostgreSQL converts using the
+/// session time zone.
 pub async fn upsert_user(
     pool: &DbPool,
     email: &str,
@@ -79,17 +79,21 @@ pub async fn upsert_user(
     access_token: &str,
     refresh_token: Option<&str>,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query(&q(r#"
+    let sql = format!(
+        r#"
         INSERT INTO users (email, name, access_token, refresh_token, created_at, last_login)
-        VALUES ($1, $2, $3, $4, $5, $5)
+        VALUES ($1, $2, $3, $4, {now}, {now})
         ON CONFLICT (email)
-        DO UPDATE SET access_token = $3, refresh_token = $4, name = $2, last_login = $5
-        "#))
-    .bind(email)
-    .bind(name)
-    .bind(access_token)
-    .bind(refresh_token)
-    .bind(Utc::now().naive_utc())
+        DO UPDATE SET access_token = $3, refresh_token = $4, name = $2, last_login = {now}
+        "#,
+        now = now_naive_expr(5)
+    );
+    let sql = q(&sql);
+    bind_now_naive!(sqlx::query(&sql)
+        .bind(email)
+        .bind(name)
+        .bind(access_token)
+        .bind(refresh_token))
     .execute(pool)
     .await?;
     Ok(())

--- a/meeting-api/src/db/participants.rs
+++ b/meeting-api/src/db/participants.rs
@@ -14,7 +14,8 @@
 //! Meeting participant table queries.
 
 use chrono::{DateTime, Utc};
-use sqlx::PgPool;
+
+use crate::db::{lock, q, DbPool};
 
 /// Row returned from the `meeting_participants` table.
 #[derive(Debug, sqlx::FromRow)]
@@ -41,84 +42,101 @@ const PARTICIPANT_COLUMNS: &str = r#"
 
 /// Insert or update a participant as host (admitted immediately).
 pub async fn upsert_host(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
     display_name: Option<&str>,
 ) -> Result<ParticipantRow, sqlx::Error> {
     let query = format!(
         r#"
-        INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
-        VALUES ($1, $2, 'admitted', TRUE, $3, NOW())
+        INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at, joined_at, created_at, updated_at)
+        VALUES ($1, $2, 'admitted', TRUE, $3, $4, $4, $4, $4)
         ON CONFLICT (meeting_id, user_id)
-        DO UPDATE SET status = 'admitted', is_host = TRUE, admitted_at = NOW(), left_at = NULL,
+        DO UPDATE SET status = 'admitted', is_host = TRUE, admitted_at = $4, updated_at = $4, left_at = NULL,
                       display_name = COALESCE($3, meeting_participants.display_name)
         RETURNING {PARTICIPANT_COLUMNS}
         "#
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
         .bind(user_id)
         .bind(display_name)
+        .bind(Utc::now())
         .fetch_one(pool)
         .await
 }
 
 /// Atomically join a meeting as an attendee, respecting the current `waiting_room_enabled`
-/// setting. Locks the meeting row with `FOR UPDATE` to serialize against concurrent
-/// waiting room toggles via `update_waiting_room_enabled`.
+/// setting. Opens the transaction through [`lock::begin_write`] so the meeting row is
+/// serialized against concurrent waiting room toggles via
+/// [`crate::db::meetings::update_waiting_room_enabled`].
 ///
 /// Returns `(auto_admitted, ParticipantRow, waiting_room_enabled)` where `auto_admitted`
 /// is `true` when the participant was immediately admitted (waiting room disabled).
-/// The third element is the `waiting_room_enabled` value observed under the row lock,
+/// The third element is the `waiting_room_enabled` value observed under the write lock,
 /// which avoids stale reads from a pre-transaction fetch.
 pub async fn join_attendee(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
     display_name: Option<&str>,
 ) -> Result<(bool, ParticipantRow, bool), sqlx::Error> {
-    let mut tx = pool.begin().await?;
+    lock::with_write_retry(|| Box::pin(join_attendee_txn(pool, meeting_id, user_id, display_name)))
+        .await
+}
 
-    // Lock the meeting row to serialize against concurrent waiting room toggles.
-    let (waiting_room_enabled,): (bool,) =
-        sqlx::query_as("SELECT waiting_room_enabled FROM meetings WHERE id = $1 FOR UPDATE")
-            .bind(meeting_id)
-            .fetch_one(&mut *tx)
-            .await?;
+/// One attempt of [`join_attendee`]. Replayable: a failure rolls the transaction
+/// back before returning.
+async fn join_attendee_txn(
+    pool: &DbPool,
+    meeting_id: i32,
+    user_id: &str,
+    display_name: Option<&str>,
+) -> Result<(bool, ParticipantRow, bool), sqlx::Error> {
+    let mut tx = lock::begin_write(pool).await?;
+    let now = Utc::now();
+
+    // Read the flag under the write lock so a concurrent toggle cannot slip in
+    // between this read and the insert below.
+    let (waiting_room_enabled,): (bool,) = sqlx::query_as(&q(lock::SELECT_WAITING_ROOM_LOCKED))
+        .bind(meeting_id)
+        .fetch_one(&mut *tx)
+        .await?;
 
     let row = if waiting_room_enabled {
         let query = format!(
             r#"
-            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name)
-            VALUES ($1, $2, 'waiting', FALSE, $3)
+            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, joined_at, created_at, updated_at)
+            VALUES ($1, $2, 'waiting', FALSE, $3, $4, $4, $4)
             ON CONFLICT (meeting_id, user_id)
-            DO UPDATE SET status = 'waiting', left_at = NULL,
+            DO UPDATE SET status = 'waiting', updated_at = $4, left_at = NULL,
                           display_name = COALESCE($3, meeting_participants.display_name)
             RETURNING {PARTICIPANT_COLUMNS}
             "#
         );
-        sqlx::query_as::<_, ParticipantRow>(&query)
+        sqlx::query_as::<_, ParticipantRow>(&q(&query))
             .bind(meeting_id)
             .bind(user_id)
             .bind(display_name)
+            .bind(now)
             .fetch_one(&mut *tx)
             .await?
     } else {
         let query = format!(
             r#"
-            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
-            VALUES ($1, $2, 'admitted', FALSE, $3, NOW())
+            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at, joined_at, created_at, updated_at)
+            VALUES ($1, $2, 'admitted', FALSE, $3, $4, $4, $4, $4)
             ON CONFLICT (meeting_id, user_id)
-            DO UPDATE SET status = 'admitted', admitted_at = NOW(), left_at = NULL,
+            DO UPDATE SET status = 'admitted', admitted_at = $4, updated_at = $4, left_at = NULL,
                           display_name = COALESCE($3, meeting_participants.display_name)
             RETURNING {PARTICIPANT_COLUMNS}
             "#
         );
-        sqlx::query_as::<_, ParticipantRow>(&query)
+        sqlx::query_as::<_, ParticipantRow>(&q(&query))
             .bind(meeting_id)
             .bind(user_id)
             .bind(display_name)
+            .bind(now)
             .fetch_one(&mut *tx)
             .await?
     };
@@ -129,13 +147,13 @@ pub async fn join_attendee(
 
 /// Get all participants in 'waiting' status for a meeting.
 pub async fn get_waiting(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
 ) -> Result<Vec<ParticipantRow>, sqlx::Error> {
     let query = format!(
         "SELECT {PARTICIPANT_COLUMNS} FROM meeting_participants WHERE meeting_id = $1 AND status = 'waiting'"
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
         .fetch_all(pool)
         .await
@@ -143,13 +161,13 @@ pub async fn get_waiting(
 
 /// Get all admitted (active) participants in a meeting.
 pub async fn get_admitted(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
 ) -> Result<Vec<ParticipantRow>, sqlx::Error> {
     let query = format!(
         "SELECT {PARTICIPANT_COLUMNS} FROM meeting_participants WHERE meeting_id = $1 AND status = 'admitted'"
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
         .fetch_all(pool)
         .await
@@ -157,14 +175,14 @@ pub async fn get_admitted(
 
 /// Get a single participant's status.
 pub async fn get_status(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
     let query = format!(
         "SELECT {PARTICIPANT_COLUMNS} FROM meeting_participants WHERE meeting_id = $1 AND user_id = $2"
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
         .bind(user_id)
         .fetch_optional(pool)
@@ -173,88 +191,92 @@ pub async fn get_status(
 
 /// Admit a single participant.
 pub async fn admit(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'admitted', admitted_at = NOW()
+        SET status = 'admitted', admitted_at = $3, updated_at = $3
         WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
         RETURNING {PARTICIPANT_COLUMNS}
         "#
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
         .bind(user_id)
+        .bind(Utc::now())
         .fetch_optional(pool)
         .await
 }
 
 /// Admit all waiting participants at once.
-pub async fn admit_all(pool: &PgPool, meeting_id: i32) -> Result<Vec<ParticipantRow>, sqlx::Error> {
+pub async fn admit_all(pool: &DbPool, meeting_id: i32) -> Result<Vec<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'admitted', admitted_at = NOW()
+        SET status = 'admitted', admitted_at = $2, updated_at = $2
         WHERE meeting_id = $1 AND status = 'waiting'
         RETURNING {PARTICIPANT_COLUMNS}
         "#
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
+        .bind(Utc::now())
         .fetch_all(pool)
         .await
 }
 
 /// Reject a participant.
 pub async fn reject(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'rejected'
+        SET status = 'rejected', updated_at = $3
         WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
         RETURNING {PARTICIPANT_COLUMNS}
         "#
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
         .bind(user_id)
+        .bind(Utc::now())
         .fetch_optional(pool)
         .await
 }
 
 /// Leave a meeting (set status to 'left').
 pub async fn leave(
-    pool: &PgPool,
+    pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'left', left_at = NOW()
+        SET status = 'left', left_at = $3, updated_at = $3
         WHERE meeting_id = $1 AND user_id = $2 AND status IN ('admitted', 'waiting')
         RETURNING {PARTICIPANT_COLUMNS}
         "#
     );
-    sqlx::query_as::<_, ParticipantRow>(&query)
+    sqlx::query_as::<_, ParticipantRow>(&q(&query))
         .bind(meeting_id)
         .bind(user_id)
+        .bind(Utc::now())
         .fetch_optional(pool)
         .await
 }
 
 /// Count admitted participants in a meeting.
-pub async fn count_admitted(pool: &PgPool, meeting_id: i32) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as(
+pub async fn count_admitted(pool: &DbPool, meeting_id: i32) -> Result<i64, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as(&q(
         "SELECT COUNT(*) FROM meeting_participants WHERE meeting_id = $1 AND status = 'admitted'",
-    )
+    ))
     .bind(meeting_id)
     .fetch_one(pool)
     .await?;
@@ -262,10 +284,10 @@ pub async fn count_admitted(pool: &PgPool, meeting_id: i32) -> Result<i64, sqlx:
 }
 
 /// Count waiting participants in a meeting.
-pub async fn count_waiting(pool: &PgPool, meeting_id: i32) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as(
+pub async fn count_waiting(pool: &DbPool, meeting_id: i32) -> Result<i64, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as(&q(
         "SELECT COUNT(*) FROM meeting_participants WHERE meeting_id = $1 AND status = 'waiting'",
-    )
+    ))
     .bind(meeting_id)
     .fetch_one(pool)
     .await?;

--- a/meeting-api/src/db/participants.rs
+++ b/meeting-api/src/db/participants.rs
@@ -13,23 +13,15 @@
 
 //! Meeting participant table queries.
 //!
-//! # Why the `_stmt` / `_txn` split
-//!
-//! Every write here is a public wrapper around a private inner function, called
-//! through [`crate::db::lock::with_write_retry`]. On PostgreSQL the wrapper is a
-//! pass-through. On SQLite it absorbs `SQLITE_BUSY`, which a single writer can
-//! still hit once `busy_timeout` expires — without it a busy database surfaces
-//! to the API client as a bare "database is locked".
-//!
-//! Replaying is safe for both shapes. A `_txn` inner has already rolled its
-//! transaction back before returning an error, and a `_stmt` inner is a single
-//! autocommit statement that applied nothing if it failed. The status
-//! predicates (`AND status = 'waiting'`) also make a replay that races a real
-//! change return `None` rather than double-applying.
+//! Every write runs through [`with_retry!`], so on SQLite it replays past
+//! `SQLITE_BUSY` instead of surfacing "database is locked" to the client (a
+//! no-op on PostgreSQL). Replay is safe: a transaction is rolled back on
+//! failure, an autocommit statement applied nothing, and the `status`
+//! predicates make a replay that raced a real change return `None`.
 
 use chrono::{DateTime, Utc};
 
-use crate::db::{bind_now, lock, now_expr, q, DbPool};
+use crate::db::{bind_now, lock, now_sql, q, with_retry, DbPool};
 
 /// Row returned from the `meeting_participants` table.
 #[derive(Debug, sqlx::FromRow)]
@@ -49,10 +41,14 @@ pub struct ParticipantRow {
     pub display_name: Option<String>,
 }
 
-const PARTICIPANT_COLUMNS: &str = r#"
-    id, meeting_id, user_id, status, is_host, is_required,
-    joined_at, admitted_at, left_at, created_at, updated_at, display_name
-"#;
+const PARTICIPANT_COLUMNS: &str = "id, meeting_id, user_id, status, is_host, is_required, \
+    joined_at, admitted_at, left_at, created_at, updated_at, display_name";
+
+/// Render a write statement: substitute `{cols}` and `{now}` (at `slot`), rewrite
+/// placeholders. Pair with `bind_now!`.
+fn stmt(template: &str, slot: usize) -> String {
+    now_sql(&template.replace("{cols}", PARTICIPANT_COLUMNS), slot)
+}
 
 /// Insert or update a participant as host (admitted immediately).
 pub async fn upsert_host(
@@ -61,116 +57,73 @@ pub async fn upsert_host(
     user_id: &str,
     display_name: Option<&str>,
 ) -> Result<ParticipantRow, sqlx::Error> {
-    lock::with_write_retry(|| Box::pin(upsert_host_stmt(pool, meeting_id, user_id, display_name)))
+    with_retry! {
+        // `joined_at` / `created_at` are left to the column DEFAULTs (the DB clock).
+        let sql = stmt(
+            "INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
+             VALUES ($1, $2, 'admitted', TRUE, $3, {now})
+             ON CONFLICT (meeting_id, user_id)
+             DO UPDATE SET status = 'admitted', is_host = TRUE, admitted_at = {now}, updated_at = {now}, left_at = NULL,
+                           display_name = COALESCE($3, meeting_participants.display_name)
+             RETURNING {cols}",
+            4,
+        );
+        bind_now!(sqlx::query_as::<_, ParticipantRow>(&sql)
+            .bind(meeting_id)
+            .bind(user_id)
+            .bind(display_name))
+        .fetch_one(pool)
         .await
+    }
 }
 
-async fn upsert_host_stmt(
-    pool: &DbPool,
-    meeting_id: i32,
-    user_id: &str,
-    display_name: Option<&str>,
-) -> Result<ParticipantRow, sqlx::Error> {
-    // `joined_at` / `created_at` are left to the column DEFAULTs, which are the
-    // database's clock on both backends.
-    let query = format!(
-        r#"
-        INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
-        VALUES ($1, $2, 'admitted', TRUE, $3, {now})
-        ON CONFLICT (meeting_id, user_id)
-        DO UPDATE SET status = 'admitted', is_host = TRUE, admitted_at = {now}, updated_at = {now}, left_at = NULL,
-                      display_name = COALESCE($3, meeting_participants.display_name)
-        RETURNING {PARTICIPANT_COLUMNS}
-        "#,
-        now = now_expr(4)
-    );
-    let query = q(&query);
-    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
-        .bind(meeting_id)
-        .bind(user_id)
-        .bind(display_name))
-    .fetch_one(pool)
-    .await
-}
-
-/// Atomically join a meeting as an attendee, respecting the current `waiting_room_enabled`
-/// setting. Opens the transaction through [`lock::begin_write`] so the meeting row is
-/// serialized against concurrent waiting room toggles via
-/// [`crate::db::meetings::update_waiting_room_enabled`].
+/// Join a meeting as an attendee, honouring the current `waiting_room_enabled`.
 ///
-/// Returns `(auto_admitted, ParticipantRow, waiting_room_enabled)` where `auto_admitted`
-/// is `true` when the participant was immediately admitted (waiting room disabled).
-/// The third element is the `waiting_room_enabled` value observed under the write lock,
-/// which avoids stale reads from a pre-transaction fetch.
+/// Reads the flag under the write lock ([`lock::begin_write`]) so it cannot go
+/// stale against a concurrent [`crate::db::meetings::update_waiting_room_enabled`],
+/// then inserts as `waiting` or `admitted` accordingly. Returns
+/// `(auto_admitted, row, waiting_room_enabled)`.
 pub async fn join_attendee(
     pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
     display_name: Option<&str>,
 ) -> Result<(bool, ParticipantRow, bool), sqlx::Error> {
-    lock::with_write_retry(|| Box::pin(join_attendee_txn(pool, meeting_id, user_id, display_name)))
-        .await
-}
+    with_retry! {
+        let mut tx = lock::begin_write(pool).await?;
 
-/// One attempt of [`join_attendee`]. Replayable: a failure rolls the transaction
-/// back before returning.
-async fn join_attendee_txn(
-    pool: &DbPool,
-    meeting_id: i32,
-    user_id: &str,
-    display_name: Option<&str>,
-) -> Result<(bool, ParticipantRow, bool), sqlx::Error> {
-    let mut tx = lock::begin_write(pool).await?;
+        let (waiting_room_enabled,): (bool,) =
+            sqlx::query_as(&q(lock::SELECT_WAITING_ROOM_LOCKED))
+                .bind(meeting_id)
+                .fetch_one(&mut *tx)
+                .await?;
 
-    // Read the flag under the write lock so a concurrent toggle cannot slip in
-    // between this read and the insert below.
-    let (waiting_room_enabled,): (bool,) = sqlx::query_as(&q(lock::SELECT_WAITING_ROOM_LOCKED))
-        .bind(meeting_id)
+        let template = if waiting_room_enabled {
+            "INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name)
+             VALUES ($1, $2, 'waiting', FALSE, $3)
+             ON CONFLICT (meeting_id, user_id)
+             DO UPDATE SET status = 'waiting', updated_at = {now}, left_at = NULL,
+                           display_name = COALESCE($3, meeting_participants.display_name)
+             RETURNING {cols}"
+        } else {
+            "INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
+             VALUES ($1, $2, 'admitted', FALSE, $3, {now})
+             ON CONFLICT (meeting_id, user_id)
+             DO UPDATE SET status = 'admitted', admitted_at = {now}, updated_at = {now}, left_at = NULL,
+                           display_name = COALESCE($3, meeting_participants.display_name)
+             RETURNING {cols}"
+        };
+        let sql = stmt(template, 4);
+        let row = bind_now!(sqlx::query_as::<_, ParticipantRow>(&sql)
+            .bind(meeting_id)
+            .bind(user_id)
+            .bind(display_name))
         .fetch_one(&mut *tx)
         .await?;
 
-    let row = if waiting_room_enabled {
-        let query = format!(
-            r#"
-            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name)
-            VALUES ($1, $2, 'waiting', FALSE, $3)
-            ON CONFLICT (meeting_id, user_id)
-            DO UPDATE SET status = 'waiting', updated_at = {now}, left_at = NULL,
-                          display_name = COALESCE($3, meeting_participants.display_name)
-            RETURNING {PARTICIPANT_COLUMNS}
-            "#,
-            now = now_expr(4)
-        );
-        let query = q(&query);
-        bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
-            .bind(meeting_id)
-            .bind(user_id)
-            .bind(display_name))
-        .fetch_one(&mut *tx)
-        .await?
-    } else {
-        let query = format!(
-            r#"
-            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
-            VALUES ($1, $2, 'admitted', FALSE, $3, {now})
-            ON CONFLICT (meeting_id, user_id)
-            DO UPDATE SET status = 'admitted', admitted_at = {now}, updated_at = {now}, left_at = NULL,
-                          display_name = COALESCE($3, meeting_participants.display_name)
-            RETURNING {PARTICIPANT_COLUMNS}
-            "#,
-            now = now_expr(4)
-        );
-        let query = q(&query);
-        bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
-            .bind(meeting_id)
-            .bind(user_id)
-            .bind(display_name))
-        .fetch_one(&mut *tx)
-        .await?
-    };
-
-    tx.commit().await?;
-    Ok((!waiting_room_enabled, row, waiting_room_enabled))
+        tx.commit().await?;
+        Ok((!waiting_room_enabled, row, waiting_room_enabled))
+    }
 }
 
 /// Get all participants in 'waiting' status for a meeting.
@@ -178,13 +131,12 @@ pub async fn get_waiting(
     pool: &DbPool,
     meeting_id: i32,
 ) -> Result<Vec<ParticipantRow>, sqlx::Error> {
-    let query = format!(
+    sqlx::query_as::<_, ParticipantRow>(&q(&format!(
         "SELECT {PARTICIPANT_COLUMNS} FROM meeting_participants WHERE meeting_id = $1 AND status = 'waiting'"
-    );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
-        .bind(meeting_id)
-        .fetch_all(pool)
-        .await
+    )))
+    .bind(meeting_id)
+    .fetch_all(pool)
+    .await
 }
 
 /// Get all admitted (active) participants in a meeting.
@@ -192,13 +144,12 @@ pub async fn get_admitted(
     pool: &DbPool,
     meeting_id: i32,
 ) -> Result<Vec<ParticipantRow>, sqlx::Error> {
-    let query = format!(
+    sqlx::query_as::<_, ParticipantRow>(&q(&format!(
         "SELECT {PARTICIPANT_COLUMNS} FROM meeting_participants WHERE meeting_id = $1 AND status = 'admitted'"
-    );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
-        .bind(meeting_id)
-        .fetch_all(pool)
-        .await
+    )))
+    .bind(meeting_id)
+    .fetch_all(pool)
+    .await
 }
 
 /// Get a single participant's status.
@@ -207,100 +158,70 @@ pub async fn get_status(
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
-    let query = format!(
+    sqlx::query_as::<_, ParticipantRow>(&q(&format!(
         "SELECT {PARTICIPANT_COLUMNS} FROM meeting_participants WHERE meeting_id = $1 AND user_id = $2"
-    );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
-        .bind(meeting_id)
-        .bind(user_id)
-        .fetch_optional(pool)
-        .await
+    )))
+    .bind(meeting_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
 }
 
-/// Admit a single participant.
+/// Admit a single waiting participant.
 pub async fn admit(
     pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
-    lock::with_write_retry(|| Box::pin(admit_stmt(pool, meeting_id, user_id))).await
-}
-
-async fn admit_stmt(
-    pool: &DbPool,
-    meeting_id: i32,
-    user_id: &str,
-) -> Result<Option<ParticipantRow>, sqlx::Error> {
-    let query = format!(
-        r#"
-        UPDATE meeting_participants
-        SET status = 'admitted', admitted_at = {now}, updated_at = {now}
-        WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
-        RETURNING {PARTICIPANT_COLUMNS}
-        "#,
-        now = now_expr(3)
-    );
-    let query = q(&query);
-    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
-        .bind(meeting_id)
-        .bind(user_id))
-    .fetch_optional(pool)
-    .await
+    with_retry! {
+        let sql = stmt(
+            "UPDATE meeting_participants SET status = 'admitted', admitted_at = {now}, updated_at = {now}
+             WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
+             RETURNING {cols}",
+            3,
+        );
+        bind_now!(sqlx::query_as::<_, ParticipantRow>(&sql)
+            .bind(meeting_id)
+            .bind(user_id))
+        .fetch_optional(pool)
+        .await
+    }
 }
 
 /// Admit all waiting participants at once.
 pub async fn admit_all(pool: &DbPool, meeting_id: i32) -> Result<Vec<ParticipantRow>, sqlx::Error> {
-    lock::with_write_retry(|| Box::pin(admit_all_stmt(pool, meeting_id))).await
+    with_retry! {
+        let sql = stmt(
+            "UPDATE meeting_participants SET status = 'admitted', admitted_at = {now}, updated_at = {now}
+             WHERE meeting_id = $1 AND status = 'waiting'
+             RETURNING {cols}",
+            2,
+        );
+        bind_now!(sqlx::query_as::<_, ParticipantRow>(&sql).bind(meeting_id))
+            .fetch_all(pool)
+            .await
+    }
 }
 
-async fn admit_all_stmt(
-    pool: &DbPool,
-    meeting_id: i32,
-) -> Result<Vec<ParticipantRow>, sqlx::Error> {
-    let query = format!(
-        r#"
-        UPDATE meeting_participants
-        SET status = 'admitted', admitted_at = {now}, updated_at = {now}
-        WHERE meeting_id = $1 AND status = 'waiting'
-        RETURNING {PARTICIPANT_COLUMNS}
-        "#,
-        now = now_expr(2)
-    );
-    let query = q(&query);
-    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query).bind(meeting_id))
-        .fetch_all(pool)
-        .await
-}
-
-/// Reject a participant.
+/// Reject a waiting participant.
 pub async fn reject(
     pool: &DbPool,
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
-    lock::with_write_retry(|| Box::pin(reject_stmt(pool, meeting_id, user_id))).await
-}
-
-async fn reject_stmt(
-    pool: &DbPool,
-    meeting_id: i32,
-    user_id: &str,
-) -> Result<Option<ParticipantRow>, sqlx::Error> {
-    let query = format!(
-        r#"
-        UPDATE meeting_participants
-        SET status = 'rejected', updated_at = {now}
-        WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
-        RETURNING {PARTICIPANT_COLUMNS}
-        "#,
-        now = now_expr(3)
-    );
-    let query = q(&query);
-    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
-        .bind(meeting_id)
-        .bind(user_id))
-    .fetch_optional(pool)
-    .await
+    with_retry! {
+        let sql = stmt(
+            "UPDATE meeting_participants SET status = 'rejected', updated_at = {now}
+             WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
+             RETURNING {cols}",
+            3,
+        );
+        bind_now!(sqlx::query_as::<_, ParticipantRow>(&sql)
+            .bind(meeting_id)
+            .bind(user_id))
+        .fetch_optional(pool)
+        .await
+    }
 }
 
 /// Leave a meeting (set status to 'left').
@@ -309,29 +230,19 @@ pub async fn leave(
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
-    lock::with_write_retry(|| Box::pin(leave_stmt(pool, meeting_id, user_id))).await
-}
-
-async fn leave_stmt(
-    pool: &DbPool,
-    meeting_id: i32,
-    user_id: &str,
-) -> Result<Option<ParticipantRow>, sqlx::Error> {
-    let query = format!(
-        r#"
-        UPDATE meeting_participants
-        SET status = 'left', left_at = {now}, updated_at = {now}
-        WHERE meeting_id = $1 AND user_id = $2 AND status IN ('admitted', 'waiting')
-        RETURNING {PARTICIPANT_COLUMNS}
-        "#,
-        now = now_expr(3)
-    );
-    let query = q(&query);
-    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
-        .bind(meeting_id)
-        .bind(user_id))
-    .fetch_optional(pool)
-    .await
+    with_retry! {
+        let sql = stmt(
+            "UPDATE meeting_participants SET status = 'left', left_at = {now}, updated_at = {now}
+             WHERE meeting_id = $1 AND user_id = $2 AND status IN ('admitted', 'waiting')
+             RETURNING {cols}",
+            3,
+        );
+        bind_now!(sqlx::query_as::<_, ParticipantRow>(&sql)
+            .bind(meeting_id)
+            .bind(user_id))
+        .fetch_optional(pool)
+        .await
+    }
 }
 
 /// Count admitted participants in a meeting.
@@ -356,11 +267,9 @@ pub async fn count_waiting(pool: &DbPool, meeting_id: i32) -> Result<i64, sqlx::
     Ok(row.0)
 }
 
-// -- Conversions to API response types --
-
 impl ParticipantRow {
-    /// Convert a database row into the API response type.
-    /// Optionally attach a `room_token` (only for the participant themselves).
+    /// Convert a database row into the API response type, optionally attaching a
+    /// `room_token` (only for the participant themselves).
     pub fn into_participant_status(
         self,
         room_token: Option<String>,

--- a/meeting-api/src/db/participants.rs
+++ b/meeting-api/src/db/participants.rs
@@ -12,10 +12,24 @@
  */
 
 //! Meeting participant table queries.
+//!
+//! # Why the `_stmt` / `_txn` split
+//!
+//! Every write here is a public wrapper around a private inner function, called
+//! through [`crate::db::lock::with_write_retry`]. On PostgreSQL the wrapper is a
+//! pass-through. On SQLite it absorbs `SQLITE_BUSY`, which a single writer can
+//! still hit once `busy_timeout` expires — without it a busy database surfaces
+//! to the API client as a bare "database is locked".
+//!
+//! Replaying is safe for both shapes. A `_txn` inner has already rolled its
+//! transaction back before returning an error, and a `_stmt` inner is a single
+//! autocommit statement that applied nothing if it failed. The status
+//! predicates (`AND status = 'waiting'`) also make a replay that races a real
+//! change return `None` rather than double-applying.
 
 use chrono::{DateTime, Utc};
 
-use crate::db::{lock, q, DbPool};
+use crate::db::{bind_now, lock, now_expr, q, DbPool};
 
 /// Row returned from the `meeting_participants` table.
 #[derive(Debug, sqlx::FromRow)]
@@ -47,23 +61,36 @@ pub async fn upsert_host(
     user_id: &str,
     display_name: Option<&str>,
 ) -> Result<ParticipantRow, sqlx::Error> {
+    lock::with_write_retry(|| Box::pin(upsert_host_stmt(pool, meeting_id, user_id, display_name)))
+        .await
+}
+
+async fn upsert_host_stmt(
+    pool: &DbPool,
+    meeting_id: i32,
+    user_id: &str,
+    display_name: Option<&str>,
+) -> Result<ParticipantRow, sqlx::Error> {
+    // `joined_at` / `created_at` are left to the column DEFAULTs, which are the
+    // database's clock on both backends.
     let query = format!(
         r#"
-        INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at, joined_at, created_at, updated_at)
-        VALUES ($1, $2, 'admitted', TRUE, $3, $4, $4, $4, $4)
+        INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
+        VALUES ($1, $2, 'admitted', TRUE, $3, {now})
         ON CONFLICT (meeting_id, user_id)
-        DO UPDATE SET status = 'admitted', is_host = TRUE, admitted_at = $4, updated_at = $4, left_at = NULL,
+        DO UPDATE SET status = 'admitted', is_host = TRUE, admitted_at = {now}, updated_at = {now}, left_at = NULL,
                       display_name = COALESCE($3, meeting_participants.display_name)
         RETURNING {PARTICIPANT_COLUMNS}
-        "#
+        "#,
+        now = now_expr(4)
     );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
+    let query = q(&query);
+    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
         .bind(meeting_id)
         .bind(user_id)
-        .bind(display_name)
-        .bind(Utc::now())
-        .fetch_one(pool)
-        .await
+        .bind(display_name))
+    .fetch_one(pool)
+    .await
 }
 
 /// Atomically join a meeting as an attendee, respecting the current `waiting_room_enabled`
@@ -94,7 +121,6 @@ async fn join_attendee_txn(
     display_name: Option<&str>,
 ) -> Result<(bool, ParticipantRow, bool), sqlx::Error> {
     let mut tx = lock::begin_write(pool).await?;
-    let now = Utc::now();
 
     // Read the flag under the write lock so a concurrent toggle cannot slip in
     // between this read and the insert below.
@@ -106,39 +132,41 @@ async fn join_attendee_txn(
     let row = if waiting_room_enabled {
         let query = format!(
             r#"
-            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, joined_at, created_at, updated_at)
-            VALUES ($1, $2, 'waiting', FALSE, $3, $4, $4, $4)
+            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name)
+            VALUES ($1, $2, 'waiting', FALSE, $3)
             ON CONFLICT (meeting_id, user_id)
-            DO UPDATE SET status = 'waiting', updated_at = $4, left_at = NULL,
+            DO UPDATE SET status = 'waiting', updated_at = {now}, left_at = NULL,
                           display_name = COALESCE($3, meeting_participants.display_name)
             RETURNING {PARTICIPANT_COLUMNS}
-            "#
+            "#,
+            now = now_expr(4)
         );
-        sqlx::query_as::<_, ParticipantRow>(&q(&query))
+        let query = q(&query);
+        bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
             .bind(meeting_id)
             .bind(user_id)
-            .bind(display_name)
-            .bind(now)
-            .fetch_one(&mut *tx)
-            .await?
+            .bind(display_name))
+        .fetch_one(&mut *tx)
+        .await?
     } else {
         let query = format!(
             r#"
-            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at, joined_at, created_at, updated_at)
-            VALUES ($1, $2, 'admitted', FALSE, $3, $4, $4, $4, $4)
+            INSERT INTO meeting_participants (meeting_id, user_id, status, is_host, display_name, admitted_at)
+            VALUES ($1, $2, 'admitted', FALSE, $3, {now})
             ON CONFLICT (meeting_id, user_id)
-            DO UPDATE SET status = 'admitted', admitted_at = $4, updated_at = $4, left_at = NULL,
+            DO UPDATE SET status = 'admitted', admitted_at = {now}, updated_at = {now}, left_at = NULL,
                           display_name = COALESCE($3, meeting_participants.display_name)
             RETURNING {PARTICIPANT_COLUMNS}
-            "#
+            "#,
+            now = now_expr(4)
         );
-        sqlx::query_as::<_, ParticipantRow>(&q(&query))
+        let query = q(&query);
+        bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
             .bind(meeting_id)
             .bind(user_id)
-            .bind(display_name)
-            .bind(now)
-            .fetch_one(&mut *tx)
-            .await?
+            .bind(display_name))
+        .fetch_one(&mut *tx)
+        .await?
     };
 
     tx.commit().await?;
@@ -195,35 +223,51 @@ pub async fn admit(
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
+    lock::with_write_retry(|| Box::pin(admit_stmt(pool, meeting_id, user_id))).await
+}
+
+async fn admit_stmt(
+    pool: &DbPool,
+    meeting_id: i32,
+    user_id: &str,
+) -> Result<Option<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'admitted', admitted_at = $3, updated_at = $3
+        SET status = 'admitted', admitted_at = {now}, updated_at = {now}
         WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
         RETURNING {PARTICIPANT_COLUMNS}
-        "#
+        "#,
+        now = now_expr(3)
     );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
+    let query = q(&query);
+    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
         .bind(meeting_id)
-        .bind(user_id)
-        .bind(Utc::now())
-        .fetch_optional(pool)
-        .await
+        .bind(user_id))
+    .fetch_optional(pool)
+    .await
 }
 
 /// Admit all waiting participants at once.
 pub async fn admit_all(pool: &DbPool, meeting_id: i32) -> Result<Vec<ParticipantRow>, sqlx::Error> {
+    lock::with_write_retry(|| Box::pin(admit_all_stmt(pool, meeting_id))).await
+}
+
+async fn admit_all_stmt(
+    pool: &DbPool,
+    meeting_id: i32,
+) -> Result<Vec<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'admitted', admitted_at = $2, updated_at = $2
+        SET status = 'admitted', admitted_at = {now}, updated_at = {now}
         WHERE meeting_id = $1 AND status = 'waiting'
         RETURNING {PARTICIPANT_COLUMNS}
-        "#
+        "#,
+        now = now_expr(2)
     );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
-        .bind(meeting_id)
-        .bind(Utc::now())
+    let query = q(&query);
+    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query).bind(meeting_id))
         .fetch_all(pool)
         .await
 }
@@ -234,20 +278,29 @@ pub async fn reject(
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
+    lock::with_write_retry(|| Box::pin(reject_stmt(pool, meeting_id, user_id))).await
+}
+
+async fn reject_stmt(
+    pool: &DbPool,
+    meeting_id: i32,
+    user_id: &str,
+) -> Result<Option<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'rejected', updated_at = $3
+        SET status = 'rejected', updated_at = {now}
         WHERE meeting_id = $1 AND user_id = $2 AND status = 'waiting'
         RETURNING {PARTICIPANT_COLUMNS}
-        "#
+        "#,
+        now = now_expr(3)
     );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
+    let query = q(&query);
+    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
         .bind(meeting_id)
-        .bind(user_id)
-        .bind(Utc::now())
-        .fetch_optional(pool)
-        .await
+        .bind(user_id))
+    .fetch_optional(pool)
+    .await
 }
 
 /// Leave a meeting (set status to 'left').
@@ -256,20 +309,29 @@ pub async fn leave(
     meeting_id: i32,
     user_id: &str,
 ) -> Result<Option<ParticipantRow>, sqlx::Error> {
+    lock::with_write_retry(|| Box::pin(leave_stmt(pool, meeting_id, user_id))).await
+}
+
+async fn leave_stmt(
+    pool: &DbPool,
+    meeting_id: i32,
+    user_id: &str,
+) -> Result<Option<ParticipantRow>, sqlx::Error> {
     let query = format!(
         r#"
         UPDATE meeting_participants
-        SET status = 'left', left_at = $3, updated_at = $3
+        SET status = 'left', left_at = {now}, updated_at = {now}
         WHERE meeting_id = $1 AND user_id = $2 AND status IN ('admitted', 'waiting')
         RETURNING {PARTICIPANT_COLUMNS}
-        "#
+        "#,
+        now = now_expr(3)
     );
-    sqlx::query_as::<_, ParticipantRow>(&q(&query))
+    let query = q(&query);
+    bind_now!(sqlx::query_as::<_, ParticipantRow>(&query)
         .bind(meeting_id)
-        .bind(user_id)
-        .bind(Utc::now())
-        .fetch_optional(pool)
-        .await
+        .bind(user_id))
+    .fetch_optional(pool)
+    .await
 }
 
 /// Count admitted participants in a meeting.

--- a/meeting-api/src/main.rs
+++ b/meeting-api/src/main.rs
@@ -20,7 +20,6 @@ use axum::http;
 use meeting_api::config::Config;
 use meeting_api::routes;
 use meeting_api::state::AppState;
-use sqlx::postgres::PgPoolOptions;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing_subscriber::EnvFilter;
 
@@ -38,13 +37,7 @@ async fn main() {
         .await
         .expect("OIDC discovery failed");
 
-    let pool = PgPoolOptions::new()
-        .max_connections(20)
-        .connect(&config.database_url)
-        .await
-        .expect("failed to connect to PostgreSQL");
-
-    tracing::info!("Connected to PostgreSQL");
+    let pool = meeting_api::db::connect(&config.database_url).await;
 
     // Connect to NATS if configured. The server works without NATS (graceful degradation).
     let nats = match &config.nats_url {

--- a/meeting-api/src/state.rs
+++ b/meeting-api/src/state.rs
@@ -16,14 +16,14 @@
 use std::sync::Arc;
 
 use crate::config::{Config, OAuthConfig};
+use crate::db::DbPool;
 use crate::oauth::JwksCache;
-use sqlx::PgPool;
 
 /// Application state shared across all request handlers.
 #[derive(Clone)]
 pub struct AppState {
-    /// PostgreSQL connection pool.
-    pub db: PgPool,
+    /// Database connection pool (PostgreSQL or SQLite, per the enabled feature).
+    pub db: DbPool,
     /// JWT signing secret (shared with the Media Server).
     pub jwt_secret: String,
     /// Room access token time-to-live in seconds.
@@ -52,7 +52,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(db: PgPool, config: &Config, nats: Option<async_nats::Client>) -> Self {
+    pub fn new(db: DbPool, config: &Config, nats: Option<async_nats::Client>) -> Self {
         let jwks_cache = config
             .oauth
             .as_ref()

--- a/meeting-api/tests/observer_token_tests.rs
+++ b/meeting-api/tests/observer_token_tests.rs
@@ -36,7 +36,7 @@ use videocall_meeting_types::{
 };
 
 /// Helper: create a meeting (idle state, host has NOT joined).
-async fn setup_idle_meeting(pool: &sqlx::PgPool, room_id: &str) {
+async fn setup_idle_meeting(pool: &meeting_api::db::DbPool, room_id: &str) {
     cleanup_test_data(pool, room_id).await;
 
     let app = build_app(pool.clone());
@@ -54,7 +54,7 @@ async fn setup_idle_meeting(pool: &sqlx::PgPool, room_id: &str) {
 }
 
 /// Helper: create a meeting and have the host join (activates it).
-async fn setup_active_meeting(pool: &sqlx::PgPool, room_id: &str) {
+async fn setup_active_meeting(pool: &meeting_api::db::DbPool, room_id: &str) {
     setup_idle_meeting(pool, room_id).await;
 
     let app = build_app(pool.clone());
@@ -69,7 +69,7 @@ async fn setup_active_meeting(pool: &sqlx::PgPool, room_id: &str) {
 }
 
 /// Helper: create a meeting with waiting room disabled and have the host join.
-async fn setup_active_meeting_no_waiting_room(pool: &sqlx::PgPool, room_id: &str) {
+async fn setup_active_meeting_no_waiting_room(pool: &meeting_api::db::DbPool, room_id: &str) {
     cleanup_test_data(pool, room_id).await;
 
     let app = build_app(pool.clone());

--- a/meeting-api/tests/participant_tests.rs
+++ b/meeting-api/tests/participant_tests.rs
@@ -26,7 +26,7 @@ use videocall_meeting_types::{
 };
 
 /// Helper: create a meeting and have the host join (activates it).
-async fn setup_active_meeting(pool: &sqlx::PgPool, room_id: &str) {
+async fn setup_active_meeting(pool: &meeting_api::db::DbPool, room_id: &str) {
     cleanup_test_data(pool, room_id).await;
 
     // Create meeting.

--- a/meeting-api/tests/schema_tests.rs
+++ b/meeting-api/tests/schema_tests.rs
@@ -247,11 +247,20 @@ async fn test_room_id_is_unique_only_among_live_meetings() {
 
 // ── updated_at ──────────────────────────────────────────────────────────
 
-/// The SQLite port has no `AFTER UPDATE` trigger for `updated_at`, on purpose:
-/// SQLite evaluates `RETURNING` before AFTER-triggers fire, so a trigger-driven
-/// `updated_at` comes back stale — the caller sees the value from *before* its
-/// own write. Every UPDATE therefore sets `updated_at` explicitly. This test is
-/// what stops the triggers being reintroduced.
+/// `UPDATE ... RETURNING updated_at` must return the *new* value.
+///
+/// The two backends satisfy this for different reasons, and this test only has
+/// teeth on one of them. PostgreSQL passes via its `BEFORE UPDATE` trigger,
+/// which runs before `RETURNING` is evaluated — it would pass even if the
+/// statement did not set `updated_at` at all, so on PostgreSQL this is a
+/// regression guard on the trigger, not on the query.
+///
+/// SQLite is the real subject. It has no trigger, because SQLite evaluates
+/// `RETURNING` *before* AFTER-triggers fire and a trigger-driven `updated_at`
+/// would come back stale — the caller would see the value from before its own
+/// write. Every UPDATE therefore sets `updated_at` explicitly, and it is the
+/// SQLite run of this test that stops those writes being dropped or the
+/// triggers being reintroduced.
 #[tokio::test]
 #[serial]
 async fn test_update_returning_yields_the_new_updated_at() {

--- a/meeting-api/tests/schema_tests.rs
+++ b/meeting-api/tests/schema_tests.rs
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ *
+ * at your option.
+ */
+
+//! Schema-level integration tests, run against both backends.
+//!
+//! `dbmate/sqlite/db/migrations` is a hand-port of `dbmate/db/migrations`; no
+//! compiler compares the two. These tests are that comparison. Each one states
+//! a property of the PostgreSQL schema and asserts the SQLite port has it too,
+//! which is why they are *not* `cfg`-gated: running the identical assertions on
+//! PostgreSQL is what makes them a port check rather than a description of
+//! whatever SQLite happens to do.
+//!
+//! They go through the shared `db` layer wherever a function exists for the
+//! operation, so the `q()` placeholder shim and the bound-timestamp convention
+//! are exercised alongside the DDL.
+
+mod test_helpers;
+
+use chrono::Utc;
+use meeting_api::db::{meetings as db_meetings, participants as db_participants, q, DbPool};
+use serde_json::json;
+use serial_test::serial;
+use test_helpers::*;
+
+/// Ends a meeting the way the delete path does, so `room_id` becomes reusable.
+async fn soft_delete(pool: &DbPool, room_id: &str, creator: &str) {
+    db_meetings::soft_delete(pool, room_id, creator)
+        .await
+        .expect("soft delete should succeed")
+        .expect("soft delete should match a row");
+}
+
+// ── Foreign keys ────────────────────────────────────────────────────────
+
+/// `ON DELETE CASCADE` is inert on SQLite unless `PRAGMA foreign_keys` is on,
+/// and that pragma is per connection. This runs through `get_test_pool`, i.e.
+/// `meeting_api::db::connect`, precisely because a hand-rolled connection with
+/// its own options would pass while production silently leaked orphan rows.
+#[tokio::test]
+#[serial]
+async fn test_deleting_a_meeting_cascades_to_its_participants() {
+    let pool = get_test_pool().await;
+    let room_id = "schema-cascade";
+    cleanup_test_data(&pool, room_id).await;
+
+    let meeting = db_meetings::create(&pool, room_id, "host@example.com", None, &json!([]))
+        .await
+        .expect("create meeting");
+    db_participants::upsert_host(&pool, meeting.id, "host@example.com", None)
+        .await
+        .expect("insert host");
+    db_participants::join_attendee(&pool, meeting.id, "guest@example.com", None)
+        .await
+        .expect("insert attendee");
+
+    let before: (i64,) = sqlx::query_as(&q(
+        "SELECT COUNT(*) FROM meeting_participants WHERE meeting_id = $1",
+    ))
+    .bind(meeting.id)
+    .fetch_one(&pool)
+    .await
+    .expect("count before");
+    assert_eq!(before.0, 2, "both participants should have been inserted");
+
+    sqlx::query(&q("DELETE FROM meetings WHERE id = $1"))
+        .bind(meeting.id)
+        .execute(&pool)
+        .await
+        .expect("hard delete meeting");
+
+    let after: (i64,) = sqlx::query_as(&q(
+        "SELECT COUNT(*) FROM meeting_participants WHERE meeting_id = $1",
+    ))
+    .bind(meeting.id)
+    .fetch_one(&pool)
+    .await
+    .expect("count after");
+    assert_eq!(
+        after.0, 0,
+        "deleting a meeting must cascade to meeting_participants; \
+         orphans here mean PRAGMA foreign_keys is off on this connection"
+    );
+}
+
+/// The other half of the same pragma: a participant may not reference a
+/// meeting that does not exist. Without `foreign_keys` SQLite accepts this.
+#[tokio::test]
+#[serial]
+async fn test_participant_referencing_a_missing_meeting_is_rejected() {
+    let pool = get_test_pool().await;
+
+    let result = sqlx::query(&q(
+        "INSERT INTO meeting_participants (meeting_id, user_id, status, joined_at, created_at, updated_at) \
+         VALUES ($1, $2, 'waiting', $3, $3, $3)",
+    ))
+    .bind(-424242_i32)
+    .bind("ghost@example.com")
+    .bind(Utc::now())
+    .execute(&pool)
+    .await;
+
+    assert!(
+        result.is_err(),
+        "insert against a non-existent meeting_id must violate the foreign key"
+    );
+}
+
+// ── CHECK constraints ───────────────────────────────────────────────────
+
+/// PostgreSQL has `CHECK (jsonb_array_length(attendees) <= 100)`; the port uses
+/// `json_array_length`. Both must reject the 101st attendee.
+#[tokio::test]
+#[serial]
+async fn test_attendees_over_one_hundred_are_rejected() {
+    let pool = get_test_pool().await;
+    let room_id = "schema-attendees-limit";
+    cleanup_test_data(&pool, room_id).await;
+
+    let hundred: Vec<String> = (0..100).map(|i| format!("a{i}@example.com")).collect();
+    db_meetings::create(&pool, room_id, "host@example.com", None, &json!(hundred))
+        .await
+        .expect("100 attendees is at the limit and must be accepted");
+    cleanup_test_data(&pool, room_id).await;
+
+    let hundred_one: Vec<String> = (0..101).map(|i| format!("a{i}@example.com")).collect();
+    let result = db_meetings::create(
+        &pool,
+        room_id,
+        "host@example.com",
+        None,
+        &json!(hundred_one),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "101 attendees must be rejected by the attendees length CHECK"
+    );
+    assert!(
+        db_meetings::get_by_room_id(&pool, room_id)
+            .await
+            .expect("lookup")
+            .is_none(),
+        "the rejected insert must not have left a row behind"
+    );
+}
+
+/// `VARCHAR(255)` in the PostgreSQL schema became `TEXT` + `CHECK (length(..) <= 255)`
+/// in the port, because SQLite ignores type-name length limits outright. Assert
+/// the limit is enforced on the columns that take user-controlled strings.
+#[tokio::test]
+#[serial]
+async fn test_columns_ported_from_varchar255_reject_longer_values() {
+    let pool = get_test_pool().await;
+    let room_id = "schema-length-limit";
+    cleanup_test_data(&pool, room_id).await;
+
+    let too_long = "x".repeat(256);
+    let at_limit = "y".repeat(255);
+
+    // room_id
+    assert!(
+        db_meetings::create(&pool, &too_long, "host@example.com", None, &json!([]))
+            .await
+            .is_err(),
+        "a 256-character room_id must be rejected"
+    );
+
+    // creator_id
+    assert!(
+        db_meetings::create(&pool, room_id, &too_long, None, &json!([]))
+            .await
+            .is_err(),
+        "a 256-character creator_id must be rejected"
+    );
+
+    let meeting = db_meetings::create(&pool, room_id, "host@example.com", None, &json!([]))
+        .await
+        .expect("create meeting with in-range values");
+
+    // display_name on meeting_participants
+    assert!(
+        db_participants::upsert_host(&pool, meeting.id, "host@example.com", Some(&too_long))
+            .await
+            .is_err(),
+        "a 256-character display_name must be rejected"
+    );
+    db_participants::upsert_host(&pool, meeting.id, "host@example.com", Some(&at_limit))
+        .await
+        .expect("255 characters is at the limit and must be accepted");
+
+    // user_id on meeting_participants
+    assert!(
+        db_participants::join_attendee(&pool, meeting.id, &too_long, None)
+            .await
+            .is_err(),
+        "a 256-character user_id must be rejected"
+    );
+
+    cleanup_test_data(&pool, room_id).await;
+}
+
+// ── Partial unique index ────────────────────────────────────────────────
+
+/// `idx_meetings_room_id_unique_active` is `UNIQUE (room_id) WHERE deleted_at IS NULL`.
+/// Both halves matter: reuse after deletion is a product requirement, and
+/// blocking reuse while active is what stops two live meetings sharing a room.
+#[tokio::test]
+#[serial]
+async fn test_room_id_is_unique_only_among_live_meetings() {
+    let pool = get_test_pool().await;
+    let room_id = "schema-partial-unique";
+    cleanup_test_data(&pool, room_id).await;
+
+    let first = db_meetings::create(&pool, room_id, "host@example.com", None, &json!([]))
+        .await
+        .expect("first meeting");
+
+    let duplicate = db_meetings::create(&pool, room_id, "host@example.com", None, &json!([])).await;
+    assert!(
+        duplicate.is_err(),
+        "a second live meeting must not be able to take a room_id that is in use"
+    );
+
+    soft_delete(&pool, room_id, "host@example.com").await;
+
+    let reused = db_meetings::create(&pool, room_id, "someone-else@example.com", None, &json!([]))
+        .await
+        .expect("room_id must be reusable once the previous meeting is soft-deleted");
+    assert_ne!(
+        reused.id, first.id,
+        "reuse must create a new meeting, not resurrect the old one"
+    );
+
+    cleanup_test_data(&pool, room_id).await;
+}
+
+// ── updated_at ──────────────────────────────────────────────────────────
+
+/// The SQLite port has no `AFTER UPDATE` trigger for `updated_at`, on purpose:
+/// SQLite evaluates `RETURNING` before AFTER-triggers fire, so a trigger-driven
+/// `updated_at` comes back stale — the caller sees the value from *before* its
+/// own write. Every UPDATE therefore sets `updated_at` explicitly. This test is
+/// what stops the triggers being reintroduced.
+#[tokio::test]
+#[serial]
+async fn test_update_returning_yields_the_new_updated_at() {
+    let pool = get_test_pool().await;
+    let room_id = "schema-updated-at";
+    cleanup_test_data(&pool, room_id).await;
+
+    let created = db_meetings::create(&pool, room_id, "host@example.com", None, &json!([]))
+        .await
+        .expect("create meeting");
+
+    // Guarantee a strictly greater timestamp regardless of clock resolution.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let toggled =
+        db_meetings::update_waiting_room_enabled(&pool, room_id, "host@example.com", false)
+            .await
+            .expect("toggle waiting room")
+            .expect("toggle should match the meeting");
+
+    assert!(
+        toggled.updated_at > created.updated_at,
+        "UPDATE ... RETURNING updated_at returned {:?}, which is not newer than the \
+         pre-update value {:?} — a stale value here means updated_at is being written \
+         by an AFTER trigger instead of by the statement itself",
+        toggled.updated_at,
+        created.updated_at
+    );
+
+    // And the returned value must match what was actually persisted.
+    let persisted = db_meetings::get_by_room_id(&pool, room_id)
+        .await
+        .expect("re-read meeting")
+        .expect("meeting should exist");
+    assert_eq!(
+        persisted.updated_at, toggled.updated_at,
+        "the value RETURNING produced must be the value stored in the row"
+    );
+
+    cleanup_test_data(&pool, room_id).await;
+}
+
+// ── Timestamp ordering ──────────────────────────────────────────────────
+
+/// SQLite stores these timestamps as TEXT, so `ORDER BY created_at DESC` is a
+/// lexicographic sort of whatever format was written. `datetime('now')` renders
+/// `2026-07-21 04:39:04` while a bound `DateTime<Utc>` renders RFC 3339 with a
+/// `T`; mixing the two in one column silently misorders rows (`' ' < 'T'`).
+/// Insert through the application, which binds RFC 3339 everywhere, and assert
+/// the ordering the list endpoint depends on.
+#[tokio::test]
+#[serial]
+async fn test_list_by_owner_orders_by_created_at_descending() {
+    let pool = get_test_pool().await;
+    let creator = "ordering-host@example.com";
+    let room_ids = ["schema-order-1", "schema-order-2", "schema-order-3"];
+    for room_id in room_ids {
+        cleanup_test_data(&pool, room_id).await;
+    }
+
+    for room_id in room_ids {
+        db_meetings::create(&pool, room_id, creator, None, &json!([]))
+            .await
+            .expect("create meeting");
+        // A gap far wider than either backend's timestamp resolution, so the
+        // expected order below is never a coin flip.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    let listed = db_meetings::list_by_owner(&pool, creator, 10, 0)
+        .await
+        .expect("list meetings");
+
+    let listed_rooms: Vec<&str> = listed.iter().map(|m| m.room_id.as_str()).collect();
+    assert_eq!(
+        listed_rooms,
+        vec!["schema-order-3", "schema-order-2", "schema-order-1"],
+        "newest meeting must sort first"
+    );
+
+    // Assert the underlying column is monotonically decreasing too, so a future
+    // change that returns the right rows in the wrong order still fails here.
+    for pair in listed.windows(2) {
+        assert!(
+            pair[0].created_at >= pair[1].created_at,
+            "created_at must be non-increasing across the result set, got {:?} then {:?}",
+            pair[0].created_at,
+            pair[1].created_at
+        );
+    }
+
+    for room_id in room_ids {
+        cleanup_test_data(&pool, room_id).await;
+    }
+}
+
+/// The format guard behind the test above: a timestamp written by the
+/// application must round-trip through the column and still compare correctly
+/// against a later one *as text*, which is how SQLite will compare them.
+#[tokio::test]
+#[serial]
+async fn test_stored_timestamps_sort_the_same_as_they_compare() {
+    let pool = get_test_pool().await;
+    let room_id = "schema-timestamp-format";
+    cleanup_test_data(&pool, room_id).await;
+
+    db_meetings::create(&pool, room_id, "host@example.com", None, &json!([]))
+        .await
+        .expect("create meeting");
+
+    // A cutoff safely in the past must select the row; one in the future must not.
+    let past = Utc::now() - chrono::Duration::hours(1);
+    let future = Utc::now() + chrono::Duration::hours(1);
+
+    let after_past: (i64,) = sqlx::query_as(&q(
+        "SELECT COUNT(*) FROM meetings WHERE room_id = $1 AND created_at > $2",
+    ))
+    .bind(room_id)
+    .bind(past)
+    .fetch_one(&pool)
+    .await
+    .expect("compare against past cutoff");
+    assert_eq!(
+        after_past.0, 1,
+        "a row created now must compare as later than an hour ago"
+    );
+
+    let after_future: (i64,) = sqlx::query_as(&q(
+        "SELECT COUNT(*) FROM meetings WHERE room_id = $1 AND created_at > $2",
+    ))
+    .bind(room_id)
+    .bind(future)
+    .fetch_one(&pool)
+    .await
+    .expect("compare against future cutoff");
+    assert_eq!(
+        after_future.0, 0,
+        "a row created now must not compare as later than an hour from now"
+    );
+
+    cleanup_test_data(&pool, room_id).await;
+}

--- a/meeting-api/tests/schema_tests.rs
+++ b/meeting-api/tests/schema_tests.rs
@@ -11,18 +11,11 @@
  * at your option.
  */
 
-//! Schema-level integration tests, run against both backends.
-//!
-//! `dbmate/sqlite/db/migrations` is a hand-port of `dbmate/db/migrations`; no
-//! compiler compares the two. These tests are that comparison. Each one states
-//! a property of the PostgreSQL schema and asserts the SQLite port has it too,
-//! which is why they are *not* `cfg`-gated: running the identical assertions on
-//! PostgreSQL is what makes them a port check rather than a description of
-//! whatever SQLite happens to do.
-//!
-//! They go through the shared `db` layer wherever a function exists for the
-//! operation, so the `q()` placeholder shim and the bound-timestamp convention
-//! are exercised alongside the DDL.
+//! Schema-level tests, run against both backends. `dbmate/sqlite` is a hand-port
+//! of `dbmate/db` that nothing compares at compile time; these are that
+//! comparison. Each states a property of the PostgreSQL schema and asserts the
+//! SQLite port has it too — hence not `cfg`-gated, so the PostgreSQL run keeps
+//! them honest as a port check rather than a description of SQLite.
 
 mod test_helpers;
 
@@ -249,18 +242,10 @@ async fn test_room_id_is_unique_only_among_live_meetings() {
 
 /// `UPDATE ... RETURNING updated_at` must return the *new* value.
 ///
-/// The two backends satisfy this for different reasons, and this test only has
-/// teeth on one of them. PostgreSQL passes via its `BEFORE UPDATE` trigger,
-/// which runs before `RETURNING` is evaluated — it would pass even if the
-/// statement did not set `updated_at` at all, so on PostgreSQL this is a
-/// regression guard on the trigger, not on the query.
-///
-/// SQLite is the real subject. It has no trigger, because SQLite evaluates
-/// `RETURNING` *before* AFTER-triggers fire and a trigger-driven `updated_at`
-/// would come back stale — the caller would see the value from before its own
-/// write. Every UPDATE therefore sets `updated_at` explicitly, and it is the
-/// SQLite run of this test that stops those writes being dropped or the
-/// triggers being reintroduced.
+/// SQLite is the real subject: it has no trigger (it evaluates `RETURNING`
+/// before AFTER-triggers, so one would return a stale value), and this guards
+/// the explicit `updated_at` writes that stand in for it. PostgreSQL passes via
+/// its `BEFORE UPDATE` trigger regardless, so there it only guards the trigger.
 #[tokio::test]
 #[serial]
 async fn test_update_returning_yields_the_new_updated_at() {

--- a/meeting-api/tests/sqlite_backend_tests.rs
+++ b/meeting-api/tests/sqlite_backend_tests.rs
@@ -11,12 +11,25 @@
  * at your option.
  */
 
-//! Tests for the parts of the SQLite backend that have no PostgreSQL analogue:
-//! the per-connection pragmas `db::connect` sets, and the `SQLITE_BUSY` retry
-//! in `db::lock::with_write_retry`.
+//! The parts of the SQLite backend that have no PostgreSQL analogue, and so
+//! cannot live in the shared suite: the per-connection pragmas `db::connect`
+//! sets, and the `SQLITE_BUSY` retry in `db::lock::with_write_retry`.
 //!
-//! Everything else about the SQLite build is covered by the shared suite, which
-//! runs unchanged under `--no-default-features --features sqlite`.
+//! Nothing here re-tests behaviour the shared suite already covers. Schema,
+//! queries and the waiting-room race all run against both backends from the
+//! ordinary test files; this file exists only for the two things PostgreSQL has
+//! no equivalent of.
+//!
+//! Because this file is SQLite-only it binds timestamps directly rather than
+//! going through `db::now_expr` / `bind_now!`, which are crate-internal and
+//! exist to keep *shared* SQL dialect-neutral. There is no PostgreSQL run of
+//! these tests for them to diverge from.
+//!
+//! Every test runs against the same `DATABASE_URL` database dbmate migrated for
+//! the rest of the suite. The pools opened here differ from the production pool
+//! in exactly one option each — the one under test — so what they prove is that
+//! the option is load-bearing, not that some separately-built schema behaves
+//! some way.
 //!
 //! ## Feature guards (verified by hand, not by a test)
 //!
@@ -29,15 +42,11 @@
 //! $ cargo check -p meeting-api --all-features
 //! error: meeting-api: the `postgres` and `sqlite` features are mutually exclusive.
 //!        Build with `--no-default-features --features sqlite` to select SQLite.
-//!   --> meeting-api/src/db/mod.rs:46:1
-//! error: could not compile `meeting-api` (lib) due to 1 previous error
 //!
 //! $ cargo check -p meeting-api --no-default-features
 //! error: meeting-api: exactly one database backend feature must be enabled
 //!        (`postgres` or `sqlite`).
-//!   --> meeting-api/src/db/mod.rs:52:1
 //! error[E0432]: unresolved import `crate::db::DbPool`
-//!   --> meeting-api/src/db/lock.rs:33:5
 //! ```
 //!
 //! The `--all-features` case stops at the guard with nothing else reported. The
@@ -49,22 +58,29 @@
 
 mod test_helpers;
 
-use meeting_api::db::{lock, DbPool};
+use chrono::Utc;
+use meeting_api::db::{lock, q, DbPool};
+use serial_test::serial;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::Row;
 use std::str::FromStr;
 use std::time::Duration;
-use test_helpers::sqlite_support;
+use test_helpers::{cleanup_test_data, get_test_pool};
 
 // ── Per-connection pragmas ──────────────────────────────────────────────
 
 /// `foreign_keys`, `journal_mode` and `busy_timeout` are per *connection*, so a
 /// pool that set them only while opening the first one would leave the other
 /// four on SQLite's defaults — foreign keys off, rollback journal, no wait.
-/// Hold every connection in the pool at once and check each of them.
+/// Hold every connection in the pool at once and check all three on each.
+///
+/// `busy_timeout` is the one that fails silently: a connection left at the
+/// default of 0 does not misbehave until it is the one that happens to hit
+/// contention, and then it returns `SQLITE_BUSY` instantly instead of waiting.
 #[tokio::test]
+#[serial]
 async fn test_every_pooled_connection_has_the_required_pragmas() {
-    let pool = sqlite_support::migrated_pool().await;
+    let pool = get_test_pool().await;
 
     // `db::connect` builds the pool with max_connections(5); holding five at
     // once guarantees each was configured on open rather than reused.
@@ -94,6 +110,17 @@ async fn test_every_pooled_connection_has_the_required_pragmas() {
             "wal",
             "connection {n} is not in WAL mode; readers will block on the writer"
         );
+
+        let busy_timeout: i64 = sqlx::query("PRAGMA busy_timeout")
+            .fetch_one(&mut **conn)
+            .await
+            .expect("read busy_timeout")
+            .get(0);
+        assert_eq!(
+            busy_timeout, 5_000,
+            "connection {n} has busy_timeout {busy_timeout}ms, not the 5000ms \
+             db::connect sets; it will surface SQLITE_BUSY without waiting"
+        );
     }
 }
 
@@ -102,25 +129,43 @@ async fn test_every_pooled_connection_has_the_required_pragmas() {
 /// `foreign_keys` silently leaves orphans, which is what the production pool
 /// would do if that option were ever dropped.
 #[tokio::test]
+#[serial]
 async fn test_cascade_depends_on_the_foreign_keys_pragma() {
-    let path = scratch_path("fk-off");
-    let pool = raw_pool(&path, /* foreign_keys */ false, Duration::from_secs(5)).await;
-    sqlite_support::migrate(&pool).await;
+    let room_id = "sqlite-fk-off";
+    let pool = variant_pool(/* foreign_keys */ false, Duration::from_secs(5)).await;
+    cleanup_test_data(&pool, room_id).await;
 
-    sqlx::raw_sql(
-        "INSERT INTO meetings (id, room_id, started_at, created_at, updated_at) \
-         VALUES (1, 'fk-off', '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00'); \
-         INSERT INTO meeting_participants (meeting_id, user_id) VALUES (1, 'guest@example.com'); \
-         DELETE FROM meetings WHERE id = 1;",
-    )
+    let (meeting_id,): (i32,) = sqlx::query_as(&q(
+        "INSERT INTO meetings (room_id, started_at) VALUES ($1, $2) RETURNING id",
+    ))
+    .bind(room_id)
+    .bind(Utc::now())
+    .fetch_one(&pool)
+    .await
+    .expect("seed meeting");
+
+    sqlx::query(&q(
+        "INSERT INTO meeting_participants (meeting_id, user_id) VALUES ($1, $2)",
+    ))
+    .bind(meeting_id)
+    .bind("guest@example.com")
     .execute(&pool)
     .await
-    .expect("seed and delete without foreign key enforcement");
+    .expect("seed participant");
 
-    let orphans: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM meeting_participants")
-        .fetch_one(&pool)
+    sqlx::query(&q("DELETE FROM meetings WHERE id = $1"))
+        .bind(meeting_id)
+        .execute(&pool)
         .await
-        .expect("count orphans");
+        .expect("delete without foreign key enforcement");
+
+    let orphans: (i64,) = sqlx::query_as(&q(
+        "SELECT COUNT(*) FROM meeting_participants WHERE meeting_id = $1",
+    ))
+    .bind(meeting_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count orphans");
     assert_eq!(
         orphans.0, 1,
         "expected the pragma-off pool to leave an orphan — if this fails the schema \
@@ -128,8 +173,14 @@ async fn test_cascade_depends_on_the_foreign_keys_pragma() {
          proving that db::connect turns foreign keys on"
     );
 
+    // The orphan outlived its meeting, so cleanup_test_data's room_id join can
+    // no longer reach it.
+    sqlx::query(&q("DELETE FROM meeting_participants WHERE meeting_id = $1"))
+        .bind(meeting_id)
+        .execute(&pool)
+        .await
+        .expect("clean up the orphan");
     pool.close().await;
-    cleanup_db_files(&path);
 }
 
 // ── SQLITE_BUSY retry ───────────────────────────────────────────────────
@@ -142,10 +193,11 @@ async fn test_cascade_depends_on_the_foreign_keys_pragma() {
 /// instead, which surfaces `SQLITE_BUSY` immediately and puts the retry on the
 /// same code path it would take in production.
 #[tokio::test]
+#[serial]
 async fn test_with_write_retry_recovers_from_a_busy_database() {
-    let path = scratch_path("busy-retry");
-    let pool = raw_pool(&path, true, Duration::ZERO).await;
-    sqlite_support::migrate(&pool).await;
+    let room_id = "sqlite-busy-retry";
+    let pool = variant_pool(true, Duration::ZERO).await;
+    cleanup_test_data(&pool, room_id).await;
 
     // First: prove the setup really does produce SQLITE_BUSY. Without this the
     // success below could just mean nothing was ever contended.
@@ -167,13 +219,12 @@ async fn test_with_write_retry_recovers_from_a_busy_database() {
         let pool = pool_for_op.clone();
         Box::pin(async move {
             let mut tx = lock::begin_write(&pool).await?;
-            sqlx::query(
-                "INSERT INTO meetings (room_id, started_at, created_at, updated_at) \
-                 VALUES ('busy-retry', '2026-01-01T00:00:00+00:00', \
-                         '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')",
-            )
-            .execute(&mut *tx)
-            .await?;
+            let sql = q("INSERT INTO meetings (room_id, started_at) VALUES ($1, $2)");
+            sqlx::query(&sql)
+                .bind(room_id)
+                .bind(Utc::now())
+                .execute(&mut *tx)
+                .await?;
             tx.commit().await
         })
     })
@@ -182,27 +233,27 @@ async fn test_with_write_retry_recovers_from_a_busy_database() {
 
     result.expect("with_write_retry should have retried past the busy window");
 
-    let written: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM meetings WHERE room_id = 'busy-retry'")
-            .fetch_one(&pool)
-            .await
-            .expect("count written rows");
+    let written: (i64,) = sqlx::query_as(&q("SELECT COUNT(*) FROM meetings WHERE room_id = $1"))
+        .bind(room_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count written rows");
     assert_eq!(
         written.0, 1,
         "the retried transaction must be applied exactly once — a rolled-back attempt \
          that left rows behind would double-insert here"
     );
 
+    cleanup_test_data(&pool, room_id).await;
     pool.close().await;
-    cleanup_db_files(&path);
 }
 
-/// Contention that never clears must surface as an error rather than hanging.
+/// Contention that never clears must surface as an error rather than hanging,
+/// and must do so within the documented latency budget.
 #[tokio::test]
+#[serial]
 async fn test_with_write_retry_gives_up_on_permanent_contention() {
-    let path = scratch_path("busy-forever");
-    let pool = raw_pool(&path, true, Duration::ZERO).await;
-    sqlite_support::migrate(&pool).await;
+    let pool = variant_pool(true, Duration::ZERO).await;
 
     let mut blocker = pool.acquire().await.expect("acquire blocker connection");
     sqlx::raw_sql("BEGIN IMMEDIATE")
@@ -211,6 +262,7 @@ async fn test_with_write_retry_gives_up_on_permanent_contention() {
         .expect("take the write lock and keep it");
 
     let pool_for_op = pool.clone();
+    let started = std::time::Instant::now();
     let result: Result<(), sqlx::Error> = lock::with_write_retry(move || {
         let pool = pool_for_op.clone();
         Box::pin(async move {
@@ -219,10 +271,19 @@ async fn test_with_write_retry_gives_up_on_permanent_contention() {
         })
     })
     .await;
+    let elapsed = started.elapsed();
 
     assert!(
         result.is_err(),
         "with_write_retry must bound its attempts and return the error, not spin forever"
+    );
+    // busy_timeout is 0 here, so every attempt fails instantly and the only
+    // thing bounding the loop is the deadline itself.
+    assert!(
+        elapsed < lock::RETRY_DEADLINE * 2,
+        "gave up after {elapsed:?}, which is not bounded by RETRY_DEADLINE ({:?}) — \
+         the retry loop is counting attempts rather than watching the clock",
+        lock::RETRY_DEADLINE
     );
 
     sqlx::raw_sql("ROLLBACK")
@@ -231,7 +292,6 @@ async fn test_with_write_retry_gives_up_on_permanent_contention() {
         .expect("release the write lock");
     drop(blocker);
     pool.close().await;
-    cleanup_db_files(&path);
 }
 
 // ── helpers ─────────────────────────────────────────────────────────────
@@ -246,36 +306,25 @@ fn hold_write_lock(pool: &DbPool, duration: Duration) -> tokio::task::JoinHandle
     })
 }
 
-/// A pool with deliberately non-production options.
+/// A pool on the suite's own database, differing from the production pool in
+/// exactly the options passed here.
 ///
 /// Only the tests that need to *provoke* what production suppresses use this;
-/// everything else goes through `meeting_api::db::connect`.
-async fn raw_pool(path: &std::path::Path, foreign_keys: bool, busy_timeout: Duration) -> DbPool {
-    let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))
-        .expect("valid SQLite URL")
+/// everything else goes through `meeting_api::db::connect` via
+/// [`test_helpers::get_test_pool`]. The database is the dbmate-migrated one
+/// named by `DATABASE_URL` — these tests never build a schema of their own,
+/// because a schema assembled in test code is not the schema production runs.
+async fn variant_pool(foreign_keys: bool, busy_timeout: Duration) -> DbPool {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
+    let options = SqliteConnectOptions::from_str(&url)
+        .expect("valid SQLite DATABASE_URL")
         .journal_mode(SqliteJournalMode::Wal)
         .busy_timeout(busy_timeout)
-        .foreign_keys(foreign_keys)
-        .create_if_missing(true);
+        .foreign_keys(foreign_keys);
 
     SqlitePoolOptions::new()
         .max_connections(5)
         .connect_with(options)
         .await
-        .expect("open scratch SQLite pool")
-}
-
-/// A fresh database file for one test, removed first so reruns start clean.
-fn scratch_path(name: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join("meeting-api-tests");
-    std::fs::create_dir_all(&dir).expect("create test scratch dir");
-    let path = dir.join(format!("{name}-{}.db", std::process::id()));
-    cleanup_db_files(&path);
-    path
-}
-
-fn cleanup_db_files(path: &std::path::Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(path.with_extension("db-wal"));
-    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+        .expect("open variant SQLite pool")
 }

--- a/meeting-api/tests/sqlite_backend_tests.rs
+++ b/meeting-api/tests/sqlite_backend_tests.rs
@@ -20,6 +20,12 @@
 //! so a passing test shows that option is load-bearing. Being SQLite-only, this
 //! file binds timestamps directly rather than via the `db::now_sql` shim.
 //!
+//! Every test must `pool.close().await` before returning: they share one file,
+//! and sqlx tears a dropped pool's connections down in the background — the last
+//! runs a WAL checkpoint that takes the write lock. A `busy_timeout(0)` pool
+//! opened by the next test would hit that as an instant `SQLITE_BUSY`. Closing
+//! makes teardown synchronous so opens never overlap it.
+//!
 //! The `db::mod` feature guards (both backends / neither refuse to compile) are
 //! verified by hand rather than with a `trybuild` dev-dependency.
 
@@ -86,6 +92,11 @@ async fn test_every_pooled_connection_has_the_required_pragmas() {
              db::connect sets; it will surface SQLITE_BUSY without waiting"
         );
     }
+
+    // Return the checked-out connections, then close synchronously — see the
+    // module docs.
+    drop(held);
+    pool.close().await;
 }
 
 /// The pragma check above proves the setting is on; this proves it is load

--- a/meeting-api/tests/sqlite_backend_tests.rs
+++ b/meeting-api/tests/sqlite_backend_tests.rs
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ *
+ * at your option.
+ */
+
+//! Tests for the parts of the SQLite backend that have no PostgreSQL analogue:
+//! the per-connection pragmas `db::connect` sets, and the `SQLITE_BUSY` retry
+//! in `db::lock::with_write_retry`.
+//!
+//! Everything else about the SQLite build is covered by the shared suite, which
+//! runs unchanged under `--no-default-features --features sqlite`.
+//!
+//! ## Feature guards (verified by hand, not by a test)
+//!
+//! `db::mod` refuses to compile with both backends or with neither. Adding
+//! `trybuild` to prove that would cost a dev-dependency and a compile of the
+//! whole crate per case, so it is checked manually instead. Observed on this
+//! branch:
+//!
+//! ```text
+//! $ cargo check -p meeting-api --all-features
+//! error: meeting-api: the `postgres` and `sqlite` features are mutually exclusive.
+//!        Build with `--no-default-features --features sqlite` to select SQLite.
+//!   --> meeting-api/src/db/mod.rs:46:1
+//! error: could not compile `meeting-api` (lib) due to 1 previous error
+//!
+//! $ cargo check -p meeting-api --no-default-features
+//! error: meeting-api: exactly one database backend feature must be enabled
+//!        (`postgres` or `sqlite`).
+//!   --> meeting-api/src/db/mod.rs:52:1
+//! error[E0432]: unresolved import `crate::db::DbPool`
+//!   --> meeting-api/src/db/lock.rs:33:5
+//! ```
+//!
+//! The `--all-features` case stops at the guard with nothing else reported. The
+//! no-backend case reports the guard first and then the expected cascade of
+//! `DbPool` being undefined, which is why the guard lives in `db/mod.rs`: it is
+//! the first thing the user reads.
+
+#![cfg(all(feature = "sqlite", not(feature = "postgres")))]
+
+mod test_helpers;
+
+use meeting_api::db::{lock, DbPool};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
+use sqlx::Row;
+use std::str::FromStr;
+use std::time::Duration;
+use test_helpers::sqlite_support;
+
+// ── Per-connection pragmas ──────────────────────────────────────────────
+
+/// `foreign_keys`, `journal_mode` and `busy_timeout` are per *connection*, so a
+/// pool that set them only while opening the first one would leave the other
+/// four on SQLite's defaults — foreign keys off, rollback journal, no wait.
+/// Hold every connection in the pool at once and check each of them.
+#[tokio::test]
+async fn test_every_pooled_connection_has_the_required_pragmas() {
+    let pool = sqlite_support::migrated_pool().await;
+
+    // `db::connect` builds the pool with max_connections(5); holding five at
+    // once guarantees each was configured on open rather than reused.
+    let mut held = Vec::new();
+    for _ in 0..5 {
+        held.push(pool.acquire().await.expect("acquire pooled connection"));
+    }
+
+    for (n, conn) in held.iter_mut().enumerate() {
+        let foreign_keys: i64 = sqlx::query("PRAGMA foreign_keys")
+            .fetch_one(&mut **conn)
+            .await
+            .expect("read foreign_keys")
+            .get(0);
+        assert_eq!(
+            foreign_keys, 1,
+            "connection {n} has foreign_keys off; ON DELETE CASCADE is inert on it"
+        );
+
+        let journal_mode: String = sqlx::query("PRAGMA journal_mode")
+            .fetch_one(&mut **conn)
+            .await
+            .expect("read journal_mode")
+            .get(0);
+        assert_eq!(
+            journal_mode.to_lowercase(),
+            "wal",
+            "connection {n} is not in WAL mode; readers will block on the writer"
+        );
+    }
+}
+
+/// The pragma check above proves the setting is on; this proves it is load
+/// bearing. The same cascading delete against a pool built *without*
+/// `foreign_keys` silently leaves orphans, which is what the production pool
+/// would do if that option were ever dropped.
+#[tokio::test]
+async fn test_cascade_depends_on_the_foreign_keys_pragma() {
+    let path = scratch_path("fk-off");
+    let pool = raw_pool(&path, /* foreign_keys */ false, Duration::from_secs(5)).await;
+    sqlite_support::migrate(&pool).await;
+
+    sqlx::raw_sql(
+        "INSERT INTO meetings (id, room_id, started_at, created_at, updated_at) \
+         VALUES (1, 'fk-off', '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00'); \
+         INSERT INTO meeting_participants (meeting_id, user_id) VALUES (1, 'guest@example.com'); \
+         DELETE FROM meetings WHERE id = 1;",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed and delete without foreign key enforcement");
+
+    let orphans: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM meeting_participants")
+        .fetch_one(&pool)
+        .await
+        .expect("count orphans");
+    assert_eq!(
+        orphans.0, 1,
+        "expected the pragma-off pool to leave an orphan — if this fails the schema \
+         gained enforcement from somewhere else and the cascade test is no longer \
+         proving that db::connect turns foreign keys on"
+    );
+
+    pool.close().await;
+    cleanup_db_files(&path);
+}
+
+// ── SQLITE_BUSY retry ───────────────────────────────────────────────────
+
+/// `with_write_retry` must turn lock contention into a delayed success.
+///
+/// Production sets `busy_timeout(5s)`, so SQLite spins internally and the retry
+/// is only reached when contention outlasts that — impossible to provoke in a
+/// test without a five-second stall. This uses a pool with `busy_timeout(0)`
+/// instead, which surfaces `SQLITE_BUSY` immediately and puts the retry on the
+/// same code path it would take in production.
+#[tokio::test]
+async fn test_with_write_retry_recovers_from_a_busy_database() {
+    let path = scratch_path("busy-retry");
+    let pool = raw_pool(&path, true, Duration::ZERO).await;
+    sqlite_support::migrate(&pool).await;
+
+    // First: prove the setup really does produce SQLITE_BUSY. Without this the
+    // success below could just mean nothing was ever contended.
+    let holder = hold_write_lock(&pool, Duration::from_millis(120));
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let unretried = lock::begin_write(&pool).await;
+    assert!(
+        unretried.is_err(),
+        "expected BEGIN IMMEDIATE to fail while another writer holds the lock \
+         and busy_timeout is 0"
+    );
+    holder.await.expect("holder task should not panic");
+
+    // Then: the same contention, absorbed by the retry.
+    let holder = hold_write_lock(&pool, Duration::from_millis(120));
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let pool_for_op = pool.clone();
+    let result = lock::with_write_retry(move || {
+        let pool = pool_for_op.clone();
+        Box::pin(async move {
+            let mut tx = lock::begin_write(&pool).await?;
+            sqlx::query(
+                "INSERT INTO meetings (room_id, started_at, created_at, updated_at) \
+                 VALUES ('busy-retry', '2026-01-01T00:00:00+00:00', \
+                         '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')",
+            )
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await
+        })
+    })
+    .await;
+    holder.await.expect("holder task should not panic");
+
+    result.expect("with_write_retry should have retried past the busy window");
+
+    let written: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM meetings WHERE room_id = 'busy-retry'")
+            .fetch_one(&pool)
+            .await
+            .expect("count written rows");
+    assert_eq!(
+        written.0, 1,
+        "the retried transaction must be applied exactly once — a rolled-back attempt \
+         that left rows behind would double-insert here"
+    );
+
+    pool.close().await;
+    cleanup_db_files(&path);
+}
+
+/// Contention that never clears must surface as an error rather than hanging.
+#[tokio::test]
+async fn test_with_write_retry_gives_up_on_permanent_contention() {
+    let path = scratch_path("busy-forever");
+    let pool = raw_pool(&path, true, Duration::ZERO).await;
+    sqlite_support::migrate(&pool).await;
+
+    let mut blocker = pool.acquire().await.expect("acquire blocker connection");
+    sqlx::raw_sql("BEGIN IMMEDIATE")
+        .execute(&mut *blocker)
+        .await
+        .expect("take the write lock and keep it");
+
+    let pool_for_op = pool.clone();
+    let result: Result<(), sqlx::Error> = lock::with_write_retry(move || {
+        let pool = pool_for_op.clone();
+        Box::pin(async move {
+            lock::begin_write(&pool).await?;
+            Ok(())
+        })
+    })
+    .await;
+
+    assert!(
+        result.is_err(),
+        "with_write_retry must bound its attempts and return the error, not spin forever"
+    );
+
+    sqlx::raw_sql("ROLLBACK")
+        .execute(&mut *blocker)
+        .await
+        .expect("release the write lock");
+    drop(blocker);
+    pool.close().await;
+    cleanup_db_files(&path);
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+/// Hold the database write lock for `duration`, then release it.
+fn hold_write_lock(pool: &DbPool, duration: Duration) -> tokio::task::JoinHandle<()> {
+    let pool = pool.clone();
+    tokio::spawn(async move {
+        let tx = lock::begin_write(&pool).await.expect("take the write lock");
+        tokio::time::sleep(duration).await;
+        tx.rollback().await.expect("release the write lock");
+    })
+}
+
+/// A pool with deliberately non-production options.
+///
+/// Only the tests that need to *provoke* what production suppresses use this;
+/// everything else goes through `meeting_api::db::connect`.
+async fn raw_pool(path: &std::path::Path, foreign_keys: bool, busy_timeout: Duration) -> DbPool {
+    let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))
+        .expect("valid SQLite URL")
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(busy_timeout)
+        .foreign_keys(foreign_keys)
+        .create_if_missing(true);
+
+    SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect_with(options)
+        .await
+        .expect("open scratch SQLite pool")
+}
+
+/// A fresh database file for one test, removed first so reruns start clean.
+fn scratch_path(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join("meeting-api-tests");
+    std::fs::create_dir_all(&dir).expect("create test scratch dir");
+    let path = dir.join(format!("{name}-{}.db", std::process::id()));
+    cleanup_db_files(&path);
+    path
+}
+
+fn cleanup_db_files(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+}

--- a/meeting-api/tests/sqlite_backend_tests.rs
+++ b/meeting-api/tests/sqlite_backend_tests.rs
@@ -11,48 +11,17 @@
  * at your option.
  */
 
-//! The parts of the SQLite backend that have no PostgreSQL analogue, and so
-//! cannot live in the shared suite: the per-connection pragmas `db::connect`
-//! sets, and the `SQLITE_BUSY` retry in `db::lock::with_write_retry`.
+//! SQLite-only coverage with no PostgreSQL analogue: the per-connection pragmas
+//! `db::connect` sets, and the `SQLITE_BUSY` retry in `db::lock::with_write_retry`.
+//! Everything else runs against both backends from the shared suite.
 //!
-//! Nothing here re-tests behaviour the shared suite already covers. Schema,
-//! queries and the waiting-room race all run against both backends from the
-//! ordinary test files; this file exists only for the two things PostgreSQL has
-//! no equivalent of.
+//! Tests use the same `DATABASE_URL` database dbmate migrated for the rest of the
+//! suite; each pool differs from production in exactly the one option under test,
+//! so a passing test shows that option is load-bearing. Being SQLite-only, this
+//! file binds timestamps directly rather than via the `db::now_sql` shim.
 //!
-//! Because this file is SQLite-only it binds timestamps directly rather than
-//! going through `db::now_expr` / `bind_now!`, which are crate-internal and
-//! exist to keep *shared* SQL dialect-neutral. There is no PostgreSQL run of
-//! these tests for them to diverge from.
-//!
-//! Every test runs against the same `DATABASE_URL` database dbmate migrated for
-//! the rest of the suite. The pools opened here differ from the production pool
-//! in exactly one option each — the one under test — so what they prove is that
-//! the option is load-bearing, not that some separately-built schema behaves
-//! some way.
-//!
-//! ## Feature guards (verified by hand, not by a test)
-//!
-//! `db::mod` refuses to compile with both backends or with neither. Adding
-//! `trybuild` to prove that would cost a dev-dependency and a compile of the
-//! whole crate per case, so it is checked manually instead. Observed on this
-//! branch:
-//!
-//! ```text
-//! $ cargo check -p meeting-api --all-features
-//! error: meeting-api: the `postgres` and `sqlite` features are mutually exclusive.
-//!        Build with `--no-default-features --features sqlite` to select SQLite.
-//!
-//! $ cargo check -p meeting-api --no-default-features
-//! error: meeting-api: exactly one database backend feature must be enabled
-//!        (`postgres` or `sqlite`).
-//! error[E0432]: unresolved import `crate::db::DbPool`
-//! ```
-//!
-//! The `--all-features` case stops at the guard with nothing else reported. The
-//! no-backend case reports the guard first and then the expected cascade of
-//! `DbPool` being undefined, which is why the guard lives in `db/mod.rs`: it is
-//! the first thing the user reads.
+//! The `db::mod` feature guards (both backends / neither refuse to compile) are
+//! verified by hand rather than with a `trybuild` dev-dependency.
 
 #![cfg(all(feature = "sqlite", not(feature = "postgres")))]
 
@@ -69,14 +38,9 @@ use test_helpers::{cleanup_test_data, get_test_pool};
 
 // ── Per-connection pragmas ──────────────────────────────────────────────
 
-/// `foreign_keys`, `journal_mode` and `busy_timeout` are per *connection*, so a
-/// pool that set them only while opening the first one would leave the other
-/// four on SQLite's defaults — foreign keys off, rollback journal, no wait.
-/// Hold every connection in the pool at once and check all three on each.
-///
-/// `busy_timeout` is the one that fails silently: a connection left at the
-/// default of 0 does not misbehave until it is the one that happens to hit
-/// contention, and then it returns `SQLITE_BUSY` instantly instead of waiting.
+/// The pragmas are per *connection*, so setting them on only the first would
+/// leave the rest on SQLite's defaults. Hold all five at once and check each —
+/// `busy_timeout` especially, which fails silently until a connection contends.
 #[tokio::test]
 #[serial]
 async fn test_every_pooled_connection_has_the_required_pragmas() {
@@ -306,14 +270,9 @@ fn hold_write_lock(pool: &DbPool, duration: Duration) -> tokio::task::JoinHandle
     })
 }
 
-/// A pool on the suite's own database, differing from the production pool in
-/// exactly the options passed here.
-///
-/// Only the tests that need to *provoke* what production suppresses use this;
-/// everything else goes through `meeting_api::db::connect` via
-/// [`test_helpers::get_test_pool`]. The database is the dbmate-migrated one
-/// named by `DATABASE_URL` — these tests never build a schema of their own,
-/// because a schema assembled in test code is not the schema production runs.
+/// A pool on the suite's `DATABASE_URL` database, differing from the production
+/// pool only in the options passed here — used by tests that must provoke what
+/// production suppresses. Everything else uses [`test_helpers::get_test_pool`].
 async fn variant_pool(foreign_keys: bool, busy_timeout: Duration) -> DbPool {
     let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
     let options = SqliteConnectOptions::from_str(&url)

--- a/meeting-api/tests/test_helpers.rs
+++ b/meeting-api/tests/test_helpers.rs
@@ -11,31 +11,15 @@
  * at your option.
  */
 
-//! Shared test helpers for meeting-api integration tests.
+//! Shared test helpers. One suite, run against whichever backend the crate was
+//! compiled with; CI runs the same commands twice (`make tests_run` /
+//! `tests_run_sqlite`), so coverage is equal by construction.
 //!
-//! There is one suite, not one per backend. Every test here runs against
-//! whichever backend the crate was compiled with, and CI runs the *same*
-//! commands twice — see the `test` matrix in `.github/workflows/cargo-test.yaml`:
-//!
-//! ```text
-//! make tests_run         # postgres
-//! make tests_run_sqlite  # sqlite
-//! ```
-//!
-//! Both legs run the identical `$(MEETING_API_TEST)` command from the Makefile,
-//! differing only in `DATABASE_URL`, which dbmate directory is migrated, and the
-//! cargo feature. Coverage is therefore equal by construction: a test added here
-//! is automatically run against both backends, and there is no second harness to
-//! keep in sync.
-//!
-//! That matters most for the schema. `dbmate/sqlite/db/migrations` is a
-//! hand-written transliteration of `dbmate/db/migrations` and nothing compares
-//! the two at compile time, so this suite is the entire safety net against them
-//! drifting apart.
-//!
-//! Tests only ever see [`meeting_api::db::DbPool`], and statements written here
-//! go through [`meeting_api::db::q`] exactly like the ones in `src/db`, so a
-//! test file never needs a `cfg` of its own.
+//! Both legs go through [`meeting_api::db::connect`] on a database dbmate has
+//! already migrated — the SQLite leg exercises `dbmate/sqlite`, the same files
+//! production runs, so drift between the two dbmate dirs is caught here. Tests
+//! only see [`meeting_api::db::DbPool`] and route SQL through
+//! [`meeting_api::db::q`], so none needs a `cfg` of its own.
 
 #![allow(dead_code)]
 
@@ -51,19 +35,12 @@ pub const TEST_JWT_SECRET: &str = "test-secret-for-integration-tests";
 const TEST_TOKEN_TTL: i64 = 600;
 const TEST_SESSION_TTL: i64 = 3600;
 
-/// Connect to the test database named by `DATABASE_URL`.
+/// Connect to the test database named by `DATABASE_URL`, expected to already be
+/// migrated (`dbmate up` runs first — see the Makefile).
 ///
-/// Identical on both backends, because the backend-specific part is already
-/// handled underneath: [`meeting_api::db::DbPool`] resolves to the right pool
-/// type per feature, and [`meeting_api::db::connect`] — the same constructor
-/// `main` uses — applies the right options for the URL scheme. Tests therefore
-/// exercise the production pragmas (`foreign_keys`, `busy_timeout`, WAL) rather
-/// than a test-only reimplementation of them.
-///
-/// The database is expected to exist and be migrated already: `dbmate up` does
-/// that for both backends before `cargo test` runs (see the Makefile). Nothing
-/// here creates or migrates a database — the SQLite leg must exercise the same
-/// migration files production applies, not a parallel copy of the schema.
+/// Backend-agnostic: [`meeting_api::db::connect`] is the constructor `main` uses,
+/// so tests exercise the production pragmas rather than a reimplementation, and
+/// nothing here builds a schema of its own.
 pub async fn get_test_pool() -> DbPool {
     let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
     meeting_api::db::connect(&url).await

--- a/meeting-api/tests/test_helpers.rs
+++ b/meeting-api/tests/test_helpers.rs
@@ -13,13 +13,25 @@
 
 //! Shared test helpers for meeting-api integration tests.
 //!
-//! Every test in this directory runs against whichever backend the crate was
-//! compiled with, so the whole suite is executed twice in CI:
+//! There is one suite, not one per backend. Every test here runs against
+//! whichever backend the crate was compiled with, and CI runs the *same*
+//! commands twice — see the `test` matrix in `.github/workflows/cargo-test.yaml`:
 //!
 //! ```text
-//! cargo test -p meeting-api                                    # postgres
-//! cargo test -p meeting-api --no-default-features --features sqlite
+//! make tests_run         # postgres
+//! make tests_run_sqlite  # sqlite
 //! ```
+//!
+//! Both legs run the identical `$(MEETING_API_TEST)` command from the Makefile,
+//! differing only in `DATABASE_URL`, which dbmate directory is migrated, and the
+//! cargo feature. Coverage is therefore equal by construction: a test added here
+//! is automatically run against both backends, and there is no second harness to
+//! keep in sync.
+//!
+//! That matters most for the schema. `dbmate/sqlite/db/migrations` is a
+//! hand-written transliteration of `dbmate/db/migrations` and nothing compares
+//! the two at compile time, so this suite is the entire safety net against them
+//! drifting apart.
 //!
 //! Tests only ever see [`meeting_api::db::DbPool`], and statements written here
 //! go through [`meeting_api::db::q`] exactly like the ones in `src/db`, so a
@@ -39,25 +51,22 @@ pub const TEST_JWT_SECRET: &str = "test-secret-for-integration-tests";
 const TEST_TOKEN_TTL: i64 = 600;
 const TEST_SESSION_TTL: i64 = 3600;
 
-/// Connect to the test database.
+/// Connect to the test database named by `DATABASE_URL`.
 ///
-/// PostgreSQL uses `DATABASE_URL`, pointing at a database dbmate has already
-/// migrated. SQLite creates a throwaway database file and migrates it from
-/// `dbmate/sqlite/db/migrations` on first use; see [`sqlite_support`].
+/// Identical on both backends, because the backend-specific part is already
+/// handled underneath: [`meeting_api::db::DbPool`] resolves to the right pool
+/// type per feature, and [`meeting_api::db::connect`] — the same constructor
+/// `main` uses — applies the right options for the URL scheme. Tests therefore
+/// exercise the production pragmas (`foreign_keys`, `busy_timeout`, WAL) rather
+/// than a test-only reimplementation of them.
 ///
-/// Both paths go through [`meeting_api::db::connect`] — the same constructor
-/// `main` uses — so per-connection settings (`foreign_keys`, `busy_timeout`,
-/// WAL) are exercised rather than reimplemented here.
+/// The database is expected to exist and be migrated already: `dbmate up` does
+/// that for both backends before `cargo test` runs (see the Makefile). Nothing
+/// here creates or migrates a database — the SQLite leg must exercise the same
+/// migration files production applies, not a parallel copy of the schema.
 pub async fn get_test_pool() -> DbPool {
-    #[cfg(feature = "postgres")]
-    {
-        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
-        meeting_api::db::connect(&url).await
-    }
-    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
-    {
-        sqlite_support::migrated_pool().await
-    }
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
+    meeting_api::db::connect(&url).await
 }
 
 /// Delete all test data for a given `room_id` (participants first due to FK).
@@ -115,100 +124,4 @@ pub async fn response_json<T: DeserializeOwned>(resp: Response) -> T {
         .expect("collect body")
         .to_bytes();
     serde_json::from_slice(&bytes).expect("deserialize response body")
-}
-
-/// Test-database plumbing that only exists for the SQLite build.
-#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
-pub mod sqlite_support {
-    use meeting_api::db::DbPool;
-    use std::path::PathBuf;
-    use tokio::sync::OnceCell;
-
-    /// One migrated database per test binary.
-    ///
-    /// Cargo runs each integration test file as its own process, so this gives
-    /// every file an isolated database while the `#[serial]` attribute the
-    /// suite already uses keeps tests inside a file from overlapping. A file —
-    /// not `:memory:` — because WAL needs a real file and because an in-memory
-    /// SQLite database is private to a single connection, which a pool of five
-    /// would silently turn into five empty databases.
-    static POOL: OnceCell<DbPool> = OnceCell::const_new();
-
-    /// A pool over a freshly migrated throwaway database, shared per binary.
-    pub async fn migrated_pool() -> DbPool {
-        POOL.get_or_init(|| async {
-            let path = scratch_db_path();
-            let _ = std::fs::remove_file(&path);
-            let _ = std::fs::remove_file(path.with_extension("db-wal"));
-            let _ = std::fs::remove_file(path.with_extension("db-shm"));
-
-            let pool = new_pool(&path).await;
-            migrate(&pool).await;
-            pool
-        })
-        .await
-        .clone()
-    }
-
-    /// Open a pool on `path` through the application's own constructor.
-    ///
-    /// Tests must not hand-roll a `SqliteConnectOptions`: the pragmas that
-    /// constructor sets (`foreign_keys` above all) are exactly what the schema
-    /// tests are checking, and a private connection would test the test.
-    pub async fn new_pool(path: &std::path::Path) -> DbPool {
-        meeting_api::db::connect(&format!("sqlite://{}", path.display())).await
-    }
-
-    /// A unique, writable database path for this test process.
-    pub fn scratch_db_path() -> PathBuf {
-        let dir = std::env::temp_dir().join("meeting-api-tests");
-        std::fs::create_dir_all(&dir).expect("create test scratch dir");
-        dir.join(format!("test-{}.db", std::process::id()))
-    }
-
-    /// Apply the real dbmate migrations from `dbmate/sqlite/db/migrations`.
-    ///
-    /// Deliberately reads the shipped `.sql` files rather than embedding a
-    /// second copy of the schema: the point of the schema tests is to check
-    /// what production actually runs. The `-- migrate:up` section is applied in
-    /// filename order, which is dbmate's ordering.
-    pub async fn migrate(pool: &DbPool) {
-        for sql in up_migrations() {
-            sqlx::raw_sql(&sql)
-                .execute(pool)
-                .await
-                .expect("apply SQLite migration");
-        }
-    }
-
-    /// The `-- migrate:up` body of every migration, in filename order.
-    pub fn up_migrations() -> Vec<String> {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../dbmate/sqlite/db/migrations")
-            .canonicalize()
-            .expect("dbmate/sqlite/db/migrations must exist");
-
-        let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
-            .expect("read migrations dir")
-            .map(|e| e.expect("read migration entry").path())
-            .filter(|p| p.extension().is_some_and(|e| e == "sql"))
-            .collect();
-        files.sort();
-        assert!(!files.is_empty(), "no SQLite migrations found in {dir:?}");
-
-        files
-            .iter()
-            .map(|path| {
-                let body = std::fs::read_to_string(path).expect("read migration");
-                let up = body
-                    .split_once("-- migrate:up")
-                    .unwrap_or_else(|| panic!("{path:?} has no `-- migrate:up`"))
-                    .1;
-                up.split_once("-- migrate:down")
-                    .map(|(up, _)| up)
-                    .unwrap_or(up)
-                    .to_string()
-            })
-            .collect()
-    }
 }

--- a/meeting-api/tests/test_helpers.rs
+++ b/meeting-api/tests/test_helpers.rs
@@ -12,6 +12,18 @@
  */
 
 //! Shared test helpers for meeting-api integration tests.
+//!
+//! Every test in this directory runs against whichever backend the crate was
+//! compiled with, so the whole suite is executed twice in CI:
+//!
+//! ```text
+//! cargo test -p meeting-api                                    # postgres
+//! cargo test -p meeting-api --no-default-features --features sqlite
+//! ```
+//!
+//! Tests only ever see [`meeting_api::db::DbPool`], and statements written here
+//! go through [`meeting_api::db::q`] exactly like the ones in `src/db`, so a
+//! test file never needs a `cfg` of its own.
 
 #![allow(dead_code)]
 
@@ -19,40 +31,51 @@ use axum::http;
 use axum::response::Response;
 use axum::Router;
 use http_body_util::BodyExt;
+use meeting_api::db::{q, DbPool};
 use meeting_api::{routes, state::AppState, token::generate_session_token};
 use serde::de::DeserializeOwned;
-use sqlx::PgPool;
 
 pub const TEST_JWT_SECRET: &str = "test-secret-for-integration-tests";
 const TEST_TOKEN_TTL: i64 = 600;
 const TEST_SESSION_TTL: i64 = 3600;
 
-/// Connect to the test database using `DATABASE_URL`.
-pub async fn get_test_pool() -> PgPool {
-    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
-    PgPool::connect(&url)
-        .await
-        .expect("Failed to connect to test database")
+/// Connect to the test database.
+///
+/// PostgreSQL uses `DATABASE_URL`, pointing at a database dbmate has already
+/// migrated. SQLite creates a throwaway database file and migrates it from
+/// `dbmate/sqlite/db/migrations` on first use; see [`sqlite_support`].
+///
+/// Both paths go through [`meeting_api::db::connect`] — the same constructor
+/// `main` uses — so per-connection settings (`foreign_keys`, `busy_timeout`,
+/// WAL) are exercised rather than reimplemented here.
+pub async fn get_test_pool() -> DbPool {
+    #[cfg(feature = "postgres")]
+    {
+        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests");
+        meeting_api::db::connect(&url).await
+    }
+    #[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+    {
+        sqlite_support::migrated_pool().await
+    }
 }
 
 /// Delete all test data for a given `room_id` (participants first due to FK).
-pub async fn cleanup_test_data(pool: &PgPool, room_id: &str) {
-    let _ = sqlx::query(
-        "DELETE FROM meeting_participants WHERE meeting_id IN \
-         (SELECT id FROM meetings WHERE room_id = $1)",
-    )
+pub async fn cleanup_test_data(pool: &DbPool, room_id: &str) {
+    let _ = sqlx::query(&q("DELETE FROM meeting_participants WHERE meeting_id IN \
+         (SELECT id FROM meetings WHERE room_id = $1)"))
     .bind(room_id)
     .execute(pool)
     .await;
 
-    let _ = sqlx::query("DELETE FROM meetings WHERE room_id = $1")
+    let _ = sqlx::query(&q("DELETE FROM meetings WHERE room_id = $1"))
         .bind(room_id)
         .execute(pool)
         .await;
 }
 
 /// Build the Axum router backed by the given pool, ready for `tower::ServiceExt::oneshot`.
-pub fn build_app(pool: PgPool) -> Router {
+pub fn build_app(pool: DbPool) -> Router {
     let state = AppState {
         db: pool,
         jwt_secret: TEST_JWT_SECRET.to_string(),
@@ -92,4 +115,100 @@ pub async fn response_json<T: DeserializeOwned>(resp: Response) -> T {
         .expect("collect body")
         .to_bytes();
     serde_json::from_slice(&bytes).expect("deserialize response body")
+}
+
+/// Test-database plumbing that only exists for the SQLite build.
+#[cfg(all(feature = "sqlite", not(feature = "postgres")))]
+pub mod sqlite_support {
+    use meeting_api::db::DbPool;
+    use std::path::PathBuf;
+    use tokio::sync::OnceCell;
+
+    /// One migrated database per test binary.
+    ///
+    /// Cargo runs each integration test file as its own process, so this gives
+    /// every file an isolated database while the `#[serial]` attribute the
+    /// suite already uses keeps tests inside a file from overlapping. A file —
+    /// not `:memory:` — because WAL needs a real file and because an in-memory
+    /// SQLite database is private to a single connection, which a pool of five
+    /// would silently turn into five empty databases.
+    static POOL: OnceCell<DbPool> = OnceCell::const_new();
+
+    /// A pool over a freshly migrated throwaway database, shared per binary.
+    pub async fn migrated_pool() -> DbPool {
+        POOL.get_or_init(|| async {
+            let path = scratch_db_path();
+            let _ = std::fs::remove_file(&path);
+            let _ = std::fs::remove_file(path.with_extension("db-wal"));
+            let _ = std::fs::remove_file(path.with_extension("db-shm"));
+
+            let pool = new_pool(&path).await;
+            migrate(&pool).await;
+            pool
+        })
+        .await
+        .clone()
+    }
+
+    /// Open a pool on `path` through the application's own constructor.
+    ///
+    /// Tests must not hand-roll a `SqliteConnectOptions`: the pragmas that
+    /// constructor sets (`foreign_keys` above all) are exactly what the schema
+    /// tests are checking, and a private connection would test the test.
+    pub async fn new_pool(path: &std::path::Path) -> DbPool {
+        meeting_api::db::connect(&format!("sqlite://{}", path.display())).await
+    }
+
+    /// A unique, writable database path for this test process.
+    pub fn scratch_db_path() -> PathBuf {
+        let dir = std::env::temp_dir().join("meeting-api-tests");
+        std::fs::create_dir_all(&dir).expect("create test scratch dir");
+        dir.join(format!("test-{}.db", std::process::id()))
+    }
+
+    /// Apply the real dbmate migrations from `dbmate/sqlite/db/migrations`.
+    ///
+    /// Deliberately reads the shipped `.sql` files rather than embedding a
+    /// second copy of the schema: the point of the schema tests is to check
+    /// what production actually runs. The `-- migrate:up` section is applied in
+    /// filename order, which is dbmate's ordering.
+    pub async fn migrate(pool: &DbPool) {
+        for sql in up_migrations() {
+            sqlx::raw_sql(&sql)
+                .execute(pool)
+                .await
+                .expect("apply SQLite migration");
+        }
+    }
+
+    /// The `-- migrate:up` body of every migration, in filename order.
+    pub fn up_migrations() -> Vec<String> {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../dbmate/sqlite/db/migrations")
+            .canonicalize()
+            .expect("dbmate/sqlite/db/migrations must exist");
+
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .expect("read migrations dir")
+            .map(|e| e.expect("read migration entry").path())
+            .filter(|p| p.extension().is_some_and(|e| e == "sql"))
+            .collect();
+        files.sort();
+        assert!(!files.is_empty(), "no SQLite migrations found in {dir:?}");
+
+        files
+            .iter()
+            .map(|path| {
+                let body = std::fs::read_to_string(path).expect("read migration");
+                let up = body
+                    .split_once("-- migrate:up")
+                    .unwrap_or_else(|| panic!("{path:?} has no `-- migrate:up`"))
+                    .1;
+                up.split_once("-- migrate:down")
+                    .map(|(up, _)| up)
+                    .unwrap_or(up)
+                    .to_string()
+            })
+            .collect()
+    }
 }

--- a/meeting-api/tests/waiting_room_race_tests.rs
+++ b/meeting-api/tests/waiting_room_race_tests.rs
@@ -13,55 +13,33 @@
 
 //! Concurrency tests for the waiting room, run against both backends.
 //!
-//! `db::participants::join_attendee` reads `waiting_room_enabled` and then
-//! inserts a participant whose status depends on what it read;
-//! `db::meetings::update_waiting_room_enabled` writes that flag and, when
-//! disabling, admits everyone currently waiting. The two must serialize, which
-//! is what `db::lock::begin_write` is for — `SELECT ... FOR UPDATE` on
-//! PostgreSQL, `BEGIN IMMEDIATE` on SQLite. A plain `pool.begin()` is `BEGIN
-//! DEFERRED` and takes no lock at all, which permits:
+//! `join_attendee` reads `waiting_room_enabled` then inserts a participant whose
+//! status depends on the read; `update_waiting_room_enabled` writes that flag and
+//! admits the waiting when disabling. They must serialize via
+//! `db::lock::begin_write` (`FOR UPDATE` on PostgreSQL, `BEGIN IMMEDIATE` on
+//! SQLite). A plain deferred `pool.begin()` takes no lock and permits:
 //!
 //! ```text
 //! T1 join_attendee : BEGIN; SELECT waiting_room_enabled -> true
 //! T2 host toggle   : BEGIN; UPDATE waiting_room_enabled = false;
-//!                           UPDATE participants SET status='admitted' WHERE status='waiting';
-//!                           COMMIT
-//! T1               : INSERT participant status='waiting'; COMMIT
+//!                           UPDATE participants SET status='admitted' WHERE status='waiting'; COMMIT
+//! T1               : INSERT participant status='waiting'; COMMIT   -- stranded, never admitted
 //! ```
 //!
-//! leaving a participant sitting in the waiting room of a meeting that has no
-//! waiting room. Nothing ever admits them: the sweep that would have has
-//! already run.
+//! Reverting `begin_write` to `pool.begin()` fails
+//! [`test_toggle_off_between_a_joins_read_and_write_never_strands`] on PostgreSQL
+//! (the strand above) and [`test_concurrent_writers_do_not_surface_lock_errors`]
+//! on SQLite (its single write lock turns the same revert into `database is
+//! locked`). Those two hold the line; the swept-delay tests cover contention
+//! broadly but the window is too short for timing alone to catch the revert.
 //!
-//! The regression this file exists to catch is `begin_write` reverting to a
-//! plain `pool.begin()`. Both backends were checked against that revert, and
-//! they fail differently:
-//!
-//! - PostgreSQL loses `FOR UPDATE`, produces the stranded participant above,
-//!   and fails [`test_toggle_off_between_a_joins_read_and_write_never_strands`].
-//! - SQLite has one database write lock, so it cannot corrupt the state this
-//!   way; what it does instead is fail the deferred transaction's upgrade to a
-//!   write with `SQLITE_BUSY`, which `with_write_retry` cannot always absorb.
-//!   That surfaces as `database is locked` out of
-//!   [`test_concurrent_writers_do_not_surface_lock_errors`].
-//!
-//! Timing alone does not catch either: the window between the join's read and
-//! its write is far shorter than the competing transaction, so the swept-delay
-//! tests below passed against the reverted code. They stay because they cover
-//! contention broadly, but the two named tests are the ones that hold the line.
-//!
-//! On the *enabling* side there is no equivalent final-state assertion to make,
-//! and it is worth writing down why rather than shipping a test that looks like
-//! one. "Waiting room on, participant admitted" is also the outcome of the
-//! perfectly legal serial order (attendee joins, host then enables the waiting
-//! room) — existing participants are not evicted when the host turns it on. Two
-//! concurrent calls therefore cannot be distinguished from that serial order by
-//! looking at the rows afterwards, so the enabling side is covered here by
-//! [`test_toggle_on_race_stays_internally_consistent`] (the flag each join acts
-//! on is the flag its own row reflects, and nothing errors out) plus
-//! [`test_join_after_a_committed_enable_always_waits`], which pins down the one
-//! ordering that *is* observable: once the host's call has returned, no later
-//! join may be auto-admitted.
+//! The *enabling* side has no final-state assertion: "waiting room on, attendee
+//! admitted" is also the legal serial order (join, then enable — enabling does
+//! not evict), so it is indistinguishable from the rows afterwards. It is instead
+//! covered by [`test_toggle_on_race_stays_internally_consistent`] (each join's
+//! result matches the flag it acted on) and
+//! [`test_join_after_a_committed_enable_always_waits`] (once the host's call
+//! returns, no later join is auto-admitted).
 //!
 //! Where a test does depend on timing it sweeps rather than sleeps: each
 //! iteration offsets the competing task by a slightly larger delay, so the
@@ -118,12 +96,10 @@ async fn fresh_meeting(pool: &DbPool, room_id: &str, waiting_room_enabled: bool)
 /// read, so T2's UPDATE queues behind T1 instead of slipping past it: T1 commits
 /// its `waiting` row first and T2's admit-all then finds and admits it.
 ///
-/// On PostgreSQL the ordering above is exact — W blocks T1 without blocking T2,
-/// because the two contend on different rows. SQLite has a single database
-/// write lock, so W necessarily blocks T2 as well and the interleaving degrades
-/// to "both writers queue behind W"; the assertion still holds there, it just
-/// stops being the reason the test is interesting. That asymmetry is the whole
-/// reason `begin_write` has two implementations.
+/// The interleaving above is exact on PostgreSQL (W blocks T1 but not T2, since
+/// they touch different rows). SQLite's single write lock makes W block T2 too,
+/// so both writers just queue behind W; the assertion still holds, less
+/// pointedly. That asymmetry is why `begin_write` has two implementations.
 #[tokio::test]
 #[serial]
 async fn test_toggle_off_between_a_joins_read_and_write_never_strands() {
@@ -166,10 +142,8 @@ async fn test_toggle_off_between_a_joins_read_and_write_never_strands() {
     // Give the toggle every chance to run to completion ahead of the join.
     tokio::time::sleep(Duration::from_millis(150)).await;
 
-    // Without this the test can pass vacuously: if the join had already run to
-    // completion during the sleeps above, it never sat in the window this test
-    // exists to exercise, and the assertions below would hold for the boring
-    // reason. On a loaded runner that is exactly what a fixed sleep risks.
+    // Guard against a vacuous pass: if the join already finished, it never sat
+    // in the window and the assertions below would hold for the boring reason.
     assert!(
         !joiner.is_finished(),
         "the join completed before the blocking key was released, so it never \

--- a/meeting-api/tests/waiting_room_race_tests.rs
+++ b/meeting-api/tests/waiting_room_race_tests.rs
@@ -1,0 +1,483 @@
+/*
+ * Copyright 2025 Security Union LLC
+ *
+ * Licensed under either of
+ *
+ * * Apache License, Version 2.0
+ *   (http://www.apache.org/licenses/LICENSE-2.0)
+ * * MIT license
+ *   (http://opensource.org/licenses/MIT)
+ *
+ * at your option.
+ */
+
+//! Concurrency tests for the waiting room, run against both backends.
+//!
+//! `db::participants::join_attendee` reads `waiting_room_enabled` and then
+//! inserts a participant whose status depends on what it read;
+//! `db::meetings::update_waiting_room_enabled` writes that flag and, when
+//! disabling, admits everyone currently waiting. The two must serialize, which
+//! is what `db::lock::begin_write` is for — `SELECT ... FOR UPDATE` on
+//! PostgreSQL, `BEGIN IMMEDIATE` on SQLite. A plain `pool.begin()` is `BEGIN
+//! DEFERRED` and takes no lock at all, which permits:
+//!
+//! ```text
+//! T1 join_attendee : BEGIN; SELECT waiting_room_enabled -> true
+//! T2 host toggle   : BEGIN; UPDATE waiting_room_enabled = false;
+//!                           UPDATE participants SET status='admitted' WHERE status='waiting';
+//!                           COMMIT
+//! T1               : INSERT participant status='waiting'; COMMIT
+//! ```
+//!
+//! leaving a participant sitting in the waiting room of a meeting that has no
+//! waiting room. Nothing ever admits them: the sweep that would have has
+//! already run.
+//!
+//! The regression this file exists to catch is `begin_write` reverting to a
+//! plain `pool.begin()`. Both backends were checked against that revert, and
+//! they fail differently:
+//!
+//! - PostgreSQL loses `FOR UPDATE`, produces the stranded participant above,
+//!   and fails [`test_toggle_off_between_a_joins_read_and_write_never_strands`].
+//! - SQLite has one database write lock, so it cannot corrupt the state this
+//!   way; what it does instead is fail the deferred transaction's upgrade to a
+//!   write with `SQLITE_BUSY`, which `with_write_retry` cannot always absorb.
+//!   That surfaces as `database is locked` out of
+//!   [`test_concurrent_writers_do_not_surface_lock_errors`].
+//!
+//! Timing alone does not catch either: the window between the join's read and
+//! its write is far shorter than the competing transaction, so the swept-delay
+//! tests below passed against the reverted code. They stay because they cover
+//! contention broadly, but the two named tests are the ones that hold the line.
+//!
+//! On the *enabling* side there is no equivalent final-state assertion to make,
+//! and it is worth writing down why rather than shipping a test that looks like
+//! one. "Waiting room on, participant admitted" is also the outcome of the
+//! perfectly legal serial order (attendee joins, host then enables the waiting
+//! room) — existing participants are not evicted when the host turns it on. Two
+//! concurrent calls therefore cannot be distinguished from that serial order by
+//! looking at the rows afterwards, so the enabling side is covered here by
+//! [`test_toggle_on_race_stays_internally_consistent`] (the flag each join acts
+//! on is the flag its own row reflects, and nothing errors out) plus
+//! [`test_join_after_a_committed_enable_always_waits`], which pins down the one
+//! ordering that *is* observable: once the host's call has returned, no later
+//! join may be auto-admitted.
+//!
+//! Where a test does depend on timing it sweeps rather than sleeps: each
+//! iteration offsets the competing task by a slightly larger delay, so the
+//! window is crossed at many points instead of one lucky one.
+
+mod test_helpers;
+
+use chrono::Utc;
+use meeting_api::db::{meetings as db_meetings, participants as db_participants, q, DbPool};
+use serde_json::json;
+use serial_test::serial;
+use std::time::Duration;
+use test_helpers::*;
+
+/// Number of interleavings to try per race test.
+const ITERATIONS: u32 = 40;
+
+/// How much later each iteration starts the competing task.
+const SWEEP_STEP: Duration = Duration::from_micros(75);
+
+/// Create a fresh meeting for one iteration of a race and return its id.
+async fn fresh_meeting(pool: &DbPool, room_id: &str, waiting_room_enabled: bool) -> i32 {
+    cleanup_test_data(pool, room_id).await;
+    db_meetings::create_with_options(
+        pool,
+        room_id,
+        "host@example.com",
+        None,
+        &json!([]),
+        waiting_room_enabled,
+    )
+    .await
+    .expect("create meeting for race iteration")
+    .id
+}
+
+/// The interleaving from the module docs, forced rather than waited for.
+///
+/// A join cannot be paused between its read and its write from outside — but it
+/// can be *blocked* there. This test holds an uncommitted `meeting_participants`
+/// row for the joining user, which the join's `INSERT ... ON CONFLICT` must wait
+/// on, and that wait is the window:
+///
+/// ```text
+/// W  (this test)   : BEGIN; INSERT participant (meeting, attendee)   -- uncommitted
+/// T1 join_attendee : BEGIN; SELECT waiting_room_enabled -> true; INSERT ... blocked on W
+/// T2 host toggle   : BEGIN; UPDATE waiting_room_enabled = false;
+///                           admit-all sees nothing waiting; COMMIT
+/// W                : ROLLBACK
+/// T1               : INSERT participant status='waiting'; COMMIT    -- stranded
+/// ```
+///
+/// With `begin_write` intact, T1 takes the meeting's write lock *before* its
+/// read, so T2's UPDATE queues behind T1 instead of slipping past it: T1 commits
+/// its `waiting` row first and T2's admit-all then finds and admits it.
+///
+/// On PostgreSQL the ordering above is exact — W blocks T1 without blocking T2,
+/// because the two contend on different rows. SQLite has a single database
+/// write lock, so W necessarily blocks T2 as well and the interleaving degrades
+/// to "both writers queue behind W"; the assertion still holds there, it just
+/// stops being the reason the test is interesting. That asymmetry is the whole
+/// reason `begin_write` has two implementations.
+#[tokio::test]
+#[serial]
+async fn test_toggle_off_between_a_joins_read_and_write_never_strands() {
+    let pool = get_test_pool().await;
+    let room_id = "race-forced-interleave";
+    let meeting_id = fresh_meeting(&pool, room_id, true).await;
+    let attendee = "attendee@example.com";
+
+    // W: claim the attendee's (meeting_id, user_id) key without committing, so
+    // any join for that attendee blocks on the unique constraint.
+    let mut blocker = pool.begin().await.expect("begin blocking transaction");
+    sqlx::query(&q(
+        "INSERT INTO meeting_participants (meeting_id, user_id, status, joined_at, created_at, updated_at) \
+         VALUES ($1, $2, 'waiting', $3, $3, $3)",
+    ))
+    .bind(meeting_id)
+    .bind(attendee)
+    .bind(Utc::now())
+    .execute(&mut *blocker)
+    .await
+    .expect("claim the participant key");
+
+    let joiner = {
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            db_participants::join_attendee(&pool, meeting_id, attendee, None).await
+        })
+    };
+    // Let the join reach its INSERT and park there.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let toggler = {
+        let pool = pool.clone();
+        let room_id = room_id.to_string();
+        tokio::spawn(async move {
+            db_meetings::update_waiting_room_enabled(&pool, &room_id, "host@example.com", false)
+                .await
+        })
+    };
+    // Give the toggle every chance to run to completion ahead of the join.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    blocker
+        .rollback()
+        .await
+        .expect("release the participant key");
+
+    let (_, row, _) = joiner
+        .await
+        .expect("join task should not panic")
+        .expect("join_attendee should succeed once the key is free");
+    toggler
+        .await
+        .expect("toggle task should not panic")
+        .expect("update_waiting_room_enabled should succeed")
+        .expect("toggle should match the meeting");
+
+    let meeting = db_meetings::get_by_room_id(&pool, room_id)
+        .await
+        .expect("re-read meeting")
+        .expect("meeting should exist");
+    let status = db_participants::get_status(&pool, meeting_id, attendee)
+        .await
+        .expect("read participant status")
+        .expect("participant should exist");
+
+    assert!(
+        !meeting.waiting_room_enabled,
+        "the host's disable must have stuck"
+    );
+    assert_eq!(
+        status.status, "admitted",
+        "the attendee is stranded: the waiting room is off and they are still '{}' \
+         (the join returned '{}'). The join's read of waiting_room_enabled was not \
+         serialized against the toggle — db::lock::begin_write must take the write \
+         lock before that read.",
+        status.status, row.status
+    );
+
+    cleanup_test_data(&pool, room_id).await;
+}
+
+/// Disabling the waiting room concurrently with a join must never leave the
+/// joiner stranded in `waiting` with the waiting room already off.
+///
+/// Both serial orders admit the attendee: joining first puts them in `waiting`
+/// and the toggle's sweep admits them; toggling first makes the join observe a
+/// disabled waiting room and auto-admit. So `waiting_room_enabled = false` with
+/// a `waiting` participant is not equivalent to any serial execution — it is a
+/// participant nothing will ever let in.
+#[tokio::test]
+#[serial]
+async fn test_toggle_off_never_strands_a_waiting_participant() {
+    let pool = get_test_pool().await;
+    let mut violations: Vec<String> = Vec::new();
+
+    for i in 0..ITERATIONS {
+        let room_id = format!("race-off-{i}");
+        let meeting_id = fresh_meeting(&pool, &room_id, true).await;
+
+        let joiner = {
+            let pool = pool.clone();
+            tokio::spawn(async move {
+                db_participants::join_attendee(&pool, meeting_id, "attendee@example.com", None)
+                    .await
+            })
+        };
+        let toggler = {
+            let pool = pool.clone();
+            let room_id = room_id.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(SWEEP_STEP * i).await;
+                db_meetings::update_waiting_room_enabled(&pool, &room_id, "host@example.com", false)
+                    .await
+            })
+        };
+
+        let join_result = joiner.await.expect("join task should not panic");
+        let toggle_result = toggler.await.expect("toggle task should not panic");
+
+        join_result.unwrap_or_else(|e| panic!("iteration {i}: join_attendee failed: {e}"));
+        let toggled = toggle_result
+            .unwrap_or_else(|e| panic!("iteration {i}: update_waiting_room_enabled failed: {e}"))
+            .unwrap_or_else(|| panic!("iteration {i}: toggle matched no meeting"));
+        assert!(
+            !toggled.waiting_room_enabled,
+            "iteration {i}: the toggle should have disabled the waiting room"
+        );
+
+        let meeting = db_meetings::get_by_room_id(&pool, &room_id)
+            .await
+            .expect("re-read meeting")
+            .expect("meeting should exist");
+        let stranded = db_participants::count_waiting(&pool, meeting_id)
+            .await
+            .expect("count waiting");
+
+        if !meeting.waiting_room_enabled && stranded > 0 {
+            violations.push(format!(
+                "iteration {i} (toggle delayed {:?}): waiting_room_enabled = false but \
+                 {stranded} participant(s) left in 'waiting'",
+                SWEEP_STEP * i
+            ));
+        }
+
+        cleanup_test_data(&pool, &room_id).await;
+    }
+
+    assert!(
+        violations.is_empty(),
+        "non-serializable outcomes observed — a join interleaved with the waiting room \
+         being disabled stranded the participant. This is exactly what db::lock::begin_write \
+         prevents; a plain pool.begin() (BEGIN DEFERRED / no FOR UPDATE) reproduces it.\n{}",
+        violations.join("\n")
+    );
+}
+
+/// Enabling the waiting room concurrently with a join must not corrupt the
+/// pair (flag observed, status written) or surface lock errors to the caller.
+///
+/// `join_attendee` returns the `waiting_room_enabled` it read under the lock,
+/// and the route issues a room-access token from exactly that value, so the
+/// value and the row it produced have to agree in every interleaving. On SQLite
+/// this is also the path that exercises `BEGIN IMMEDIATE` contention: an error
+/// escaping here means `with_write_retry` failed to absorb a busy database.
+#[tokio::test]
+#[serial]
+async fn test_toggle_on_race_stays_internally_consistent() {
+    let pool = get_test_pool().await;
+
+    for i in 0..ITERATIONS {
+        let room_id = format!("race-on-{i}");
+        let meeting_id = fresh_meeting(&pool, &room_id, false).await;
+
+        let joiner = {
+            let pool = pool.clone();
+            tokio::spawn(async move {
+                db_participants::join_attendee(&pool, meeting_id, "attendee@example.com", None)
+                    .await
+            })
+        };
+        let toggler = {
+            let pool = pool.clone();
+            let room_id = room_id.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(SWEEP_STEP * i).await;
+                db_meetings::update_waiting_room_enabled(&pool, &room_id, "host@example.com", true)
+                    .await
+            })
+        };
+
+        let (auto_admitted, row, observed_waiting_room) = joiner
+            .await
+            .expect("join task should not panic")
+            .unwrap_or_else(|e| panic!("iteration {i}: join_attendee failed: {e}"));
+        toggler
+            .await
+            .expect("toggle task should not panic")
+            .unwrap_or_else(|e| panic!("iteration {i}: update_waiting_room_enabled failed: {e}"))
+            .unwrap_or_else(|| panic!("iteration {i}: toggle matched no meeting"));
+
+        assert_eq!(
+            auto_admitted, !observed_waiting_room,
+            "iteration {i}: auto_admitted must be the negation of the flag read under the lock"
+        );
+        assert_eq!(
+            row.status,
+            if observed_waiting_room {
+                "waiting"
+            } else {
+                "admitted"
+            },
+            "iteration {i}: the participant's status must match the flag the join acted on; \
+             a mismatch means the row was written against a different value than the one \
+             the caller was handed (and mints a room token from)"
+        );
+
+        let meeting = db_meetings::get_by_room_id(&pool, &room_id)
+            .await
+            .expect("re-read meeting")
+            .expect("meeting should exist");
+        assert!(
+            meeting.waiting_room_enabled,
+            "iteration {i}: the host's enable must have stuck"
+        );
+
+        cleanup_test_data(&pool, &room_id).await;
+    }
+}
+
+/// The observable ordering guarantee on the enabling side: once the host's
+/// `update_waiting_room_enabled(true)` has *returned*, every join that starts
+/// afterwards must land in the waiting room. A join that still auto-admits here
+/// would be reading a snapshot older than a committed transaction.
+#[tokio::test]
+#[serial]
+async fn test_join_after_a_committed_enable_always_waits() {
+    let pool = get_test_pool().await;
+    let room_id = "race-enable-then-join";
+    let meeting_id = fresh_meeting(&pool, room_id, false).await;
+
+    db_meetings::update_waiting_room_enabled(&pool, room_id, "host@example.com", true)
+        .await
+        .expect("enable waiting room")
+        .expect("toggle should match the meeting");
+
+    // Several joiners, concurrently, all starting after the enable committed.
+    let mut joins = Vec::new();
+    for n in 0..8 {
+        let pool = pool.clone();
+        joins.push(tokio::spawn(async move {
+            db_participants::join_attendee(
+                &pool,
+                meeting_id,
+                &format!("guest{n}@example.com"),
+                None,
+            )
+            .await
+        }));
+    }
+
+    for (n, join) in joins.into_iter().enumerate() {
+        let (auto_admitted, row, observed) = join
+            .await
+            .expect("join task should not panic")
+            .unwrap_or_else(|e| panic!("guest {n}: join_attendee failed: {e}"));
+        assert!(
+            !auto_admitted && observed && row.status == "waiting",
+            "guest {n} was admitted after the host's enable had already committed \
+             (auto_admitted={auto_admitted}, observed_waiting_room={observed}, status={})",
+            row.status
+        );
+    }
+
+    assert_eq!(
+        db_participants::count_admitted(&pool, meeting_id)
+            .await
+            .expect("count admitted"),
+        0,
+        "no participant may be admitted once the waiting room is on"
+    );
+
+    cleanup_test_data(&pool, room_id).await;
+}
+
+/// Many writers at once: joins racing repeated toggles. Every call must either
+/// succeed or be retried into success by `db::lock::with_write_retry` — a
+/// `SQLITE_BUSY` reaching the caller is a bug, and so is a lost participant.
+#[tokio::test]
+#[serial]
+async fn test_concurrent_writers_do_not_surface_lock_errors() {
+    let pool = get_test_pool().await;
+    let room_id = "race-writer-storm";
+    let meeting_id = fresh_meeting(&pool, room_id, true).await;
+
+    let mut tasks = Vec::new();
+    for n in 0..12 {
+        let pool = pool.clone();
+        tasks.push(tokio::spawn(async move {
+            db_participants::join_attendee(
+                &pool,
+                meeting_id,
+                &format!("storm{n}@example.com"),
+                None,
+            )
+            .await
+            .map(|_| ())
+        }));
+    }
+    for n in 0..6 {
+        let pool = pool.clone();
+        let room_id = room_id.to_string();
+        tasks.push(tokio::spawn(async move {
+            db_meetings::update_waiting_room_enabled(
+                &pool,
+                &room_id,
+                "host@example.com",
+                n % 2 == 0,
+            )
+            .await
+            .map(|_| ())
+        }));
+    }
+
+    for (n, task) in tasks.into_iter().enumerate() {
+        task.await
+            .expect("task should not panic")
+            .unwrap_or_else(|e| panic!("writer {n} failed under contention: {e}"));
+    }
+
+    // Every joiner must exist exactly once, in one of the two live statuses.
+    let waiting = db_participants::count_waiting(&pool, meeting_id)
+        .await
+        .expect("count waiting");
+    let admitted = db_participants::count_admitted(&pool, meeting_id)
+        .await
+        .expect("count admitted");
+    assert_eq!(
+        waiting + admitted,
+        12,
+        "all 12 joiners must be present exactly once (waiting={waiting}, admitted={admitted})"
+    );
+
+    // And the stranding invariant still holds after the storm.
+    let meeting = db_meetings::get_by_room_id(&pool, room_id)
+        .await
+        .expect("re-read meeting")
+        .expect("meeting should exist");
+    if !meeting.waiting_room_enabled {
+        assert_eq!(
+            waiting, 0,
+            "the waiting room ended up disabled with {waiting} participant(s) still waiting"
+        );
+    }
+
+    cleanup_test_data(&pool, room_id).await;
+}

--- a/meeting-api/tests/waiting_room_race_tests.rs
+++ b/meeting-api/tests/waiting_room_race_tests.rs
@@ -166,6 +166,17 @@ async fn test_toggle_off_between_a_joins_read_and_write_never_strands() {
     // Give the toggle every chance to run to completion ahead of the join.
     tokio::time::sleep(Duration::from_millis(150)).await;
 
+    // Without this the test can pass vacuously: if the join had already run to
+    // completion during the sleeps above, it never sat in the window this test
+    // exists to exercise, and the assertions below would hold for the boring
+    // reason. On a loaded runner that is exactly what a fixed sleep risks.
+    assert!(
+        !joiner.is_finished(),
+        "the join completed before the blocking key was released, so it never \
+         parked between its read of waiting_room_enabled and its INSERT — this \
+         run proves nothing about the race"
+    );
+
     blocker
         .rollback()
         .await

--- a/meeting-api/tests/waiting_room_tests.rs
+++ b/meeting-api/tests/waiting_room_tests.rs
@@ -26,7 +26,7 @@ use videocall_meeting_types::{
 };
 
 /// Create a meeting, have host join, and add an attendee to the waiting room.
-async fn setup_with_waiting_attendee(pool: &sqlx::PgPool, room_id: &str) {
+async fn setup_with_waiting_attendee(pool: &meeting_api::db::DbPool, room_id: &str) {
     cleanup_test_data(pool, room_id).await;
 
     // Create meeting.

--- a/meeting-api/tests/waiting_room_toggle_tests.rs
+++ b/meeting-api/tests/waiting_room_toggle_tests.rs
@@ -32,7 +32,7 @@ use videocall_meeting_types::{
 };
 
 /// Helper: create a meeting and have the host join (activates it).
-async fn setup_active_meeting(pool: &sqlx::PgPool, room_id: &str) {
+async fn setup_active_meeting(pool: &meeting_api::db::DbPool, room_id: &str) {
     cleanup_test_data(pool, room_id).await;
 
     let app = build_app(pool.clone());
@@ -60,7 +60,7 @@ async fn setup_active_meeting(pool: &sqlx::PgPool, room_id: &str) {
 }
 
 /// Helper: create a meeting with waiting room disabled and have the host join.
-async fn setup_active_meeting_no_waiting_room(pool: &sqlx::PgPool, room_id: &str) {
+async fn setup_active_meeting_no_waiting_room(pool: &meeting_api::db::DbPool, room_id: &str) {
     cleanup_test_data(pool, room_id).await;
 
     let app = build_app(pool.clone());
@@ -660,7 +660,7 @@ async fn test_update_meeting_unauthenticated() {
     let app = build_app(pool.clone());
     let req = axum::http::Request::builder()
         .method("PATCH")
-        .uri(&format!("/api/v1/meetings/{room_id}"))
+        .uri(format!("/api/v1/meetings/{room_id}"))
         .header("Content-Type", "application/json")
         .body(Body::from(r#"{"waiting_room_enabled":false}"#))
         .unwrap();


### PR DESCRIPTION
Alternative to #802, which this supersedes. Same goal — run `meeting-api` against SQLite so small deployments don't need a separate PostgreSQL instance — reached without duplicating the db layer.

## Why not #802's approach

#802 forks `db/` into `db/postgres/` and `db/sqlite/`, +1406/-40. Diffing the two generated backends mechanically: **of 1125 duplicated lines, 48 differ** — 25 are `$1`→`?1`, 13 are `NOW()`→`datetime('now')`, 8 are doc comments, and 2 dropped `FOR UPDATE`. `RETURNING`, `ON CONFLICT ... DO UPDATE` (including table-qualified refs), booleans and `LIMIT/OFFSET` are byte-identical in both copies; #802 itself proves they're portable.

`sqlx::Any` isn't the answer either, for a specific reason: `AnyRow` decodes only bool/int/float/String/bytes, and `MeetingRow` carries six `DateTime<Utc>` fields plus a `serde_json::Value`. You'd hand-parse all of them from strings.

So: keep one db layer, isolate the two things that genuinely differ.

## Shape

- **`db/mod.rs`** — `DbPool` alias, mutually-exclusive feature `compile_error!` guards, `now_expr`/`bind_now!` (emit `NOW()` on pg, a bound parameter on SQLite), and `q()`, a `$N`→`?N` rewrite.
  `q()` is **defence-in-depth, not load-bearing**: sqlx-sqlite parses `$NNN` natively, so the queries bind correctly without it. It's kept because `?N` is the documented-portable form and depending on that sqlx internal across upgrades is unwise. Its doc says so, so nobody mistakes it for the thing making SQLite work.
- **`db/lock.rs`** — the one genuinely non-portable query. `SELECT ... FOR UPDATE` on pg, `BEGIN IMMEDIATE` on SQLite, plus a deadline-bounded `SQLITE_BUSY` retry. **Both** `join_attendee` and `update_waiting_room_enabled` take the write lock; locking one side only moves the race.
- **`db/{meetings,participants,oauth}.rs`** — edited in place. No per-backend modules.

## Correctness notes

**#802's dropped `FOR UPDATE` is a real bug, but not the one it looks like.** It's not an admission bypass: "waiting room ON but participant admitted" is also the outcome of a legal serial order (attendee joins, host then enables), enabling doesn't evict existing participants, and the two are indistinguishable from final state. The genuinely non-serializable outcome is the **disable** direction — `waiting_room_enabled = false` with a participant still `waiting`, because the admit-all sweep already ran past them. A hang, not a bypass. That's what `lock.rs` prevents and what the regression test asserts.

**Pool options go on `SqliteConnectOptions`, not a one-off `PRAGMA`.** `busy_timeout` and `foreign_keys` are per-connection; setting them by executing a `PRAGMA` against the pool configures one arbitrary connection and leaves the rest at defaults — which silently makes every `ON DELETE CASCADE` inert. A test holds all five connections open and asserts each one.

**PostgreSQL's clock stays in the database.** An earlier revision of this branch bound `Utc::now()` client-side on both backends to erase a dialect difference. That was wrong: it keyed `ORDER BY created_at DESC` on API-pod wall clock (NTP skew between replicas could invert meetings created seconds apart) and allowed `updated_at < created_at`. Reverted. Verified against a live server with `log_statement=all` — every timestamp write arrives as `NOW()`/`CURRENT_TIMESTAMP`.

## Tests — one suite, run twice

Not a second harness. The Makefile defines the cargo invocation once; the two legs differ only in `DATABASE_URL`, which dbmate directory is migrated, and the feature flag, so a test added to `meeting-api/tests` runs against both backends automatically. `get_test_pool` has no `cfg` at all — it reads `DATABASE_URL` and calls `db::connect`, so both legs exercise the production pool constructor.

Both legs run **real dbmate**. An earlier revision hand-parsed `-- migrate:up` out of the `.sql` files in test code, which meant the SQLite leg validated a migration path production never executes. Deleted.

Per-binary counts are identical on both backends except the one deliberately SQLite-only file (pragmas, BUSY retry): **95 lib + 75 integration, all passing on each.**

New shared coverage, running on both backends — this is what guards a hand-ported schema no compiler checks: cascade behavior, the attendees and length CHECKs, the partial unique index, `RETURNING` freshness, and timestamp sort order.

**On the race test:** the first design was timing-swept and **passed against deliberately-reverted code** on both backends — the window between the join's read and its write is far too short to hit by sleeping. It was rewritten to be deterministic (hold an uncommitted participant row so the join's `INSERT ... ON CONFLICT` blocks precisely in the window). With `begin_write` reverted it fails as it should. Two swept tests are retained but documented as *not* catching the regression.

## Also fixed here

`meeting-api/**` was missing from `cargo-test.yaml`'s `paths` filter, so that workflow never ran on meeting-api changes **even for PostgreSQL**. Pre-existing, unrelated to SQLite.

## Migration parity

`dbmate/sqlite/` is a consolidated port of the 12 pg migrations — the one duplication that can't be collapsed, since dbmate has no dialect layer. Reviewed column-by-column: tables, column order, nullability, defaults, CHECKs, FKs, and all 7 indexes including the partial unique `idx_meetings_room_id_unique_active`. `session_participants` is omitted deliberately (zero Rust references repo-wide). The `attendees` CHECK adds `json_type = 'array'`, since `json_array_length` accepts a JSON object where `jsonb_array_length` raises.

## Type of Change
- [x] New feature

## Test plan
- [x] `cargo fmt -p meeting-api -- --check`
- [x] `cargo clippy -p meeting-api --all-targets -- -D warnings`
- [x] `cargo clippy -p meeting-api --all-targets --no-default-features --features sqlite -- -D warnings`
- [x] Full suite green on PostgreSQL 16 and on SQLite (95 lib + 75 integration each)
- [x] Race regression test observed **failing** against reverted locking, on both backends

## Testing
- [x] Tests written or updated

## Known gaps
- Docker/Helm have no SQLite path yet — the feature is reachable via cargo and the Makefile, not via a deployment target. Suggest a follow-up rather than widening this PR.
- The compose plumbing for the SQLite leg (`--no-deps`, the `DATABASE_URL` override) first executes in CI; it was verified by running the identical inner commands natively, since Docker wasn't available on the dev box.

Fixes #795
