### PR TITLE
fix(helm): repoint Bitnami images off the deleted public.ecr.aws registry

### DIFF
--- a/helm/global/us-east/matomo/values.yaml
+++ b/helm/global/us-east/matomo/values.yaml
@@ -1,16 +1,18 @@
 # US East Matomo configuration using Bitnami chart
   # Regional deployment configuration for matomo.videocall.rs
 
-# Global security override to allow AWS ECR images
+# Global security override to allow non-default (bitnamilegacy) images
 global:
   security:
     allowInsecureImages: true
 
 matomo:
-  # Override image to use AWS ECR public registry with Bitnami images
+  # Bitnami deleted the entire public.ecr.aws/bitnami/* registry; the archived
+  # bitnamilegacy repos on Docker Hub carry the identical tag we already run.
+  # Registry/repository move only — version is unchanged.
   image:
-    registry: public.ecr.aws
-    repository: bitnami/matomo
+    registry: docker.io
+    repository: bitnamilegacy/matomo
     tag: 5.3.2-debian-12-r12
     pullPolicy: IfNotPresent
 
@@ -40,9 +42,10 @@ matomo:
   # MariaDB configuration - auto-generate passwords
   mariadb:
     enabled: true
+    # Same registry migration as above — identical tag, bitnamilegacy on Docker Hub.
     image:
-      registry: public.ecr.aws
-      repository: bitnami/mariadb
+      registry: docker.io
+      repository: bitnamilegacy/mariadb
       tag: 11.4.4-debian-12-r3
     auth:
       # Leave passwords empty to auto-generate secure random passwords
@@ -64,6 +67,19 @@ matomo:
   persistence:
     enabled: true
     size: 10Gi
+
+  # ⚠️  LATENT DELETED-IMAGE LANDMINE — read before enabling optional features.
+  # The matomo 10.0.25 chart still defaults several optional images to
+  # docker.io/bitnami/* coordinates that now 404 on Docker Hub:
+  #   volumePermissions.image -> bitnami/os-shell:12-debian-12-r50
+  #   metrics.image           -> bitnami/apache-exporter:1.0.10-debian-12-r55
+  #   certificates.image      -> bitnami/os-shell:12-debian-12-r50
+  # None of them are rendered today (all three features default to enabled:false,
+  # and volume permissions are handled by the custom busybox initContainer below).
+  # But flipping volumePermissions.enabled, metrics.enabled, or certificates on
+  # would schedule a pod referencing a deleted image and land in an instant
+  # ImagePullBackOff. If you enable any of them, override the corresponding
+  # image.repository to the bitnamilegacy/* equivalent at the same time.
 
   # Init container to fix volume permissions for Bitnami image
   initContainers:

--- a/helm/global/us-east/postgres/README.md
+++ b/helm/global/us-east/postgres/README.md
@@ -4,12 +4,17 @@ This Helm chart deploys PostgreSQL with persistent storage for the videocall-rs 
 
 ## Installation
 
-### 1. Update Helm dependencies
+### 1. Build Helm dependencies
 
 ```bash
 cd helm/global/us-east/postgres
-helm dependency update
+helm dependency build
 ```
+
+> Use `helm dependency build`, **not** `helm dependency update`. `build` installs
+> exactly the versions recorded in `Chart.lock`. `update` re-resolves against
+> `charts.bitnami.com` and can pull a chart newer than the 18.1.3 that
+> `scripts/digitalocean-prod-setup-preview-infra.sh` validates against.
 
 ### 2. Install PostgreSQL
 

--- a/helm/global/us-east/postgres/values.yaml
+++ b/helm/global/us-east/postgres/values.yaml
@@ -1,22 +1,47 @@
 # PostgreSQL configuration for US East region
 
-# Allow AWS ECR images
+# Allow non-default (Docker Hub legacy / digest-pinned) images
 global:
   security:
     allowInsecureImages: true
 
 postgresql:
-  # Use AWS ECR for Bitnami images (Bitnami no longer hosts on Docker Hub)
+  # Bitnami deleted the entire public.ecr.aws/bitnami/* registry, so the old
+  # ECR coordinates now 404 on every cold pull. Images come from Docker Hub again.
+  #
+  # Pinned by digest on purpose: docker.io/bitnami/postgresql only publishes a
+  # floating `latest` tag now (versioned tags moved behind paid Secure Images),
+  # and the on-disk PVC data directory is PostgreSQL 18. An unpinned `latest`
+  # would silently roll forward to PG 19 and refuse to start against v18 data.
+  # This digest freezes PostgreSQL 18.4.0.
+  # NOTE: bitnamilegacy/postgresql cannot be used here — it tops out at 17.6.
+  #
+  # THIS IS ALSO A VERSION BUMP, not just a registry move: prod was running the
+  # floating `latest` tag (chart appVersion 18.0.0, so most likely an 18.0.x
+  # image), and this pins 18.4.0. Same major version, so the on-disk data
+  # directory is compatible and no pg_upgrade is required — but it is a
+  # patch-level upgrade, unlike the pure registry moves for matomo/mariadb.
   image:
-    registry: public.ecr.aws
+    registry: docker.io
     repository: bitnami/postgresql
-    
+    digest: sha256:db2312d9b243afa8c3b3f5496e478d17d0dff9791d06f3b93b9567abd86ae92f
+    # Tripwire / documentation only. The digest above takes precedence, so this
+    # tag is never what gets pulled. It exists because the subchart's own default
+    # is `image.tag: latest`, which stays merged underneath this block: if the
+    # digest is ever blanked, the image would silently fall back to a floating
+    # `latest` — precisely the failure mode this pin exists to prevent. Keep this
+    # in sync with the digest.
+    tag: "18.4.0"
+
   # Metrics exporter image
+  # bitnamilegacy retains the exact version that runs in production today (0.17.1),
+  # so this is a registry move only — no version change.
   metrics:
     enabled: true
     image:
-      registry: public.ecr.aws
-      repository: bitnami/postgres-exporter
+      registry: docker.io
+      repository: bitnamilegacy/postgres-exporter
+      tag: 0.17.1-debian-12-r16
     serviceMonitor:
       enabled: false
   

--- a/helm/global/us-east/videocall-website/values.yaml
+++ b/helm/global/us-east/videocall-website/values.yaml
@@ -5,10 +5,44 @@ videocall-website:
 
   replicaCount: 1
 
+  # TEMPORARY ROLLBACK pending a fix to docker/Dockerfile.website.
+  #
+  # Symptom: the image pulls fine but the container exits 1 immediately with
+  #   exec /app/leptos_website: no such file or directory
+  #
+  # Bisected by booting published tags on the cluster node:
+  #   main-60f7bea7 (Website: SEO improvement #630, 2026-02-18) -> boots,
+  #                 logs "listening on http://0.0.0.0:8080"
+  #   main-1691e5ab (Nixify videocall.rs website #631, 2026-02-19) -> broken
+  # So #631 is the first broken build.
+  #
+  # Cause: the nix build produces a dynamically linked binary whose ELF
+  # interpreter is /nix/store/...-glibc-2.40-66/lib/ld-linux-x86-64.so.2, but the
+  # runtime stage never copies the nix store, so /nix does not exist in the image.
+  # A missing ELF interpreter is reported by the kernel as ENOENT ("no such file
+  # or directory") even though /app/leptos_website is present in the image.
+  #
+  # The fix belongs in docker/Dockerfile.website — build static/musl, copy the nix
+  # closure into the runtime stage, or `patchelf --set-interpreter` to the base
+  # image's loader. It does NOT belong in the CI workflow: an earlier multi-arch
+  # build was already reverted in #665/#666, and upload-website-docker-hub.yaml has
+  # no `platforms:` key today, so this is not an architecture problem.
+  #
+  # main-60f7bea7 is the newest tag verified to boot, so it is pinned here rather
+  # than an older tag that would needlessly discard #630 and everything after it.
+  #
+  # Note: `latest` is currently stuck pointing at the ed4ba314 manifest and will
+  # need one successful republish after the Dockerfile is fixed.
   image:
     repository: securityunion/video-call-rs-website
-    pullPolicy: Always
-    tag: latest
+    # IfNotPresent only protects nodes whose image cache is already warm. A fresh
+    # or recycled node cold-pulls whatever the tag points at — that is the exact
+    # mechanism behind this outage. A `@sha256:` digest would close the hole, but
+    # helm/videocall-website/templates/deployment.yaml renders the image as
+    # "{{ .Values.image.repository }}:{{ .Values.image.tag }}", so digests are not
+    # supported without a template change. Residual risk recorded, not fixed here.
+    pullPolicy: IfNotPresent
+    tag: main-60f7bea7
 
   resources:
     limits:

--- a/scripts/digitalocean-prod-setup-preview-infra.sh
+++ b/scripts/digitalocean-prod-setup-preview-infra.sh
@@ -104,6 +104,21 @@ echo "3. Deploying PostgreSQL into ${NAMESPACE}"
 
 CHART_DIR="helm/global/us-east/postgres"
 
+# The PostgreSQL image is NOT set here on purpose: a fresh install inherits
+# ${CHART_DIR}/values.yaml, which pins docker.io/bitnami/postgresql by digest
+# (PostgreSQL 18.4.0). Bitnami deleted public.ecr.aws/bitnami/* and now publishes
+# only a floating `latest` tag on Docker Hub, so the digest is what keeps this
+# reproducible against the existing PG 18 PVC. Do not add a
+# --set postgresql.image.digest here — it would fork the pin and drift.
+#
+# IMPORTANT: this script will NOT apply that pin to an existing release. The
+# guard below short-circuits whenever a release whose name starts with "postgres"
+# is present in the namespace, and the `postgres` release in preview-infra does
+# exist today — it is in ImagePullBackOff, which still counts as deployed. Moving
+# an already-installed release onto the digest requires a manual:
+#   helm upgrade postgres helm/global/us-east/postgres/ -n preview-infra \
+#     -f helm/global/us-east/postgres/values.yaml
+
 # The chart dependency tgz is committed to the repo; fail early if somehow missing
 if ! ls "${CHART_DIR}/charts/postgresql-"*.tgz &>/dev/null 2>&1; then
   echo "❌ Helm chart dependency missing: ${CHART_DIR}/charts/postgresql-*.tgz"


### PR DESCRIPTION
> **Status: already deployed to production.** This was an active outage; the changes in this PR were applied to the `us-east` cluster before review. Deployment record and follow-ups are at the bottom.

## Why

Bitnami **deleted the entire `public.ecr.aws/bitnami/*` registry**:

```
GET https://public.ecr.aws/v2/bitnami/postgresql/tags/list
-> {"errors":[{"code":"NAME_UNKNOWN","message":"The repository with name 'postgresql' does not exist ..."}]}
```

The `us-east` node had these images cached for 265 days, so nothing surfaced. That node was replaced, the fresh node had to pull cold, and every Bitnami-based workload went to `ImagePullBackOff`: `postgres-postgresql-0` (both `default` and `preview-infra`), `matomo-us-east`, `matomo-us-east-mariadb-0`, with `meeting-api` crashlooping downstream of Postgres.

## What changed

| Workload | Before | After | Nature |
|---|---|---|---|
| postgresql | `public.ecr.aws/bitnami/postgresql:latest` | `docker.io/bitnami/postgresql@sha256:db2312d9…` (18.4.0) | registry + patch bump |
| postgres-exporter | `public.ecr.aws/bitnami/postgres-exporter:latest` | `docker.io/bitnamilegacy/postgres-exporter:0.17.1-debian-12-r16` | registry only |
| matomo | `public.ecr.aws/bitnami/matomo:5.3.2-debian-12-r12` | `docker.io/bitnamilegacy/matomo:5.3.2-debian-12-r12` | registry only |
| mariadb | `public.ecr.aws/bitnami/mariadb:11.4.4-debian-12-r3` | `docker.io/bitnamilegacy/mariadb:11.4.4-debian-12-r3` | registry only |

### Why Postgres is pinned by digest

Both PVCs hold **PG 18** data on disk (`PG_VERSION` = 18, probed read-only in-cluster). `docker.io/bitnami/postgresql` now publishes **only** a floating `latest` — versioned tags moved behind paid Secure Images — so an unpinned tag would eventually roll onto PG 19 and refuse to start against v18 data. The digest freezes 18.4.0.

`bitnamilegacy/postgresql` is **not** usable here: it tops out at **17.6**, which cannot open a v18 data directory.

A `tag: "18.4.0"` tripwire sits alongside the digest because the subchart's own `image.tag: latest` default stays merged underneath — if the digest were ever blanked, the image would silently fall back to floating `latest`.

## Deployment record

Applied in this order. All releases healthy afterwards; node sits at 41% memory.

| Release | Namespace | Revision | Result |
|---|---|---|---|
| `postgres` | `default` | 2 | 2/2 Running |
| `matomo-us-east` | `default` | 20 | matomo 1/1, mariadb 1/1, CronJobs Completed |
| `videocall-website-us-east` | `default` | 25 | 1/1 Running |
| `postgres` | `preview-infra` | 2 | 1/1 Running |

`meeting-api-us-east` recovered on its own once Postgres was reachable — no upgrade needed.

### Things that came up during rollout

**1. StatefulSets deadlock — manual pod deletion required.** Both `postgres-postgresql` and `matomo-us-east-mariadb` kept their old broken pods after the upgrade. A StatefulSet will not roll a pod that was never `Ready`, so the new spec sat unapplied in `updateRevision` while the pod stayed on the dead image. Deleting the pod lets it be recreated from the new spec; PVCs are untouched by this. Anyone replaying this on another region will hit the same thing.

**2. `preview-infra` must NOT be upgraded with `-f values.yaml`.** That release carries its own overrides (5Gi PVC, `metrics.enabled=false`, tuned `max_connections`). Passing the shared values file would clobber them and attempt to resize an immutable PVC. The correct invocation is:

```bash
helm upgrade postgres helm/global/us-east/postgres/ -n preview-infra --reuse-values \
  --set postgresql.image.registry=docker.io \
  --set postgresql.image.repository=bitnami/postgresql \
  --set postgresql.image.digest=sha256:db2312d9b243afa8c3b3f5496e478d17d0dff9791d06f3b93b9567abd86ae92f \
  --set postgresql.image.tag=18.4.0
```

Note that `--reuse-values` **alone is not enough** — it snapshots the previous release's computed values, so it silently retains the dead ECR image. The explicit `--set` flags are required. ⚠️ The comment currently committed in `scripts/digitalocean-prod-setup-preview-infra.sh` recommends the `-f values.yaml` form and is therefore **wrong**; see follow-ups.

**3. Deploy-script `--force` was deliberately omitted.** `deploy-global-infrastructure.sh` uses `helm upgrade --install --force`. A forced replace against a StatefulSet bound to live PGDATA is not something you want during a data-layer migration; these upgrades were run without it.

## ⚠️ Outstanding: collation repair not yet done

The new image is Photon OS 5.0 / **glibc 2.43**; the images previously cached on the old node were Debian 12 / **glibc 2.36**. Postgres starts fine, but logs:

```
WARNING: database "actix-api-db" has a collation version mismatch
DETAIL:  The database was created using collation version 2.36,
         but the operating system provides version 2.43.
```

Confirmed present on **both** clusters:

| database | recorded | actual |
|---|---|---|
| `default` / `actix-api-db` | 2.36 | 2.43 |
| `default` / `postgres` | 2.36 | 2.43 |
| `preview-infra` / `preview_slot_1` | 2.36 | 2.43 |

This is dangerous precisely because it is **not** a startup failure — libc-collation text indexes can silently return wrong results (missed rows on index scans, unique constraints that no longer hold). It could not be pre-flighted: Postgres cannot answer queries while in `ImagePullBackOff`, and the old image no longer exists to compare against.

All databases are ~8MB, so the repair is near-instant:

```bash
kubectl exec postgres-postgresql-0 -n default -c postgresql -- bash -c \
  'export PGPASSWORD=$(cat "$POSTGRES_PASSWORD_FILE"); for db in "actix-api-db" postgres template1; do
     psql -U postgres -X -d "$db" -c "REINDEX DATABASE \"$db\";";
     psql -U postgres -X -d postgres -c "ALTER DATABASE \"$db\" REFRESH COLLATION VERSION;"; done'
```

Repeat for `-n preview-infra` with `preview_slot_1`.

## Verification

Every replacement was **cold-pull tested on the actual target node** before rollout, not just resolved via the registry API:

- postgres digest → `postgres (PostgreSQL) 18.4`, `uid=1001 gid=0(root)`, multi-arch index (amd64+arm64), ships `pgaudit.so` (the chart preloads it — its absence would be a hard startup failure)
- exporter / matomo / mariadb → all pulled and ran; tags byte-identical to production
- The Postgres StatefulSet **render diff was exactly two `image:` lines** — `PGDATA=/bitnami/postgresql/data`, mount path, `fsGroup`/`runAsUser: 1001`, and `volumeClaimTemplates` all unchanged
- DB passwords preserved via `common.secrets.passwords.manage` cluster lookup (verified with `--dry-run=server`; note client-side `--dry-run` cannot do lookups and fails with a spurious `PASSWORDS ERROR`)

## Unrelated fix included: videocall-website

`:latest` pulls fine but exits 1 with `exec /app/leptos_website: no such file or directory`. Bisecting published tags on the node:

| tag | result |
|---|---|
| `main-60f7bea7` (SEO #630, 2026-02-18) | **boots** — `listening on http://0.0.0.0:8080` |
| `main-1691e5ab` (Nixify #631, 2026-02-19) | **broken** |

**#631 is the first broken build.** The nix build emits a dynamically linked binary whose ELF interpreter is `/nix/store/…-glibc-2.40-66/lib/ld-linux-x86-64.so.2`, but the runtime stage never copies the nix store — a missing ELF interpreter is reported by the kernel as ENOENT even though `/app/leptos_website` exists. Not an architecture problem (multi-arch was already reverted in #665/#666).

Pinned to `main-60f7bea7` as a **temporary rollback**. The real fix belongs in `docker/Dockerfile.website`; `latest` is stuck on the `ed4ba314` manifest and needs one republish afterwards.

## Follow-ups

- **Run the collation repair above** — highest priority, real data-integrity exposure
- **Correct the `preview-infra` comment** in `scripts/digitalocean-prod-setup-preview-infra.sh` — it recommends `-f values.yaml`, which would clobber that release's overrides
- `docker/Dockerfile.website` nix/ELF fix, then republish `latest`
- `helm/postgres/` (`rustlemania-postgres`, chart 12.5.7) is a stale second copy with the same latent bug; `ARCHITECTURE.md:435` still documents it. Delete or deprecate.
- Matomo chart's optional images (`volumePermissions`, `metrics`, `certificates`) still default to deleted `bitnami/os-shell` + `apache-exporter` coordinates — documented inline as a landmine
- `global.security.allowInsecureImages: true` is now effectively a no-op for these `bitnamilegacy` substitutions; left in place rather than changing guardrails mid-outage
- Dev/prod Postgres drift: docker-compose files still use `postgres:12` while prod is PG 18
- **Infrastructure, outside this PR:** the cluster is now a single 8GB node with no redundancy — both Postgres instances and ingress have nowhere to reschedule. The prior 16GB node's deletion is also unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
