### PR TITLE
Roll core media path to nix-built images (main-330bc5e8)

### DIFF
--- a/helm/rustlemania-websocket/values.yaml
+++ b/helm/rustlemania-websocket/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 image:
   repository: securityunion/videocall-media-server
   pullPolicy: Always
-  tag: high-availability-cf63fcce
+  tag: main-330bc5e8
 env:
   - name: RUST_LOG
     value: info

--- a/helm/rustlemania-webtransport/values.yaml
+++ b/helm/rustlemania-webtransport/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: securityunion/videocall-media-server
   pullPolicy: Always
-  tag: high-availability-cf63fcce
+  tag: main-330bc5e8
 command: ['webtransport_server']
 args: []
 tlsSecret: rustlemania-ui-tls


### PR DESCRIPTION
Bumps rustlemania-websocket and rustlemania-webtransport from `high-availability-cf63fcce` to `main-330bc5e8` — the first nix-built media-server image (#897).

Pre-validated: binary layout, shell availability, probe compatibility (chart-vs-image audit found no blockers), and amd64 binaries executed from the cachix-built artifacts. Rollback = revert this one-line tag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)