### PR TITLE
Fix helm-deploy: tolerate decommissioned singapore cluster

### DIFF
--- a/.github/workflows/helm-deploy.yml
+++ b/.github/workflows/helm-deploy.yml
@@ -130,7 +130,10 @@ jobs:
         run: |
           # Get kubeconfigs for both clusters
           doctl kubernetes cluster kubeconfig save videocall-us-east
-          doctl kubernetes cluster kubeconfig save videocall-singapore
+          # singapore was decommissioned; keep the save tolerant so single-region
+          # us-east deploys work, and it picks the cluster back up if recreated
+          doctl kubernetes cluster kubeconfig save videocall-singapore || \
+            echo "singapore cluster not found - skipping"
           
       - name: 🔍 Validate Prerequisites
         run: |
@@ -143,8 +146,7 @@ jobs:
           fi
           
           if ! kubectl config get-contexts | grep -q "do-sgp1-videocall-singapore"; then
-            echo "❌ Singapore context not available"
-            exit 1
+            echo "Singapore context not available (cluster decommissioned) - us-east only"
           fi
           
           # Validate deployment script
@@ -188,7 +190,10 @@ jobs:
         run: |
           # Get kubeconfigs for both clusters
           doctl kubernetes cluster kubeconfig save videocall-us-east
-          doctl kubernetes cluster kubeconfig save videocall-singapore
+          # singapore was decommissioned; keep the save tolerant so single-region
+          # us-east deploys work, and it picks the cluster back up if recreated
+          doctl kubernetes cluster kubeconfig save videocall-singapore || \
+            echo "singapore cluster not found - skipping"
           
       - name: Create DigitalOcean DNS Secret
         run: |
@@ -347,7 +352,10 @@ jobs:
         run: |
           # Get kubeconfigs for both clusters
           doctl kubernetes cluster kubeconfig save videocall-us-east
-          doctl kubernetes cluster kubeconfig save videocall-singapore
+          # singapore was decommissioned; keep the save tolerant so single-region
+          # us-east deploys work, and it picks the cluster back up if recreated
+          doctl kubernetes cluster kubeconfig save videocall-singapore || \
+            echo "singapore cluster not found - skipping"
           
       - name: 🔍 Cross-Region Validation
         run: |


### PR DESCRIPTION
Deploy run 31441660074 failed in pre-checks: `no cluster goes by the name "videocall-singapore"` — the workflow hardcodes both clusters but only `videocall-us-east` exists now. Kubeconfig fetches become tolerant and the context assertion becomes a warning, so single-region us-east deploys work today and a future singapore cluster is picked up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)