### PR TITLE
Deploy script: drop helm --force (kills bound PVCs mid-rollout)

### DIFF
--- a/scripts/deploy-global-infrastructure.sh
+++ b/scripts/deploy-global-infrastructure.sh
@@ -556,7 +556,9 @@ deploy_chart() {
     log_info "Switched to context: ${context}"
     
     # Standard local chart deployment for all regional charts
-    if ! (cd "${chart_path}" && helm upgrade --install "${release_name}" . -f values.yaml --timeout 300s --force); then
+    # No --force: force-replace recreates every object even when unchanged,
+    # which is illegal for bound PVCs (matomo) and causes needless restarts.
+    if ! (cd "${chart_path}" && helm upgrade --install "${release_name}" . -f values.yaml --timeout 300s); then
         error_exit "Failed to deploy ${chart}"
     fi
     


### PR DESCRIPTION
Run 31443499304 aborted at matomo: `--force` replaces every object unconditionally, and replacing a bound PVC is forbidden — which also meant videocall-ui/website/monitoring never deployed. Plain `helm upgrade` patches only real diffs. Deploy will be re-dispatched from this branch; merge to make it stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)