### PR TITLE
Fix dioxus-ui crashloop on read-only config.js mount

### DIFF
--- a/nix/images/dioxus-ui.nix
+++ b/nix/images/dioxus-ui.nix
@@ -50,8 +50,10 @@ let
     #!/bin/sh
     set -eu
     CONFIG=/usr/share/nginx/html/config.js
-    if [ ! -e "$CONFIG" ] || [ -w "$CONFIG" ]; then
-    cat > "$CONFIG" <<EOF
+    # A configmap may be mounted read-only over $CONFIG. Don't trust [ -w ]:
+    # the container runs as root, which passes the permission-bit test even on
+    # a read-only mount. Probe by attempting the write itself.
+    if ! { cat > "$CONFIG"; } 2>/dev/null <<EOF
     window.__APP_CONFIG = Object.freeze({
       apiBaseUrl: "''${API_BASE_URL:-http://localhost:8081}",
       wsUrl: "''${ACTIX_UI_BACKEND_URL:-ws://localhost:8080}",
@@ -69,8 +71,8 @@ let
       vadThreshold: ''${VAD_THRESHOLD:-0.02}
     });
     EOF
-    else
-      echo "config.js is not writable; keeping the mounted config"
+    then
+      echo "config.js is read-only (mounted); keeping the mounted config"
     fi
     exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
   '';


### PR DESCRIPTION
First prod rollout of the nix dioxus-ui image crashlooped: the chart mounts config.js read-only from a configmap, and the entrypoint's `[ -w ]` guard passes for root even on a read-only mount, so it attempted the write and died. No user impact — the rolling update kept the old replica serving. Guard now probes by attempting the write and falls back to the mounted config; both paths verified in Docker with an :ro mount.

After merge: wait for the dioxus-ui publish workflow, then `kubectl rollout restart deployment videocall-ui-us-east`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)