### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An open-source, ultra-low-latency video conferencing platform and API built with
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=security-union/videocall-rs&type=Date)](https://star-history.com/#security-union/videocall-rs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=security-union/videocall-rs&type=Date)](https://star-history.dera.page/#security-union/videocall-rs&Date)
 
 ## Who is this for?
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders due to GitHub stargazer API restrictions. This change repoints it to star-history.dera.page, whose data source requires no API token, restoring the chart for visitors.